### PR TITLE
Add circuit breaker for database connectivity failures during sync

### DIFF
--- a/Services/Providers/GraphEmailService.cs
+++ b/Services/Providers/GraphEmailService.cs
@@ -116,6 +116,9 @@ private async Task<GraphServiceClient> CreateGraphClientAsync(MailAccount accoun
                 var folderPaths = BuildFolderPathsMap(folders);
 
                 // Process each folder
+                int consecutiveFolderDbErrors = 0;
+                const int maxConsecutiveFolderDbErrors = 2;
+
                 foreach (var folder in folders)
                 {
                     // Check if job has been cancelled
@@ -128,6 +131,23 @@ private async Task<GraphServiceClient> CreateGraphClientAsync(MailAccount accoun
                             _syncJobService.CompleteJob(jobId, false, "Job was cancelled");
                             return;
                         }
+                    }
+
+                    // Circuit breaker: if multiple folders in a row failed due to DB issues, check connectivity before continuing
+                    if (consecutiveFolderDbErrors >= maxConsecutiveFolderDbErrors)
+                    {
+                        _logger.LogError("Circuit breaker triggered at folder level: {Count} consecutive folders failed due to database connectivity issues. Checking database health...",
+                            consecutiveFolderDbErrors);
+                        if (!await IsDatabaseReachableAsync())
+                        {
+                            _logger.LogError("Database is unreachable. Aborting sync for account {AccountName}.", account.Name);
+                            if (jobId != null)
+                            {
+                                _syncJobService.CompleteJob(jobId, false, "Database connectivity lost during sync");
+                            }
+                            return;
+                        }
+                        consecutiveFolderDbErrors = 0; // DB is back, reset counter
                     }
 
                     try
@@ -159,6 +179,7 @@ private async Task<GraphServiceClient> CreateGraphClientAsync(MailAccount accoun
                         processedEmails += folderResult.ProcessedEmails;
                         newEmails += folderResult.NewEmails;
                         failedEmails += folderResult.FailedEmails;
+                        consecutiveFolderDbErrors = 0; // Folder completed, reset DB error counter
 
                         processedFolders++;
 
@@ -178,6 +199,15 @@ private async Task<GraphServiceClient> CreateGraphClientAsync(MailAccount accoun
                         _logger.LogError(ex, "Error syncing folder {FolderName} for account {AccountName}: {Message}",
                             folder.DisplayName, account.Name, ex.Message);
                         failedEmails++;
+
+                        if (IsDbConnectivityError(ex))
+                        {
+                            consecutiveFolderDbErrors++;
+                        }
+                        else
+                        {
+                            consecutiveFolderDbErrors = 0;
+                        }
                     }
                 }
 
@@ -562,6 +592,10 @@ private async Task<GraphServiceClient> CreateGraphClientAsync(MailAccount accoun
                     _logger.LogInformation("Processing page 1 with {Count} messages in folder {FolderName} for account: {AccountName}",
                         filteredMessages.Count, folder.DisplayName, account.Name);
 
+                    // Circuit breaker: abort folder sync after consecutive DB connectivity failures
+                    const int maxConsecutiveDbErrors = 5;
+                    int consecutiveDbErrors = 0;
+
                     // Process messages in batches for better memory management
                     for (int i = 0; i < filteredMessages.Count; i += _batchOptions.BatchSize)
                     {
@@ -619,11 +653,27 @@ private async Task<GraphServiceClient> CreateGraphClientAsync(MailAccount accoun
                                     {
                                         result.NewEmails++;
                                     }
-                                    
+                                    consecutiveDbErrors = 0; // Reset on success
+
                                     processedInThisFolder++;
+                                }
+                                catch (Exception ex) when (IsDbConnectivityError(ex))
+                                {
+                                    consecutiveDbErrors++;
+                                    result.FailedEmails++;
+                                    processedInThisFolder++;
+                                    _logger.LogError("Database connectivity error ({ConsecutiveCount}/{MaxCount}) while archiving message in folder {FolderName}",
+                                        consecutiveDbErrors, maxConsecutiveDbErrors, folderNameForStorage);
+                                    if (consecutiveDbErrors >= maxConsecutiveDbErrors)
+                                    {
+                                        _logger.LogError("Circuit breaker triggered: {MaxCount} consecutive database connectivity failures in folder {FolderName}. Aborting folder sync.",
+                                            maxConsecutiveDbErrors, folderNameForStorage);
+                                        return result;
+                                    }
                                 }
                                 catch (Exception ex)
                                 {
+                                    consecutiveDbErrors = 0; // Non-DB errors don't count
                                     var subject = message.Subject ?? "Unknown";
                                     var date = message.SentDateTime?.ToString() ?? "Unknown";
                                     _logger.LogError(ex, "Error archiving Graph API message {MessageId} from folder {FolderName}. Subject: {Subject}, Date: {Date}, Message: {Message}",
@@ -687,7 +737,22 @@ private async Task<GraphServiceClient> CreateGraphClientAsync(MailAccount accoun
                             await Task.Delay(_batchOptions.PauseBetweenBatchesMs);
                         }
 
-                        _logger.LogInformation("Fetching page {PageNumber} for folder {FolderName} (Total processed so far: {TotalProcessed})", 
+                        // Circuit breaker check: if too many DB errors accumulated, stop pagination
+                        if (consecutiveDbErrors >= maxConsecutiveDbErrors)
+                        {
+                            _logger.LogError("Circuit breaker active: skipping further pagination for folder {FolderName} due to database connectivity issues", folderNameForStorage);
+                            break;
+                        }
+
+                        // DB health check before fetching next page to avoid wasting API calls
+                        if (consecutiveDbErrors > 0 && !await IsDatabaseReachableAsync())
+                        {
+                            _logger.LogError("Database unreachable before fetching page {PageNumber} for folder {FolderName}. Aborting folder sync.",
+                                paginationCount, folderNameForStorage);
+                            break;
+                        }
+
+                        _logger.LogInformation("Fetching page {PageNumber} for folder {FolderName} (Total processed so far: {TotalProcessed})",
                             paginationCount, folder.DisplayName, result.ProcessedEmails);
 
                         // Get next page
@@ -743,11 +808,27 @@ private async Task<GraphServiceClient> CreateGraphClientAsync(MailAccount accoun
                                     {
                                         result.NewEmails++;
                                     }
-                                    
+                                    consecutiveDbErrors = 0; // Reset on success
+
                                     processedInThisFolder++;
+                                }
+                                catch (Exception ex) when (IsDbConnectivityError(ex))
+                                {
+                                    consecutiveDbErrors++;
+                                    result.FailedEmails++;
+                                    processedInThisFolder++;
+                                    _logger.LogError("Database connectivity error ({ConsecutiveCount}/{MaxCount}) during pagination page {PageNumber} in folder {FolderName}",
+                                        consecutiveDbErrors, maxConsecutiveDbErrors, paginationCount, folderNameForStorage);
+                                    if (consecutiveDbErrors >= maxConsecutiveDbErrors)
+                                    {
+                                        _logger.LogError("Circuit breaker triggered during pagination: {MaxCount} consecutive database connectivity failures in folder {FolderName}. Aborting folder sync.",
+                                            maxConsecutiveDbErrors, folderNameForStorage);
+                                        return result;
+                                    }
                                 }
                                 catch (Exception ex)
                                 {
+                                    consecutiveDbErrors = 0; // Non-DB errors don't count
                                     var subject = message.Subject ?? "Unknown";
                                     var date = message.SentDateTime?.ToString() ?? "Unknown";
                                     _logger.LogError(ex, "Error archiving Graph API message {MessageId} from folder {FolderName}. Subject: {Subject}, Date: {Date}, Message: {Message}",
@@ -755,7 +836,7 @@ private async Task<GraphServiceClient> CreateGraphClientAsync(MailAccount accoun
                                     result.FailedEmails++;
                                     processedInThisFolder++;
                                 }
-                                
+
                                 // Force garbage collection after each email to free memory
                                 if (processedInThisFolder % 10 == 0)
                                 {
@@ -863,9 +944,15 @@ private async Task<GraphServiceClient> CreateGraphClientAsync(MailAccount accoun
                     return false; // Email already exists
                 }
             }
+            catch (Exception ex) when (IsDbConnectivityError(ex))
+            {
+                _logger.LogError(ex, "Database connectivity error while checking email {MessageId} for account {AccountName}",
+                    messageId, account.Name);
+                throw; // Let caller handle DB connectivity failures via circuit breaker
+            }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error checking if email {MessageId} exists for account {AccountName}: {Message}", 
+                _logger.LogError(ex, "Error checking if email {MessageId} exists for account {AccountName}: {Message}",
                     messageId, account.Name, ex.Message);
                 return false;
             }
@@ -2644,6 +2731,52 @@ private async Task<GraphServiceClient> CreateGraphClientAsync(MailAccount accoun
         Task<int> MailArchiver.Services.Providers.IProviderEmailService.GetEmailCountByAccountAsync(int accountId)
         {
             return _coreService.GetEmailCountByAccountAsync(accountId);
+        }
+
+        #endregion
+
+        #region Database Connectivity Helpers
+
+        /// <summary>
+        /// Checks if an exception indicates a database connectivity issue (connection refused, DNS failure, timeout).
+        /// Used by the circuit breaker to distinguish transient DB failures from application-level errors.
+        /// </summary>
+        private static bool IsDbConnectivityError(Exception ex)
+        {
+            // Check the full exception chain for connectivity indicators
+            var current = ex;
+            while (current != null)
+            {
+                var message = current.Message ?? "";
+                if (current is System.Net.Sockets.SocketException ||
+                    message.Contains("Name or service not known", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("Connection refused", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("No such host", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("connection to server", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("An exception has been raised that is likely due to a transient failure", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                current = current.InnerException;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Performs a lightweight database connectivity check by executing a simple query.
+        /// Returns true if the database is reachable, false otherwise.
+        /// </summary>
+        private async Task<bool> IsDatabaseReachableAsync()
+        {
+            try
+            {
+                await _context.Database.CanConnectAsync();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         #endregion

--- a/Services/Providers/ImapEmailService.cs
+++ b/Services/Providers/ImapEmailService.cs
@@ -83,6 +83,10 @@ namespace MailArchiver.Services.Providers
 
                 _logger.LogInformation("Found {Count} folders for account: {AccountName}", allFolders.Count, account.Name);
 
+                // Circuit breaker: abort sync after consecutive DB connectivity failures across folders
+                int consecutiveFolderDbErrors = 0;
+                const int maxConsecutiveFolderDbErrors = 2;
+
                 foreach (var folder in allFolders)
                 {
                     if (jobId != null)
@@ -94,6 +98,23 @@ namespace MailArchiver.Services.Providers
                             _syncJobService.CompleteJob(jobId, false, "Job was cancelled");
                             return;
                         }
+                    }
+
+                    // Circuit breaker: check DB health if previous folders failed due to DB issues
+                    if (consecutiveFolderDbErrors >= maxConsecutiveFolderDbErrors)
+                    {
+                        _logger.LogError("Circuit breaker triggered at folder level: {Count} consecutive folders failed due to database connectivity issues. Checking database health...",
+                            consecutiveFolderDbErrors);
+                        if (!await IsDatabaseReachableAsync())
+                        {
+                            _logger.LogError("Database is unreachable. Aborting sync for account {AccountName}.", account.Name);
+                            if (jobId != null)
+                            {
+                                _syncJobService.CompleteJob(jobId, false, "Database connectivity lost during sync");
+                            }
+                            return;
+                        }
+                        consecutiveFolderDbErrors = 0; // DB is back, reset counter
                     }
 
                     try
@@ -119,6 +140,7 @@ namespace MailArchiver.Services.Providers
                         processedEmails += folderResult.ProcessedEmails;
                         newEmails += folderResult.NewEmails;
                         failedEmails += folderResult.FailedEmails;
+                        consecutiveFolderDbErrors = 0; // Folder completed, reset DB error counter
 
                         processedFolders++;
 
@@ -138,6 +160,15 @@ namespace MailArchiver.Services.Providers
                         _logger.LogError(ex, "Error syncing folder {FolderName} for account {AccountName}: {Message}",
                             folder.FullName, account.Name, ex.Message);
                         failedEmails++;
+
+                        if (IsDbConnectivityError(ex))
+                        {
+                            consecutiveFolderDbErrors++;
+                        }
+                        else
+                        {
+                            consecutiveFolderDbErrors = 0;
+                        }
                     }
                 }
 
@@ -1010,6 +1041,10 @@ namespace MailArchiver.Services.Providers
 
                     result.ProcessedEmails = uids.Count;
 
+                    // Circuit breaker: abort folder sync after consecutive DB connectivity failures
+                    const int maxConsecutiveDbErrors = 5;
+                    int consecutiveDbErrors = 0;
+
                     // Process emails in smaller chunks to reduce memory usage
                     for (int i = 0; i < uids.Count; i += _batchOptions.BatchSize)
                     {
@@ -1075,9 +1110,24 @@ namespace MailArchiver.Services.Providers
                                 {
                                     result.NewEmails++;
                                 }
+                                consecutiveDbErrors = 0; // Reset on success
+                            }
+                            catch (Exception ex) when (IsDbConnectivityError(ex))
+                            {
+                                consecutiveDbErrors++;
+                                result.FailedEmails++;
+                                _logger.LogError("Database connectivity error ({ConsecutiveCount}/{MaxCount}) while archiving message in folder {FolderName}",
+                                    consecutiveDbErrors, maxConsecutiveDbErrors, folder.FullName);
+                                if (consecutiveDbErrors >= maxConsecutiveDbErrors)
+                                {
+                                    _logger.LogError("Circuit breaker triggered: {MaxCount} consecutive database connectivity failures in folder {FolderName}. Aborting folder sync.",
+                                        maxConsecutiveDbErrors, folder.FullName);
+                                    return result;
+                                }
                             }
                             catch (Exception ex)
                             {
+                                consecutiveDbErrors = 0; // Non-DB errors don't count
                                 // Enhanced error logging with email details for better debugging
                                 var emailSubject = "Unknown";
                                 var emailFrom = "Unknown";
@@ -2310,6 +2360,51 @@ namespace MailArchiver.Services.Providers
 
             // Remove null bytes
             return input.Replace("\0", "");
+        }
+
+        #endregion
+
+        #region Database Connectivity Helpers
+
+        /// <summary>
+        /// Checks if an exception indicates a database connectivity issue (connection refused, DNS failure, timeout).
+        /// Used by the circuit breaker to distinguish transient DB failures from application-level errors.
+        /// </summary>
+        private static bool IsDbConnectivityError(Exception ex)
+        {
+            var current = ex;
+            while (current != null)
+            {
+                var message = current.Message ?? "";
+                if (current is System.Net.Sockets.SocketException ||
+                    message.Contains("Name or service not known", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("Connection refused", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("No such host", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("connection to server", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("An exception has been raised that is likely due to a transient failure", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                current = current.InnerException;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Performs a lightweight database connectivity check.
+        /// Returns true if the database is reachable, false otherwise.
+        /// </summary>
+        private async Task<bool> IsDatabaseReachableAsync()
+        {
+            try
+            {
+                await _context.Database.CanConnectAsync();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         #endregion


### PR DESCRIPTION
## Summary

When PostgreSQL becomes unreachable during email sync (e.g. container crash, OOM kill, DNS failure), the sync loop currently continues processing every single email — logging a DB error for each one without ever stopping. This causes massive log spam, wasted Graph API / IMAP calls, and high memory/CPU usage for no benefit.

This PR adds a **circuit breaker pattern** to both `GraphEmailService` and `ImapEmailService`:

- **Message-level circuit breaker**: After 5 consecutive DB connectivity errors within a folder, abort the folder sync immediately
- **Folder-level circuit breaker**: After 2 consecutive folders fail due to DB issues, check database health. Abort entire account sync if DB is unreachable
- **Pre-pagination health check**: Before fetching the next page from Graph API, verify DB connectivity to avoid wasting API quota
- **`IsDbConnectivityError()` helper**: Distinguishes DB connectivity errors (`SocketException`, DNS failures, transient failures) from application-level errors (UTF-8 issues, parse errors, etc.)
- **`IsDatabaseReachableAsync()` helper**: Lightweight connectivity check via `CanConnectAsync()`

Non-DB errors are **not** affected by the circuit breaker and continue to be handled as before.

## Context

This was discovered when the PostgreSQL container died during a large sync operation (800+ emails across multiple folders). The mail archiver continued running, spamming thousands of identical "Name or service not known" errors in the logs — one for every email it tried to process — while also continuing to fetch pages from the Graph API (wasting API calls). The container had to be manually stopped.

Related issues:
- #382 (Gmail sync loop)
- #388 (IMAP sync loop with malformed headers)
- #363 (DB corruption after container restart)

## Test plan

- [ ] Verify normal sync still works without DB issues (circuit breaker should not trigger)
- [ ] Simulate DB outage during sync (stop postgres container) — sync should abort after 5 consecutive DB errors per folder
- [ ] Verify non-DB errors (e.g. UTF-8 encoding) don't trigger circuit breaker
- [ ] Verify folder-level circuit breaker aborts account sync after 2 folder failures
- [ ] Check that sync resumes normally after DB comes back

🤖 Generated with [Claude Code](https://claude.com/claude-code)