### PR TITLE
Don't expose Postgres to the network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
+version: '3.8'
+
 networks:
   postgres:
-
-version: '3.8'
 
 services:
   mailarchive-app:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+networks:
+  postgres:
+
 version: '3.8'
 
 services:
@@ -6,6 +9,8 @@ services:
     restart: always
     ports:
       - "5000:5000"
+    networks:
+      - postgres
     volumes:
       - ./appsettings.json:/app/appsettings.json
       - ./logs:/app/logs
@@ -21,8 +26,8 @@ services:
       POSTGRES_PASSWORD: masterkey
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
-    ports:
-      - "5432"
+    networks:
+      - postgres
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U mailuser -d MailArchiver"]
       interval: 10s


### PR DESCRIPTION
Consider creating a docker network for both container so Postgres won't be exposed on the host. 
I think this will improve security a little bit.