### PR TITLE
Fixes #257 added missing properties SortBy and SortOrder to page links

### DIFF
--- a/Views/Emails/Index.cshtml
+++ b/Views/Emails/Index.cshtml
@@ -423,7 +423,9 @@
                                     IsOutgoing = Model.IsOutgoing,
                                     PageNumber = Model.PageNumber - 1,
                                     PageSize = Model.PageSize,
-                                    ShowSelectionControls = Model.ShowSelectionControls
+                                    ShowSelectionControls = Model.ShowSelectionControls,
+                                    SortBy = Model.SortBy,
+                                    SortOrder = Model.SortOrder
                                 })">@Localizer["Previous"]</a>
                             </li>
                         }
@@ -443,7 +445,9 @@
                                     IsOutgoing = Model.IsOutgoing,
                                     PageNumber = i,
                                     PageSize = Model.PageSize,
-                                    ShowSelectionControls = Model.ShowSelectionControls
+                                    ShowSelectionControls = Model.ShowSelectionControls,
+                                    SortBy = Model.SortBy,
+                                    SortOrder = Model.SortOrder
                                 })">@i</a>
                             </li>
                         }
@@ -459,7 +463,9 @@
                                     IsOutgoing = Model.IsOutgoing,
                                     PageNumber = Model.PageNumber + 1,
                                     PageSize = Model.PageSize,
-                                    ShowSelectionControls = Model.ShowSelectionControls
+                                    ShowSelectionControls = Model.ShowSelectionControls,
+                                    SortBy = Model.SortBy,
+                                    SortOrder = Model.SortOrder
                                 })">@Localizer["Next"]</a>
                             </li>
                         }


### PR DESCRIPTION
Fixes #257

### Problem
Email archive doesn't keep the selected sorting order when navigating through the result pages. It swiches back to the default sorting order (DATE descending) after each page navigation.

### Solution
In the pagination item links the missing properties SortBy and SortOrder were added.

### Testing
- Tested using Docker (fork build)
- Added mail account and started sync (needs to archive more than 20 mails)
- Opened Archive view
- Double click on DATE column (changes sort order to "ascending")
- Clicked on "Next" page button
- The result was sorted by DATE ascending (as expected)
- Changed sort order by SUBJECT
- Clicked on "Next" page button
- The result was still by SUBJECT (as expected)