### PR TITLE
Add `en-GB` language

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -373,8 +373,8 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseRequestLocalization(new RequestLocalizationOptions()
     .SetDefaultCulture("en")
-    .AddSupportedCultures("en", "de", "es", "fr", "it", "sl", "nl", "ru", "hu")
-    .AddSupportedUICultures("en", "de", "es", "fr", "it", "sl", "nl", "ru", "hu"));
+    .AddSupportedCultures("en", "en-GB", "de", "es", "fr", "it", "sl", "nl", "ru", "hu")
+    .AddSupportedUICultures("en", "en-GB", "de", "es", "fr", "it", "sl", "nl", "ru", "hu"));
 app.UseRouting();
 app.UseSession();
 

--- a/Resources/SharedResource.en-GB.resx
+++ b/Resources/SharedResource.en-GB.resx
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- English (United Kingdom) resource overrides.
+     This file intentionally contains only overrides for en-GB.
+     Missing entries will fall back to SharedResource.resx (neutral). -->
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+              </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+                <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+                <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+                <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+                <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <!-- Add keys that only require en-GB-specific wording here.
+       Leave empty to inherit missing strings from SharedResource.resx. -->
+  <data name="LastSync" xml:space="preserve">
+    <value>Last Synchronisation</value>
+  </data>
+    <data name="SynchronizationJobs" xml:space="preserve">
+    <value>Synchronisation Jobs</value>
+  </data>
+  <data name="DisabledAccountsNotSynced" xml:space="preserve">
+    <value>Disabled accounts will not be synchronised</value>
+  </data>
+  <data name="DeleteItemSyncHistory" xml:space="preserve">
+    <value>Synchronisation history</value>
+  </data>
+  <data name="ActionWillStopSync" xml:space="preserve">
+    <value>Will stop all synchronisation for this account</value>
+  </data>
+  <data name="AlternativeDisableInfo" xml:space="preserve">
+    <value>If you only want to stop email synchronisation without losing data, you can disable the account instead.</value>
+  </data>
+  <data name="EnterFolderNamesText" xml:space="preserve">
+    <value>Folders to exclude from synchronisation. Enter folder names separated by semicolons.</value>
+  </data>
+  <data name="NotYetSynchronized" xml:space="preserve">
+    <value>Not yet synchronised</value>
+  </data>
+  <data name="EmailAccountEnabled" xml:space="preserve">
+    <value>Account '{0}' has been enabled for synchronisation.</value>
+    <comment>{0} - account name</comment>
+  </data>
+  <data name="EmailAccountDisabled" xml:space="preserve">
+    <value>Account '{0}' has been disabled for synchronisation.</value>
+    <comment>{0} - account name</comment>
+  </data>
+  <data name="SyncStarted" xml:space="preserve">
+    <value>Synchronisation for '{0}' was successfully started.</value>
+    <comment>{0} - account name</comment>
+  </data>
+  <data name="SyncSuccess" xml:space="preserve">
+    <value>Synchronisation for '{0}' was successfully completed.</value>
+    <comment>{0} - account name</comment>
+  </data>
+    <data name="SyncFailed" xml:space="preserve">
+    <value>Error during synchronisation</value>
+  </data>
+    <data name="ImportOnlyAccountDescription" xml:space="preserve">
+    <value>Account for importing MBox or EML files without IMAP synchronisation</value>
+  </data>
+  <data name="ImportOnlyAccountNoSync" xml:space="preserve">
+    <value>Import-only accounts cannot be synchronised</value>
+  </data>
+    <data name="ExportInfoText" xml:space="preserve">
+    <value>This export will create a downloadable ZIP file containing all emails from this account. The format you choose determines how the emails are organised.</value>
+  </data>
+    <data name="EMLFormatDescription" xml:space="preserve">
+    <value>Creates individual .eml files organised in folders.</value>
+  </data>
+</root>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -1,7 +1,7 @@
 ﻿@using MailArchiver.Services
 @inject MailArchiver.Services.IAuthenticationService AuthService
 @inject Microsoft.Extensions.Localization.IStringLocalizer<MailArchiver.SharedResource> Localizer
-@{ var currentCulture = System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName; }
+@{ var currentCulture = System.Globalization.CultureInfo.CurrentUICulture.Name; }
 <!DOCTYPE html>
 <html lang="@currentCulture">
 

--- a/Views/Shared/_UserInfo.cshtml
+++ b/Views/Shared/_UserInfo.cshtml
@@ -2,7 +2,7 @@
 @inject MailArchiver.Services.IAuthenticationService AuthService
 @inject IUserService UserService
 @inject Microsoft.Extensions.Localization.IStringLocalizer<MailArchiver.SharedResource> Localizer
-@{ var currentCulture = System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName; }
+@{ var currentCulture = System.Globalization.CultureInfo.CurrentUICulture.Name; }
 
 @if (AuthService.IsAuthenticationRequired())
 {
@@ -53,6 +53,7 @@
                         <select name="culture" class="form-select form-select-sm" onchange="this.form.submit()">
                             @{ var ui = System.Threading.Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName; }
                             <option value="en" selected="@(ui=="en" ? "selected" : null)">English</option>
+                            <option value="en-GB" selected="@(System.Threading.Thread.CurrentThread.CurrentUICulture.Name=="en-GB" ? "selected" : null)">English (GB)</option>
                             <option value="sl" selected="@(ui=="sl" ? "selected" : null)">Slovenščina</option>
                             <option value="de" selected="@(ui=="de" ? "selected" : null)">Deutsch</option>
                             <option value="it" selected="@(ui=="it" ? "selected" : null)">Italiano</option>


### PR DESCRIPTION
This changes a few US spellings to UK spelling, as well as fixing the date/time format:
`10/15/2025, 06:12 PM` (`en-US`)
`15/10/2025, 18:12` (`en-GB`)
