### PR TITLE
Add configurable OIDC login display name

### DIFF
--- a/Auth/Options/OAuthOptions.cs
+++ b/Auth/Options/OAuthOptions.cs
@@ -9,6 +9,7 @@
         public string? Authority { get; set; }
         public string? ClientId { get; set; }
         public string? ClientSecret { get; set; }
+        public string? DisplayName { get; set; }
         public string[]? ClientScopes { get; set; }
         public bool DisablePasswordLogin { get; set; }
         public bool AutoRedirect { get; set; }

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -55,14 +55,11 @@ namespace MailArchiver.Controllers
                 return RedirectToLocal(returnUrl);
             }
 
+            ConfigureOAuthViewData(returnUrl);
+
             var oAuthEnabled = _oAuthOptions.Value?.Enabled ?? false;
             var disablePasswordLogin = _oAuthOptions.Value?.DisablePasswordLogin ?? false;
             var autoRedirect = _oAuthOptions.Value?.AutoRedirect ?? false;
-
-            ViewBag.OAuthEnabled = oAuthEnabled;
-            ViewBag.DisablePasswordLogin = disablePasswordLogin;
-            ViewBag.AutoRedirect = autoRedirect;
-            ViewData["ReturnUrl"] = returnUrl;
 
             // Auto-redirect to OAuth if enabled and password login is disabled
             // SECURITY: Do not auto-redirect if there's an error message (e.g., from failed OIDC auth)
@@ -71,7 +68,7 @@ namespace MailArchiver.Controllers
             if (oAuthEnabled && disablePasswordLogin && autoRedirect && !hasError)
             {
                 _logger.LogInformation("Auto-redirecting to OAuth provider (password login disabled, auto-redirect enabled)");
-                return View("AutoRedirect", new OAuthLoginViewModel { ReturnUrl = returnUrl });
+                return View("AutoRedirect", new OAuthLoginViewModel { ReturnUrl = returnUrl, DisplayName = ViewBag.OAuthDisplayName });
             }
 
             // Pass OIDC error message to the view if present
@@ -81,6 +78,23 @@ namespace MailArchiver.Controllers
             }
 
             return View(new LoginViewModel());
+        }
+
+        private void ConfigureOAuthViewData(string? returnUrl)
+        {
+            var options = _oAuthOptions.Value;
+            var displayName = string.IsNullOrWhiteSpace(options?.DisplayName)
+                ? null
+                : options.DisplayName.Trim();
+
+            ViewBag.OAuthEnabled = options?.Enabled ?? false;
+            ViewBag.DisablePasswordLogin = options?.DisablePasswordLogin ?? false;
+            ViewBag.AutoRedirect = options?.AutoRedirect ?? false;
+            ViewBag.OAuthDisplayName = displayName ?? "OAuth";
+            ViewBag.OAuthSignInLabel = string.IsNullOrWhiteSpace(displayName)
+                ? _localizer["SignInWithOAuth"].Value
+                : _localizer["SignInWithOAuthProvider", displayName].Value;
+            ViewData["ReturnUrl"] = returnUrl;
         }
 
         [HttpPost]
@@ -134,14 +148,14 @@ namespace MailArchiver.Controllers
                 else
                 {
                     ModelState.AddModelError("", _localizer["InvalidUserPassword"]);
-                    ViewBag.OAuthEnabled = _oAuthOptions.Value?.Enabled ?? false;
+                    ConfigureOAuthViewData(returnUrl);
                     _logger.LogWarning("Failed login attempt for username: {Username} from IP: {IP}", 
                         model.Username, HttpContext.Connection.RemoteIpAddress);
                 }
             }
 
-            // Ensure OAuthEnabled is set when returning view on validation errors
-            ViewBag.OAuthEnabled = _oAuthOptions.Value?.Enabled ?? false;
+            // Ensure OAuth view data is set when returning view on validation errors
+            ConfigureOAuthViewData(returnUrl);
             return View(model);
         }
 

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -83,18 +83,28 @@ namespace MailArchiver.Controllers
         private void ConfigureOAuthViewData(string? returnUrl)
         {
             var options = _oAuthOptions.Value;
+            var enabled = options?.Enabled ?? false;
+
+            ViewBag.OAuthEnabled = enabled;
+            ViewBag.DisablePasswordLogin = options?.DisablePasswordLogin ?? false;
+            ViewBag.AutoRedirect = options?.AutoRedirect ?? false;
+            ViewData["ReturnUrl"] = returnUrl;
+
+            if (!enabled)
+            {
+                ViewBag.OAuthDisplayName = "OAuth";
+                ViewBag.OAuthSignInLabel = null;
+                return;
+            }
+
             var displayName = string.IsNullOrWhiteSpace(options?.DisplayName)
                 ? null
                 : options.DisplayName.Trim();
 
-            ViewBag.OAuthEnabled = options?.Enabled ?? false;
-            ViewBag.DisablePasswordLogin = options?.DisablePasswordLogin ?? false;
-            ViewBag.AutoRedirect = options?.AutoRedirect ?? false;
             ViewBag.OAuthDisplayName = displayName ?? "OAuth";
             ViewBag.OAuthSignInLabel = string.IsNullOrWhiteSpace(displayName)
                 ? _localizer["SignInWithOAuth"].Value
                 : _localizer["SignInWithOAuthProvider", displayName].Value;
-            ViewData["ReturnUrl"] = returnUrl;
         }
 
         [HttpPost]
@@ -148,7 +158,6 @@ namespace MailArchiver.Controllers
                 else
                 {
                     ModelState.AddModelError("", _localizer["InvalidUserPassword"]);
-                    ConfigureOAuthViewData(returnUrl);
                     _logger.LogWarning("Failed login attempt for username: {Username} from IP: {IP}", 
                         model.Username, HttpContext.Connection.RemoteIpAddress);
                 }

--- a/Resources/SharedResource.de.resx
+++ b/Resources/SharedResource.de.resx
@@ -2390,6 +2390,15 @@
   <data name="SignInWithOAuthProvider" xml:space="preserve">
     <value>Anmelden mit {0}</value>
   </data>
+  <data name="RedirectingToProvider" xml:space="preserve">
+    <value>Weiterleitung zu {0}...</value>
+  </data>
+  <data name="PleaseWaitRedirectingToProvider" xml:space="preserve">
+    <value>Bitte warten Sie, während wir Sie zu {0} weiterleiten...</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Wird geladen...</value>
+  </data>
   <data name="AccountDeleted" xml:space="preserve">
     <value>Account '{0}' wurde erfolgreich gelöscht, einschließlich aller archivierten E-Mails und Anhänge.</value>
   </data>

--- a/Resources/SharedResource.de.resx
+++ b/Resources/SharedResource.de.resx
@@ -2387,6 +2387,9 @@
   <data name="SignInWithOAuth" xml:space="preserve">
     <value>Anmelden mit OAuth</value>
   </data>
+  <data name="SignInWithOAuthProvider" xml:space="preserve">
+    <value>Anmelden mit {0}</value>
+  </data>
   <data name="AccountDeleted" xml:space="preserve">
     <value>Account '{0}' wurde erfolgreich gelöscht, einschließlich aller archivierten E-Mails und Anhänge.</value>
   </data>

--- a/Resources/SharedResource.en-GB.resx
+++ b/Resources/SharedResource.en-GB.resx
@@ -118,7 +118,4 @@
     <data name="EMLFormatDescription" xml:space="preserve">
     <value>Creates individual .eml files organised in folders.</value>
   </data>
-  <data name="SignInWithOAuthProvider" xml:space="preserve">
-    <value>Login with {0}</value>
-  </data>
 </root>

--- a/Resources/SharedResource.en-GB.resx
+++ b/Resources/SharedResource.en-GB.resx
@@ -118,4 +118,7 @@
     <data name="EMLFormatDescription" xml:space="preserve">
     <value>Creates individual .eml files organised in folders.</value>
   </data>
+  <data name="SignInWithOAuthProvider" xml:space="preserve">
+    <value>Login with {0}</value>
+  </data>
 </root>

--- a/Resources/SharedResource.es.resx
+++ b/Resources/SharedResource.es.resx
@@ -2337,6 +2337,15 @@
   <data name="SignInWithOAuthProvider" xml:space="preserve">
     <value>Iniciar sesión con {0}</value>
   </data>
+  <data name="RedirectingToProvider" xml:space="preserve">
+    <value>Redirigiendo a {0}...</value>
+  </data>
+  <data name="PleaseWaitRedirectingToProvider" xml:space="preserve">
+    <value>Espere mientras le redirigimos a {0}...</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Cargando...</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Hora de sincronización actual</value>
   </data>

--- a/Resources/SharedResource.es.resx
+++ b/Resources/SharedResource.es.resx
@@ -2334,6 +2334,9 @@
   <data name="SignInWithOAuth" xml:space="preserve">
     <value>Iniciar sesión con OAuth</value>
   </data>
+  <data name="SignInWithOAuthProvider" xml:space="preserve">
+    <value>Iniciar sesión con {0}</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Hora de sincronización actual</value>
   </data>

--- a/Resources/SharedResource.fr.resx
+++ b/Resources/SharedResource.fr.resx
@@ -2338,6 +2338,15 @@
   <data name="SignInWithOAuthProvider" xml:space="preserve">
     <value>Se connecter avec {0}</value>
   </data>
+  <data name="RedirectingToProvider" xml:space="preserve">
+    <value>Redirection vers {0}...</value>
+  </data>
+  <data name="PleaseWaitRedirectingToProvider" xml:space="preserve">
+    <value>Veuillez patienter pendant que nous vous redirigeons vers {0}...</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Chargement...</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Heure de synchronisation actuelle</value>
   </data>

--- a/Resources/SharedResource.fr.resx
+++ b/Resources/SharedResource.fr.resx
@@ -2335,6 +2335,9 @@
   <data name="SignInWithOAuth" xml:space="preserve">
     <value>Se connecter avec OAuth</value>
   </data>
+  <data name="SignInWithOAuthProvider" xml:space="preserve">
+    <value>Se connecter avec {0}</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Heure de synchronisation actuelle</value>
   </data>

--- a/Resources/SharedResource.hu.resx
+++ b/Resources/SharedResource.hu.resx
@@ -2330,6 +2330,15 @@
   <data name="SignInWithOAuthProvider" xml:space="preserve">
     <value>Bejelentkezés ezzel: {0}</value>
   </data>
+  <data name="RedirectingToProvider" xml:space="preserve">
+    <value>Átirányítás a következőre: {0}...</value>
+  </data>
+  <data name="PleaseWaitRedirectingToProvider" xml:space="preserve">
+    <value>Kérjük, várjon, amíg átirányítjuk a következőre: {0}...</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Betöltés...</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Jelenlegi szinkronidő</value>
   </data>

--- a/Resources/SharedResource.hu.resx
+++ b/Resources/SharedResource.hu.resx
@@ -2327,6 +2327,9 @@
   <data name="SignInWithOAuth" xml:space="preserve">
     <value>Bejelentkezés OAuth segítségével</value>
   </data>
+  <data name="SignInWithOAuthProvider" xml:space="preserve">
+    <value>Bejelentkezés ezzel: {0}</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Jelenlegi szinkronidő</value>
   </data>

--- a/Resources/SharedResource.it.resx
+++ b/Resources/SharedResource.it.resx
@@ -2338,6 +2338,15 @@
   <data name="SignInWithOAuthProvider" xml:space="preserve">
     <value>Accedi con {0}</value>
   </data>
+  <data name="RedirectingToProvider" xml:space="preserve">
+    <value>Reindirizzamento a {0}...</value>
+  </data>
+  <data name="PleaseWaitRedirectingToProvider" xml:space="preserve">
+    <value>Attendere mentre la reindirizziamo a {0}...</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Caricamento...</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Ora di sincronizzazione corrente</value>
   </data>

--- a/Resources/SharedResource.it.resx
+++ b/Resources/SharedResource.it.resx
@@ -2335,6 +2335,9 @@
   <data name="SignInWithOAuth" xml:space="preserve">
     <value>Accedi con OAuth</value>
   </data>
+  <data name="SignInWithOAuthProvider" xml:space="preserve">
+    <value>Accedi con {0}</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Ora di sincronizzazione corrente</value>
   </data>

--- a/Resources/SharedResource.nl.resx
+++ b/Resources/SharedResource.nl.resx
@@ -2338,6 +2338,15 @@
   <data name="SignInWithOAuthProvider" xml:space="preserve">
     <value>Inloggen met {0}</value>
   </data>
+  <data name="RedirectingToProvider" xml:space="preserve">
+    <value>Doorverwijzen naar {0}...</value>
+  </data>
+  <data name="PleaseWaitRedirectingToProvider" xml:space="preserve">
+    <value>Een ogenblik geduld terwijl we u doorverwijzen naar {0}...</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Laden...</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Huidige synchronisatietijd</value>
   </data>

--- a/Resources/SharedResource.nl.resx
+++ b/Resources/SharedResource.nl.resx
@@ -2335,6 +2335,9 @@
   <data name="SignInWithOAuth" xml:space="preserve">
     <value>Inloggen met OAuth</value>
   </data>
+  <data name="SignInWithOAuthProvider" xml:space="preserve">
+    <value>Inloggen met {0}</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Huidige synchronisatietijd</value>
   </data>

--- a/Resources/SharedResource.pl.resx
+++ b/Resources/SharedResource.pl.resx
@@ -2379,6 +2379,9 @@
   <data name="SignInWithOAuth" xml:space="preserve">
     <value>Logowanie za pomocą OAuth</value>
   </data>
+  <data name="SignInWithOAuthProvider" xml:space="preserve">
+    <value>Logowanie za pomocą {0}</value>
+  </data>
   <data name="OidcUserCannotHavePassword" xml:space="preserve">
     <value>Użytkownicy OIDC nie mogą posiadać hasła. Uwierzytelniają się oni za pośrednictwem dostawcy OIDC.</value>
   </data>

--- a/Resources/SharedResource.pl.resx
+++ b/Resources/SharedResource.pl.resx
@@ -2382,6 +2382,15 @@
   <data name="SignInWithOAuthProvider" xml:space="preserve">
     <value>Logowanie za pomocą {0}</value>
   </data>
+  <data name="RedirectingToProvider" xml:space="preserve">
+    <value>Przekierowywanie do {0}...</value>
+  </data>
+  <data name="PleaseWaitRedirectingToProvider" xml:space="preserve">
+    <value>Proszę czekać, trwa przekierowywanie do {0}...</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Ładowanie...</value>
+  </data>
   <data name="OidcUserCannotHavePassword" xml:space="preserve">
     <value>Użytkownicy OIDC nie mogą posiadać hasła. Uwierzytelniają się oni za pośrednictwem dostawcy OIDC.</value>
   </data>

--- a/Resources/SharedResource.resx
+++ b/Resources/SharedResource.resx
@@ -2351,8 +2351,19 @@
   <data name="SignInWithOAuth" xml:space="preserve">
     <value>Login with OAuth</value>
   </data>
-   <data name="SignInWithOAuthProvider" xml:space="preserve">
+  <data name="SignInWithOAuthProvider" xml:space="preserve">
     <value>Login with {0}</value>
+  </data>
+  <data name="RedirectingToProvider" xml:space="preserve">
+    <value>Redirecting to {0}...</value>
+    <comment>{0} - OAuth provider display name</comment>
+  </data>
+  <data name="PleaseWaitRedirectingToProvider" xml:space="preserve">
+    <value>Please wait while we redirect you to {0}...</value>
+    <comment>{0} - OAuth provider display name</comment>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Loading...</value>
   </data>
   <data name="OidcUserCannotHavePassword" xml:space="preserve">
     <value>OIDC users cannot have a password. They authenticate through the OIDC provider.</value>

--- a/Resources/SharedResource.resx
+++ b/Resources/SharedResource.resx
@@ -2351,6 +2351,9 @@
   <data name="SignInWithOAuth" xml:space="preserve">
     <value>Login with OAuth</value>
   </data>
+   <data name="SignInWithOAuthProvider" xml:space="preserve">
+    <value>Login with {0}</value>
+  </data>
   <data name="OidcUserCannotHavePassword" xml:space="preserve">
     <value>OIDC users cannot have a password. They authenticate through the OIDC provider.</value>
   </data>

--- a/Resources/SharedResource.ru.resx
+++ b/Resources/SharedResource.ru.resx
@@ -2335,6 +2335,9 @@
   <data name="SignInWithOAuth" xml:space="preserve">
     <value>Войти с OAuth</value>
   </data>
+  <data name="SignInWithOAuthProvider" xml:space="preserve">
+    <value>Войти с {0}</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Текущее время синхронизации</value>
   </data>

--- a/Resources/SharedResource.ru.resx
+++ b/Resources/SharedResource.ru.resx
@@ -2338,6 +2338,15 @@
   <data name="SignInWithOAuthProvider" xml:space="preserve">
     <value>Войти с {0}</value>
   </data>
+  <data name="RedirectingToProvider" xml:space="preserve">
+    <value>Перенаправление на {0}...</value>
+  </data>
+  <data name="PleaseWaitRedirectingToProvider" xml:space="preserve">
+    <value>Пожалуйста, подождите, пока мы перенаправим вас на {0}...</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Загрузка...</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Текущее время синхронизации</value>
   </data>

--- a/Resources/SharedResource.sl.resx
+++ b/Resources/SharedResource.sl.resx
@@ -2335,6 +2335,9 @@
   <data name="SignInWithOAuth" xml:space="preserve">
     <value>Prijava z OAuth</value>
   </data>
+  <data name="SignInWithOAuthProvider" xml:space="preserve">
+    <value>Prijava z {0}</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Trenutni čas sinhronizacije</value>
   </data>

--- a/Resources/SharedResource.sl.resx
+++ b/Resources/SharedResource.sl.resx
@@ -2338,6 +2338,15 @@
   <data name="SignInWithOAuthProvider" xml:space="preserve">
     <value>Prijava z {0}</value>
   </data>
+  <data name="RedirectingToProvider" xml:space="preserve">
+    <value>Preusmerjanje na {0}...</value>
+  </data>
+  <data name="PleaseWaitRedirectingToProvider" xml:space="preserve">
+    <value>Prosimo počakajte, medtem ko vas preusmerimo na {0}...</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Nalaganje...</value>
+  </data>
   <data name="CurrentSyncTime" xml:space="preserve">
     <value>Trenutni čas sinhronizacije</value>
   </data>

--- a/ViewModels/OAuthLoginViewModel.cs
+++ b/ViewModels/OAuthLoginViewModel.cs
@@ -3,5 +3,6 @@
     public class OAuthLoginViewModel
     {
         public string? ReturnUrl { get; set; }
+        public string? DisplayName { get; set; }
     }
 }

--- a/Views/Auth/AutoRedirect.cshtml
+++ b/Views/Auth/AutoRedirect.cshtml
@@ -11,14 +11,14 @@
             <div class="text-center mb-4">
                 <i class="bi bi-envelope-check display-3 text-primary"></i>
                 <h2 class="mt-3">@Localizer["AppName"]</h2>
-                <p class="text-muted">Redirecting to @Model.DisplayName...</p>
+                <p class="text-muted">@Localizer["RedirectingToProvider", Model.DisplayName]</p>
             </div>
 
             <div class="text-center mb-4">
                 <div class="spinner-border text-primary" role="status">
-                    <span class="visually-hidden">Loading...</span>
+                    <span class="visually-hidden">@Localizer["Loading"]</span>
                 </div>
-                <p class="mt-3 text-muted">Please wait while we redirect you to @Model.DisplayName...</p>
+                <p class="mt-3 text-muted">@Localizer["PleaseWaitRedirectingToProvider", Model.DisplayName]</p>
             </div>
 
             <form id="autoRedirectForm" asp-action="LoginWithOAuth" method="post">

--- a/Views/Auth/AutoRedirect.cshtml
+++ b/Views/Auth/AutoRedirect.cshtml
@@ -11,14 +11,14 @@
             <div class="text-center mb-4">
                 <i class="bi bi-envelope-check display-3 text-primary"></i>
                 <h2 class="mt-3">@Localizer["AppName"]</h2>
-                <p class="text-muted">Redirecting to authentication provider...</p>
+                <p class="text-muted">Redirecting to @Model.DisplayName...</p>
             </div>
 
             <div class="text-center mb-4">
                 <div class="spinner-border text-primary" role="status">
                     <span class="visually-hidden">Loading...</span>
                 </div>
-                <p class="mt-3 text-muted">Please wait while we redirect you to the login provider...</p>
+                <p class="mt-3 text-muted">Please wait while we redirect you to @Model.DisplayName...</p>
             </div>
 
             <form id="autoRedirectForm" asp-action="LoginWithOAuth" method="post">

--- a/Views/Auth/Login.cshtml
+++ b/Views/Auth/Login.cshtml
@@ -66,7 +66,7 @@
                     <input type="hidden" name="ReturnUrl" value="@ViewData["ReturnUrl"]" />
                     <div class="d-grid">
                         <button type="submit" class="btn btn-primary btn-lg">
-                            <i class="bi bi-box-arrow-in-right me-2"></i>@Localizer["SignInWithOAuth"]
+                            <i class="bi bi-box-arrow-in-right me-2"></i>@(ViewBag.OAuthSignInLabel ?? Localizer["SignInWithOAuth"])
                         </button>
                     </div>
                 </form>

--- a/appsettings.json
+++ b/appsettings.json
@@ -14,6 +14,7 @@
     "Authority": "",
     "ClientId": "",
     "ClientSecret": null,
+    "DisplayName": null,
     "ClientScopes": [
       "openid",
       "profile",

--- a/doc/OIDC_Implementation.md
+++ b/doc/OIDC_Implementation.md
@@ -98,6 +98,7 @@ environment:
   - OAuth__Authority=https://sts.windows.net/{TENANT-ID}/
   - OAuth__ClientId=YOUR-CLIENT-ID
   - OAuth__ClientSecret=YOUR-CLIENT-SECRET
+  - OAuth__DisplayName=PocketID SSO
   - OAuth__ClientScopes__0=openid
   - OAuth__ClientScopes__1=profile
   - OAuth__ClientScopes__2=email
@@ -110,6 +111,7 @@ environment:
 - **OAuth__Authority**: The OpenID Connect authority URL of your identity provider
 - **OAuth__ClientId**: The client ID assigned by your identity provider
 - **OAuth__ClientSecret**: The client secret assigned by your identity provider
+- **OAuth__DisplayName**: Optional display name for the OIDC login button (for example, `PocketID SSO` renders as `Login with PocketID SSO`)
 - **OAuth__ClientScopes**: Array of scopes requested from the identity provider
 - **OAuth__DisablePasswordLogin**: Set to `true` to disable traditional username/password login and enforce OAuth-only authentication (see Passwordless Login Configuration for more details)
 - **OAuth__AutoApproveUsers**: Set to `true` to automatically approve new OIDC users without requiring admin approval (default: `false`). See [Auto-Approve OIDC Users](#auto-approve-oidc-users) for details
@@ -220,8 +222,8 @@ identity_providers:
 
 1. Restart your Mail Archiver application after configuring OIDC settings
 2. Navigate to your Mail Archiver login page
-3. You should see a new "Login with OAuth" button alongside the regular login form
-4. Click the "Login with OAuth" button to initiate the OIDC flow
+3. You should see a new OAuth login button alongside the regular login form. With `OAuth__DisplayName=PocketID SSO`, the button reads `Login with PocketID SSO`.
+4. Click the OAuth login button to initiate the OIDC flow
 5. You should be redirected to your identity provider's login page
 6. After successful authentication, you should be redirected back to Mail Archiver
 
@@ -343,6 +345,7 @@ This option is recommended for environments where:
     "Authority": "https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0",
     "ClientId": "your-client-id",
     "ClientSecret": "your-secret",
+    "DisplayName": "PocketID SSO",
     "ClientScopes": ["openid", "profile", "email"],
     "DisablePasswordLogin": true,
     "AutoRedirect": true,
@@ -387,7 +390,7 @@ Set `DisablePasswordLogin` to `true` to hide username/password fields:
 }
 ```
 
-**Result**: Login page displays only the "Login with OAuth" button.
+**Result**: Login page displays only the OAuth login button. If `DisplayName` is configured, the button uses that value (for example, `Login with PocketID SSO`).
 
 ### Auto-Redirect to OAuth Provider
 
@@ -421,6 +424,7 @@ Enable `AutoRedirect` to automatically redirect users to your OAuth provider:
     "Authority": "https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0",
     "ClientId": "your-client-id",
     "ClientSecret": "your-secret",
+    "DisplayName": "PocketID SSO",
     "ClientScopes": ["openid", "profile", "email"],
     "DisablePasswordLogin": true,
     "AutoRedirect": true,

--- a/doc/Setup.md
+++ b/doc/Setup.md
@@ -108,6 +108,7 @@ services:
       - OAuth__Authority=https://example.com
       - OAuth__ClientId=YOUR-CLIENT-ID
       - OAuth__ClientSecret=YOUR-CLIENT-SECRET
+      - OAuth__DisplayName=PocketID SSO
       - OAuth__ClientScopes__0=openid
       - OAuth__ClientScopes__1=profile
       - OAuth__ClientScopes__2=email
@@ -301,6 +302,7 @@ For detailed setup instructions for OpenID Connect authentication, see [OIDC Imp
 - `OAuth__Authority`: The OpenID Connect authority URL (e.g., https://sts.windows.net/{TENANT-ID}/ for Azure AD)
 - `OAuth__ClientId`: The client ID assigned by your identity provider
 - `OAuth__ClientSecret`: The client secret assigned by your identity provider
+- `OAuth__DisplayName`: Optional display name shown on the OIDC login button and auto-redirect page (e.g., `PocketID SSO`). If omitted, the generic "Login with OAuth" label is used.
 - `OAuth__ClientScopes__0`: First scope requested from the identity provider (openid)
 - `OAuth__ClientScopes__1`: Second scope requested from the identity provider (profile)
 - `OAuth__ClientScopes__2`: Third scope requested from the identity provider (email)
@@ -320,6 +322,7 @@ environment:
   - OAuth__Authority=https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0
   - OAuth__ClientId=your-client-id
   - OAuth__ClientSecret=your-client-secret
+  - OAuth__DisplayName=PocketID SSO
   - OAuth__ClientScopes__0=openid
   - OAuth__ClientScopes__1=profile
   - OAuth__ClientScopes__2=email


### PR DESCRIPTION
## Summary

Adds an optional OIDC display name setting so the login button can show a provider-specific label such as `Login with PocketID SSO` instead of the generic OAuth label.

Keeps the existing OAuth login label as the fallback when no display name is configured.

Adds localized `SignInWithOAuthProvider` format strings for all existing resource files.

Shows the configured OIDC display name on the auto-redirect screen when password login is disabled and auto-redirect is enabled.

Documents the new `OAuth__DisplayName` / `OAuth:DisplayName` setting in the OIDC setup documentation.

## Details

The OAuth configuration now supports an optional `DisplayName` value that can be configured via `appsettings.json` or environment variables, for example:

```yaml
OAuth__DisplayName=PocketID SSO
```

When configured, the display name is used throughout the login flow, including the login button and the automatic redirect page, providing a more user-friendly and provider-specific authentication experience.

If no display name is configured, the existing generic OAuth labels remain unchanged, ensuring full backward compatibility.

The localization resources have been extended with a new `SignInWithOAuthProvider` format string for all supported languages, allowing translated provider-specific login labels while preserving the existing fallback behavior.

The OIDC documentation has been updated to describe the new `DisplayName` configuration option and its corresponding environment variable.