### PR TITLE
Feat: external attachment storage

### DIFF
--- a/Controllers/EmailsController.cs
+++ b/Controllers/EmailsController.cs
@@ -4,6 +4,7 @@ using MailArchiver.Models;
 using MailArchiver.Models.ViewModels;
 using MailArchiver.Services;
 using MailArchiver.Services.Providers;
+using MailArchiver.Services.Storage;
 using MailArchiver.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -36,6 +37,7 @@ namespace MailArchiver.Controllers
         private readonly MailArchiver.Services.IAuthenticationService _authService;
         private readonly IEmailDeletionService? _emailDeletionService;
         private readonly ViewOptions _viewOptions;
+        private readonly AttachmentStorageFactory _storageFactory;
 
         public EmailsController(
             MailArchiverDbContext context,
@@ -46,6 +48,7 @@ namespace MailArchiver.Controllers
             IOptions<BatchRestoreOptions> batchOptions,
             IOptions<SelectionOptions> selectionOptions,
             IOptions<ViewOptions> viewOptions,
+            AttachmentStorageFactory storageFactory,
             IBatchRestoreService? batchRestoreService = null,
             ISyncJobService? syncJobService = null,
             IStringLocalizer<SharedResource> localizer = null,
@@ -62,6 +65,7 @@ namespace MailArchiver.Controllers
             _providerFactory = providerFactory;
             _graphEmailService = graphEmailService;
             _logger = logger;
+            _storageFactory = storageFactory;
             _batchRestoreService = batchRestoreService;
             _syncJobService = syncJobService;
             _batchOptions = batchOptions.Value;
@@ -325,8 +329,8 @@ namespace MailArchiver.Controllers
             {
                 Email = email,
                 AccountName = email.MailAccount?.Name ?? "Unknown account",
-                FormattedHtmlBody = !string.IsNullOrEmpty(htmlBodyToDisplay) 
-                    ? ResolveInlineImagesInHtml(SanitizeHtml(htmlBodyToDisplay, _viewOptions.BlockExternalResources), email.Attachments) 
+                FormattedHtmlBody = !string.IsNullOrEmpty(htmlBodyToDisplay)
+                    ? await ResolveInlineImagesInHtml(SanitizeHtml(htmlBodyToDisplay, _viewOptions.BlockExternalResources), email.Attachments)
                     : string.Empty,
                 PlainTextBody = textBodyToDisplay ?? string.Empty,
                 DefaultToPlainText = _viewOptions.DefaultToPlainText,
@@ -450,7 +454,7 @@ namespace MailArchiver.Controllers
                 return View("Details404");
             }
 
-            return File(attachment.Content, attachment.ContentType, attachment.FileName);
+            return File(await attachment.GetContentAsync(_storageFactory), attachment.ContentType, attachment.FileName);
         }
 
         // GET: Emails/AttachmentPreview/5/1
@@ -477,7 +481,7 @@ namespace MailArchiver.Controllers
             }
 
             // Return the attachment content without forcing download
-            return File(attachment.Content, attachment.ContentType);
+            return File(await attachment.GetContentAsync(_storageFactory), attachment.ContentType);
         }
 
         // GET: Emails/DownloadAllAttachments/5
@@ -513,7 +517,8 @@ namespace MailArchiver.Controllers
                         var entry = archive.CreateEntry(attachment.FileName, CompressionLevel.Optimal);
                         using (var entryStream = entry.Open())
                         {
-                            entryStream.Write(attachment.Content, 0, attachment.Content.Length);
+                            var content = await attachment.GetContentAsync(_storageFactory);
+                            await entryStream.WriteAsync(content, 0, content.Length);
                         }
                     }
                 }
@@ -2512,7 +2517,7 @@ namespace MailArchiver.Controllers
             else
             {
                 // Display HTML with external resource blocking if configured
-                html = ResolveInlineImagesInHtml(SanitizeHtml(htmlBodyToDisplay, _viewOptions.BlockExternalResources), email.Attachments);
+                html = await ResolveInlineImagesInHtml(SanitizeHtml(htmlBodyToDisplay, _viewOptions.BlockExternalResources), email.Attachments);
 
                 // Fügen Sie die Basis-HTML-Struktur hinzu, wenn sie fehlt
                 if (!html.Contains("<!DOCTYPE") && !html.Contains("<html"))
@@ -2601,7 +2606,7 @@ namespace MailArchiver.Controllers
         }
 
         // Hilfsmethode zur Auflösung von Inline-Bildern in HTML
-        private string ResolveInlineImagesInHtml(string htmlBody, ICollection<EmailAttachment> attachments)
+        private async Task<string> ResolveInlineImagesInHtml(string htmlBody, ICollection<EmailAttachment> attachments)
         {
             if (string.IsNullOrEmpty(htmlBody) || attachments == null || !attachments.Any())
                 return htmlBody;
@@ -2631,12 +2636,13 @@ namespace MailArchiver.Controllers
                          a.FileName.Contains($"_{cid}")));
                 }
 
-                if (attachment != null && attachment.Content != null && attachment.Content.Length > 0)
+                if (attachment != null)
                 {
                     try
                     {
+                        var content = await attachment.GetContentAsync(_storageFactory);
                         // Erstelle eine data URL für das Inline-Bild
-                        var base64Content = Convert.ToBase64String(attachment.Content);
+                        var base64Content = Convert.ToBase64String(content);
                         var dataUrl = $"data:{attachment.ContentType ?? "image/png"};base64,{base64Content}";
                         
                         // Ersetze die cid: Referenz mit der data URL

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -148,8 +148,9 @@ namespace MailArchiver.Controllers
                     .Contains(a.ArchivedEmailId))
                 .CountAsync();
 
-            var totalDatabaseSizeBytes = await GetDatabaseSizeAsync();
-            model.TotalStorageUsed = FormatFileSize(totalDatabaseSizeBytes);
+            var sizes = await GetStorageSizesAsync();
+            model.TotalStorageUsed = FormatFileSize(sizes.DatabaseSize);
+            model.TotalAttachmentsStorageUsed = FormatFileSize(sizes.AttachmentsSize);
 
             model.EmailsPerAccount = await _context.MailAccounts
                 .Where(a => accountIds.Contains(a.Id))
@@ -224,28 +225,7 @@ namespace MailArchiver.Controllers
         /// Gets the total size of the PostgreSQL database in bytes
         /// </summary>
         /// <returns>Database size in bytes</returns>
-        private async Task<long> GetDatabaseSizeAsync()
-        {
-            try
-            {
-                using var connection = new Npgsql.NpgsqlConnection(_context.Database.GetConnectionString());
-                await connection.OpenAsync();
-
-                // Query to get the total size of the current database
-                var sql = "SELECT pg_database_size(current_database())";
-                
-                using var command = new Npgsql.NpgsqlCommand(sql, connection);
-                var result = await command.ExecuteScalarAsync();
-                
-                return Convert.ToInt64(result);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error getting database size: {Message}", ex.Message);
-                // Fallback to attachment size if database size query fails
-                return await _context.EmailAttachments.SumAsync(a => (long)a.Size);
-            }
-        }
+        private Task<StorageSizes> GetStorageSizesAsync() => _context.GetStorageSizesAsync();
 
         private string FormatFileSize(long bytes)
         {

--- a/Data/MailArchiverDbContext.cs
+++ b/Data/MailArchiverDbContext.cs
@@ -1,5 +1,7 @@
 using MailArchiver.Models;
+using MailArchiver.Models.ViewModels;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace MailArchiver.Data
 {
@@ -18,6 +20,36 @@ namespace MailArchiver.Data
         public MailArchiverDbContext(DbContextOptions<MailArchiverDbContext> options)
             : base(options)
         {
+        }
+
+        public async Task<StorageSizes> GetStorageSizesAsync(CancellationToken ct = default)
+        {
+            try
+            {
+                using var connection = new NpgsqlConnection(Database.GetConnectionString());
+                await connection.OpenAsync(ct);
+
+                const string sql = @"
+                    SELECT pg_database_size(current_database()),
+                           COALESCE(SUM(pg_column_size(""Content"")), 0),
+                           COALESCE(SUM(""Size""), 0)
+                    FROM mail_archiver.""AttachmentContents""";
+
+                using var command = new NpgsqlCommand(sql, connection);
+                using var reader = await command.ExecuteReaderAsync(ct);
+                await reader.ReadAsync(ct);
+
+                var totalDbSize = reader.GetInt64(0);
+                var contentColumnSize = reader.GetInt64(1);
+                var attachmentsSize = reader.GetInt64(2);
+
+                return new StorageSizes(totalDbSize - contentColumnSize, attachmentsSize);
+            }
+            catch
+            {
+                var attachmentsSize = await AttachmentContents.SumAsync(c => c.Size, ct);
+                return new StorageSizes(0, attachmentsSize);
+            }
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Data/MailArchiverDbContext.cs
+++ b/Data/MailArchiverDbContext.cs
@@ -152,7 +152,12 @@ namespace MailArchiver.Data
             modelBuilder.Entity<AttachmentContent>()
                 .Property(c => c.Content)
                 .HasColumnType("bytea")
-                .IsRequired();
+                .IsRequired(false);
+
+            modelBuilder.Entity<AttachmentContent>()
+                .Property(c => c.StorageType)
+                .HasColumnType("smallint")
+                .HasDefaultValue(AttachmentStorageType.Database);
 
             modelBuilder.Entity<AttachmentContent>()
                 .Property(c => c.Size)

--- a/Migrations/20260622000000_MigrateV2606_2.Designer.cs
+++ b/Migrations/20260622000000_MigrateV2606_2.Designer.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using MailArchiver.Data;
+
+#nullable disable
+
+namespace MailArchiver.Migrations
+{
+    [DbContext(typeof(MailArchiverDbContext))]
+    [Migration("20260622000000_MigrateV2606_2")]
+    partial class MigrateV2606_2
+    {
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasDefaultSchema("mail_archiver")
+                .HasAnnotation("ProductVersion", "9.0.4")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+
+            // Simplified BuildTargetModel - full model snapshot is in MailArchiverDbContextModelSnapshot.cs
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/Migrations/20260622000000_MigrateV2606_2.cs
+++ b/Migrations/20260622000000_MigrateV2606_2.cs
@@ -1,0 +1,90 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailArchiver.Migrations
+{
+    /// <inheritdoc />
+    public partial class MigrateV2606_2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Add StorageType column to AttachmentContents.
+            // 0 = Database (default)
+            // All existing rows have their content in the database, so DEFAULT 0 is correct.
+            migrationBuilder.Sql(@"
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1
+                        FROM information_schema.columns
+                        WHERE table_schema = 'mail_archiver'
+                        AND table_name = 'AttachmentContents'
+                        AND column_name = 'StorageType'
+                    ) THEN
+                        ALTER TABLE mail_archiver.""AttachmentContents""
+                        ADD COLUMN ""StorageType"" smallint NOT NULL DEFAULT 0;
+                    END IF;
+                END $$;
+            ");
+
+            // Allow Content to be NULL so that non-database-backed rows can omit the bytea payload.
+            migrationBuilder.Sql(@"
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1
+                        FROM information_schema.columns
+                        WHERE table_schema = 'mail_archiver'
+                        AND table_name = 'AttachmentContents'
+                        AND column_name = 'Content'
+                        AND is_nullable = 'NO'
+                    ) THEN
+                        ALTER TABLE mail_archiver.""AttachmentContents""
+                        ALTER COLUMN ""Content"" DROP NOT NULL;
+                    END IF;
+                END $$;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1
+                        FROM information_schema.columns
+                        WHERE table_schema = 'mail_archiver'
+                        AND table_name = 'AttachmentContents'
+                        AND column_name = 'StorageType'
+                    ) THEN
+                        ALTER TABLE mail_archiver.""AttachmentContents""
+                        DROP COLUMN ""StorageType"";
+                    END IF;
+                END $$;
+            ");
+
+            //  Only re-add NOT NULL if all rows actually have content
+            // (this may fail if file-backed rows exist with NULL Content).
+            migrationBuilder.Sql(@"
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1
+                        FROM information_schema.columns
+                        WHERE table_schema = 'mail_archiver'
+                        AND table_name = 'AttachmentContents'
+                        AND column_name = 'Content'
+                        AND is_nullable = 'YES'
+                    ) THEN
+                        ALTER TABLE mail_archiver.""AttachmentContents""
+                        ALTER COLUMN ""Content"" SET NOT NULL;
+                    END IF;
+                END $$;
+            ");
+        }
+    }
+}

--- a/Migrations/MailArchiverDbContextModelSnapshot.cs
+++ b/Migrations/MailArchiverDbContextModelSnapshot.cs
@@ -263,6 +263,10 @@ namespace MailArchiver.Migrations
                     b.Property<long>("Size")
                         .HasColumnType("bigint");
 
+                    b.Property<byte>("StorageType")
+                        .HasColumnType("smallint")
+                        .HasDefaultValue((byte)0);
+
                     b.HasKey("Id");
 
                     b.HasIndex("ArchivedEmailId");

--- a/Models/AttachmentContent.cs
+++ b/Models/AttachmentContent.cs
@@ -1,3 +1,5 @@
+using MailArchiver.Services.Storage;
+
 namespace MailArchiver.Models
 {
     /// <summary>
@@ -9,18 +11,33 @@ namespace MailArchiver.Models
     {
         public int Id { get; set; }
 
-        /// <summary>SHA-256 hash of <see cref="Content"/> as lowercase hex string (64 chars).</summary>
+        /// <summary>SHA-256 hash of the payload as lowercase hex string (64 chars).</summary>
         public string Hash { get; set; } = string.Empty;
 
-        /// <summary>The raw attachment bytes (stored once per unique hash).</summary>
-        public byte[] Content { get; set; } = Array.Empty<byte>();
+        /// <summary>
+        /// Raw attachment bytes. Non-null when <see cref="StorageType"/> is
+        /// <see cref="AttachmentStorageType.Database"/>; null when the payload has
+        /// been moved to another storage.
+        /// </summary>
+        public byte[]? Content { get; set; }
 
-        /// <summary>Size of <see cref="Content"/> in bytes.</summary>
+        /// <summary>Size of the payload in bytes.</summary>
         public long Size { get; set; }
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+        /// <summary>Where the attachment bytes currently live.</summary>
+        public AttachmentStorageType StorageType { get; set; } = AttachmentStorageType.Database;
 
         public virtual ICollection<EmailAttachment> Attachments { get; set; } = new List<EmailAttachment>();
+
+        private byte[]? _cachedContent;
+
+        public async Task<byte[]> GetContentAsync(AttachmentStorageFactory storageFactory,
+            CancellationToken ct = default)
+        {
+            _cachedContent ??= await storageFactory.GetStorageFor(this).ReadAsync(this, ct);
+            return _cachedContent;
+        }
     }
 }

--- a/Models/AttachmentStorageType.cs
+++ b/Models/AttachmentStorageType.cs
@@ -3,5 +3,6 @@ namespace MailArchiver.Models
     public enum AttachmentStorageType : byte
     {
         Database = 0,
+        File = 1,
     }
 }

--- a/Models/AttachmentStorageType.cs
+++ b/Models/AttachmentStorageType.cs
@@ -1,0 +1,7 @@
+namespace MailArchiver.Models
+{
+    public enum AttachmentStorageType : byte
+    {
+        Database = 0,
+    }
+}

--- a/Models/EmailAttachment.cs
+++ b/Models/EmailAttachment.cs
@@ -1,3 +1,4 @@
+using MailArchiver.Services.Storage;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace MailArchiver.Models
@@ -49,6 +50,16 @@ namespace MailArchiver.Models
 
         /// <summary>Clears the pending bytes after they have been deduplicated.</summary>
         internal void ClearPendingContent() => _pendingContent = null;
+
+        public Task<byte[]> GetContentAsync(AttachmentStorageFactory storageFactory,
+            CancellationToken ct = default)
+        {
+            if (AttachmentContent == null)
+                throw new InvalidOperationException(
+                    $"Attachment {Id} ({FileName}) has no AttachmentContent loaded. " +
+                    "Ensure AttachmentContent is eagerly included in the query.");
+            return AttachmentContent.GetContentAsync(storageFactory, ct);
+        }
 
         public virtual ArchivedEmail ArchivedEmail { get; set; }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -332,6 +332,7 @@ builder.Services.AddSingleton<IMBoxImportService>(provider => provider.GetRequir
 builder.Services.AddHostedService<MBoxImportService>(provider => provider.GetRequiredService<MBoxImportService>());
 
 builder.Services.AddSingleton<MailArchiver.Services.Storage.AttachmentStorageFactory>();
+builder.Services.AddHostedService<MailArchiver.Services.AttachmentMigrationService>();
 
 // EML import services (refactored from monolithic EmlImportService)
 builder.Services.AddScoped<MailArchiver.Services.Providers.Eml.EmlMailCleaner>();

--- a/Program.cs
+++ b/Program.cs
@@ -331,6 +331,8 @@ builder.Services.AddSingleton<MBoxImportService>();
 builder.Services.AddSingleton<IMBoxImportService>(provider => provider.GetRequiredService<MBoxImportService>());
 builder.Services.AddHostedService<MBoxImportService>(provider => provider.GetRequiredService<MBoxImportService>());
 
+builder.Services.AddSingleton<MailArchiver.Services.Storage.AttachmentStorageFactory>();
+
 // EML import services (refactored from monolithic EmlImportService)
 builder.Services.AddScoped<MailArchiver.Services.Providers.Eml.EmlMailCleaner>();
 builder.Services.AddScoped<MailArchiver.Services.Providers.Eml.EmlAttachmentCollector>();

--- a/Services/AttachmentMigrationService.cs
+++ b/Services/AttachmentMigrationService.cs
@@ -1,0 +1,128 @@
+using MailArchiver.Data;
+using MailArchiver.Services.Storage;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace MailArchiver.Services;
+
+public class AttachmentMigrationService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly AttachmentStorageFactory _storageFactory;
+    private readonly ILogger<AttachmentMigrationService> _logger;
+    private readonly bool _migrationEnabled;
+    private readonly int _batchSize;
+    private readonly double _pauseSeconds;
+
+    public AttachmentMigrationService(
+        IServiceScopeFactory scopeFactory,
+        AttachmentStorageFactory storageFactory,
+        IConfiguration configuration,
+        ILogger<AttachmentMigrationService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _storageFactory = storageFactory;
+        _logger = logger;
+        _migrationEnabled = configuration.GetValue("Attachments:MigrationEnabled", true);
+        _batchSize = configuration.GetValue("Attachments:MigrationBatchSize", 25);
+        _pauseSeconds = configuration.GetValue("Attachments:MigrationPauseSeconds", 1.0);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        if (!_migrationEnabled)
+        {
+            _logger.LogInformation("Attachment migration is disabled.");
+            return;
+        }
+
+        var target = _storageFactory.ActiveStorage;
+
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MailArchiverDbContext>();
+            var pending = await db.AttachmentContents
+                .CountAsync(c => c.StorageType != target.StorageType, ct);
+
+            if (pending == 0) {
+                _logger.LogInformation("No attachment content migration needed.");
+                return;
+            }
+
+            _logger.LogInformation("Migrating {Count} attachment content(s) to {StorageType}.", pending, target.StorageType);
+        }
+
+        var failedIds = new HashSet<int>();
+
+        while (!ct.IsCancellationRequested)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<MailArchiverDbContext>();
+
+            var batch = await db.AttachmentContents
+                .Where(c => c.StorageType != target.StorageType && !failedIds.Contains(c.Id))
+                .Take(_batchSize)
+                .ToListAsync(ct);
+
+            if (batch.Count == 0)
+            {
+                if (failedIds.Count > 0)
+                    _logger.LogWarning("Attachment migration finished with errors. Failed content ID(s): {Ids}.",
+                        string.Join(", ", failedIds));
+                else
+                    _logger.LogInformation("Attachment migration complete.");
+
+                await VacuumAttachmentContentsAsync(ct);
+                break;
+            }
+
+            foreach (var content in batch)
+            {
+                if (ct.IsCancellationRequested) break;
+                try
+                {
+                    var source = _storageFactory.GetStorageFor(content);
+                    var data = await source.ReadAsync(content, ct);
+
+                    content.StorageType = target.StorageType;
+                    await target.WriteAsync(content, data, ct);
+                    await db.SaveChangesAsync(ct);
+
+                    await source.DeleteAsync(content, ct);
+
+                    _logger.LogDebug(
+                        "Migrated content {ContentId} from {Source} to {Target}.",
+                        content.Id, source.StorageType, target.StorageType);
+                }
+                catch (Exception ex)
+                {
+                    failedIds.Add(content.Id);
+                    _logger.LogError(ex, "Failed to migrate content {ContentId}.", content.Id);
+                }
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(_pauseSeconds), ct);
+        }
+    }
+
+    private async Task VacuumAttachmentContentsAsync(CancellationToken ct)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<MailArchiverDbContext>();
+            // VACUUM must run outside a transaction; open the connection directly.
+            var conn = (NpgsqlConnection)context.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync(ct);
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "VACUUM mail_archiver.\"AttachmentContents\"";
+            await cmd.ExecuteNonQueryAsync(ct);
+            _logger.LogInformation("Vacuumed AttachmentContents table.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to vacuum AttachmentContents table.");
+        }
+    }
+}

--- a/Services/Core/EmailCoreService.cs
+++ b/Services/Core/EmailCoreService.cs
@@ -1054,8 +1054,9 @@ namespace MailArchiver.Services.Core
             model.TotalAccounts = await _context.MailAccounts.CountAsync();
             model.TotalAttachments = await _context.EmailAttachments.CountAsync();
 
-            var totalDatabaseSizeBytes = await GetDatabaseSizeAsync();
-            model.TotalStorageUsed = FormatFileSize(totalDatabaseSizeBytes);
+            var sizes = await GetStorageSizesAsync();
+            model.TotalStorageUsed = FormatFileSize(sizes.DatabaseSize);
+            model.TotalAttachmentsStorageUsed = FormatFileSize(sizes.AttachmentsSize);
 
             model.EmailsPerAccount = await _context.MailAccounts
                 .Select(a => new AccountStatistics
@@ -1120,26 +1121,7 @@ namespace MailArchiver.Services.Core
             return model;
         }
 
-        private async Task<long> GetDatabaseSizeAsync()
-        {
-            try
-            {
-                using var connection = new Npgsql.NpgsqlConnection(_context.Database.GetConnectionString());
-                await connection.OpenAsync();
-
-                var sql = "SELECT pg_database_size(current_database())";
-
-                using var command = new Npgsql.NpgsqlCommand(sql, connection);
-                var result = await command.ExecuteScalarAsync();
-
-                return Convert.ToInt64(result);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error getting database size: {Message}", ex.Message);
-                return await _context.EmailAttachments.SumAsync(a => (long)a.Size);
-            }
-        }
+        private Task<StorageSizes> GetStorageSizesAsync() => _context.GetStorageSizesAsync();
 
         private string FormatFileSize(long bytes)
         {

--- a/Services/Core/EmailCoreService.cs
+++ b/Services/Core/EmailCoreService.cs
@@ -2,6 +2,7 @@ using MailArchiver.Data;
 using MailArchiver.Models;
 using MailArchiver.Models.ViewModels;
 using MailArchiver.Services.Shared;
+using MailArchiver.Services.Storage;
 using MailArchiver.Utilities;
 using MailArchiver.ViewModels;
 using Microsoft.EntityFrameworkCore;
@@ -24,17 +25,20 @@ namespace MailArchiver.Services.Core
         private readonly ILogger<EmailCoreService> _logger;
         private readonly DateTimeHelper _dateTimeHelper;
         private readonly BatchOperationOptions _batchOptions;
+        private readonly AttachmentStorageFactory _storageFactory;
 
         public EmailCoreService(
             MailArchiverDbContext context,
             ILogger<EmailCoreService> logger,
             DateTimeHelper dateTimeHelper,
-            IOptions<BatchOperationOptions> batchOptions)
+            IOptions<BatchOperationOptions> batchOptions,
+            AttachmentStorageFactory storageFactory)
         {
             _context = context;
             _logger = logger;
             _dateTimeHelper = dateTimeHelper;
             _batchOptions = batchOptions.Value;
+            _storageFactory = storageFactory;
         }
 
         #region Search Methods
@@ -956,9 +960,10 @@ namespace MailArchiver.Services.Core
 
                     foreach (var attachment in inlineAttachments)
                     {
+                        var content = await attachment.GetContentAsync(_storageFactory);
                         var mimePart = new MimePart(attachment.ContentType)
                         {
-                            Content = new MimeContent(new MemoryStream(attachment.Content)),
+                            Content = new MimeContent(new MemoryStream(content)),
                             ContentId = attachment.ContentId,
                             ContentDisposition = new ContentDisposition(ContentDisposition.Inline),
                             ContentTransferEncoding = ContentEncoding.Base64,
@@ -976,9 +981,10 @@ namespace MailArchiver.Services.Core
 
                 foreach (var attachment in regularAttachments)
                 {
+                    var content = await attachment.GetContentAsync(_storageFactory);
                     var mimePart = new MimePart(attachment.ContentType)
                     {
-                        Content = new MimeContent(new MemoryStream(attachment.Content)),
+                        Content = new MimeContent(new MemoryStream(content)),
                         ContentDisposition = new ContentDisposition(ContentDisposition.Attachment),
                         ContentTransferEncoding = ContentEncoding.Base64,
                         FileName = attachment.FileName
@@ -1512,66 +1518,6 @@ namespace MailArchiver.Services.Core
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Resolves inline images in HTML by converting cid: references to data URLs
-        /// </summary>
-        private string ResolveInlineImagesInHtml(string htmlBody, List<EmailAttachment> attachments)
-        {
-            if (string.IsNullOrEmpty(htmlBody) || attachments == null || !attachments.Any())
-                return htmlBody;
-
-            var resultHtml = htmlBody;
-
-            // Find all cid: references in the HTML
-            var cidMatches = Regex.Matches(htmlBody, @"src\s*=\s*[""']cid:([^""']+)[""']", RegexOptions.IgnoreCase);
-
-            foreach (Match match in cidMatches)
-            {
-                var cid = match.Groups[1].Value;
-
-                // Find the corresponding attachment
-                var attachment = attachments.FirstOrDefault(a =>
-                    !string.IsNullOrEmpty(a.ContentId) &&
-                    (a.ContentId.Equals($"<{cid}>", StringComparison.OrdinalIgnoreCase) ||
-                     a.ContentId.Equals(cid, StringComparison.OrdinalIgnoreCase)));
-
-                // If no attachment with ContentId found, try matching by filename
-                if (attachment == null)
-                {
-                    attachment = attachments.FirstOrDefault(a =>
-                        !string.IsNullOrEmpty(a.FileName) &&
-                        (a.FileName.Equals($"inline_{cid}", StringComparison.OrdinalIgnoreCase) ||
-                         a.FileName.StartsWith($"inline_{cid}.", StringComparison.OrdinalIgnoreCase) ||
-                         a.FileName.Contains($"_{cid}")));
-                }
-
-                if (attachment != null && attachment.Content != null && attachment.Content.Length > 0)
-                {
-                    try
-                    {
-                        // Create a data URL for the inline image
-                        var base64Content = Convert.ToBase64String(attachment.Content);
-                        var dataUrl = $"data:{attachment.ContentType ?? "image/png"};base64,{base64Content}";
-
-                        // Replace the cid: reference with the data URL
-                        resultHtml = resultHtml.Replace(match.Groups[0].Value, $"src=\"{dataUrl}\"");
-
-                        _logger.LogDebug("Resolved inline image with CID: {Cid} to data URL", cid);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning(ex, "Failed to resolve inline image with CID: {Cid}", cid);
-                    }
-                }
-                else
-                {
-                    _logger.LogWarning("Could not find attachment for CID: {Cid}", cid);
-                }
-            }
-
-            return resultHtml;
         }
 
         // Hilfsmethode für Dateierweiterungen

--- a/Services/ExportService.cs
+++ b/Services/ExportService.cs
@@ -1,5 +1,6 @@
 using MailArchiver.Data;
 using MailArchiver.Models;
+using MailArchiver.Services.Storage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
@@ -21,18 +22,21 @@ namespace MailArchiver.Services
         private CancellationTokenSource? _currentJobCancellation;
         private readonly string _exportsPath;
         private readonly TimeZoneOptions _timeZoneOptions;
+        private readonly AttachmentStorageFactory _storageFactory;
 
         public ExportService(
             IServiceProvider serviceProvider, 
             ILogger<ExportService> logger, 
             IWebHostEnvironment environment, 
             IOptions<BatchOperationOptions> batchOptions,
-            IOptions<TimeZoneOptions> timeZoneOptions)
+            IOptions<TimeZoneOptions> timeZoneOptions,
+            AttachmentStorageFactory storageFactory)
         {
             _serviceProvider = serviceProvider;
             _logger = logger;
             _batchOptions = batchOptions.Value;
             _timeZoneOptions = timeZoneOptions.Value;
+            _storageFactory = storageFactory;
             _exportsPath = Path.Combine(environment.ContentRootPath, "exports");
 
             // Create exports directory if it doesn't exist
@@ -918,6 +922,7 @@ namespace MailArchiver.Services
                 // Add inline attachments first so they can be referenced in the HTML body
                 foreach (var attachment in inlineAttachments)
                 {
+                    var content = await attachment.GetContentAsync(_storageFactory);
                     try
                     {
                         // Extract just the filename in case attachment.FileName contains a path or URI
@@ -926,7 +931,7 @@ namespace MailArchiver.Services
                             fileName = "attachment";
                         
                         var contentType = ContentType.Parse(attachment.ContentType);
-                        var mimePart = bodyBuilder.LinkedResources.Add(fileName, attachment.Content, contentType);
+                        var mimePart = bodyBuilder.LinkedResources.Add(fileName, content, contentType);
                         mimePart.ContentId = attachment.ContentId;
                     }
                     catch
@@ -936,7 +941,7 @@ namespace MailArchiver.Services
                         if (string.IsNullOrEmpty(fileName))
                             fileName = "attachment";
                         
-                        var mimePart = bodyBuilder.LinkedResources.Add(fileName, attachment.Content);
+                        var mimePart = bodyBuilder.LinkedResources.Add(fileName, content);
                         mimePart.ContentId = attachment.ContentId;
                     }
                 }
@@ -944,6 +949,7 @@ namespace MailArchiver.Services
                 // Add regular attachments
                 foreach (var attachment in regularAttachments)
                 {
+                    var content = await attachment.GetContentAsync(_storageFactory);
                     try
                     {
                         // Extract just the filename in case attachment.FileName contains a path or URI
@@ -952,7 +958,7 @@ namespace MailArchiver.Services
                             fileName = "attachment";
                         
                         var contentType = ContentType.Parse(attachment.ContentType);
-                        bodyBuilder.Attachments.Add(fileName, attachment.Content, contentType);
+                        bodyBuilder.Attachments.Add(fileName, content, contentType);
                     }
                     catch
                     {
@@ -961,7 +967,7 @@ namespace MailArchiver.Services
                         if (string.IsNullOrEmpty(fileName))
                             fileName = "attachment";
                         
-                        bodyBuilder.Attachments.Add(fileName, attachment.Content);
+                        bodyBuilder.Attachments.Add(fileName, content);
                     }
                 }
             }

--- a/Services/Providers/Eml/EmlTruncatedContentSaver.cs
+++ b/Services/Providers/Eml/EmlTruncatedContentSaver.cs
@@ -1,6 +1,7 @@
 using MailArchiver.Data;
 using MailArchiver.Models;
 using MailArchiver.Services.Shared;
+using MailArchiver.Services.Storage;
 using Microsoft.EntityFrameworkCore;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -14,10 +15,12 @@ namespace MailArchiver.Services.Providers.Eml
     public class EmlTruncatedContentSaver
     {
         private readonly ILogger<EmlTruncatedContentSaver> _logger;
+        private readonly AttachmentStorageFactory _storageFactory;
 
-        public EmlTruncatedContentSaver(ILogger<EmlTruncatedContentSaver> logger)
+        public EmlTruncatedContentSaver(ILogger<EmlTruncatedContentSaver> logger, AttachmentStorageFactory storageFactory)
         {
             _logger = logger;
+            _storageFactory = storageFactory;
         }
 
         /// <summary>
@@ -35,7 +38,7 @@ namespace MailArchiver.Services.Providers.Eml
 
                 if (email != null && email.Attachments != null && email.Attachments.Any())
                 {
-                    originalHtml = ResolveInlineImagesInHtml(originalHtml, email.Attachments.ToList(), jobId);
+                    originalHtml = await ResolveInlineImagesInHtml(originalHtml, email.Attachments.ToList(), jobId);
                 }
 
                 var cleanFileName = MailContentHelper.CleanText($"original_content_{DateTime.UtcNow:yyyyMMddHHmmss}.html");
@@ -97,7 +100,7 @@ namespace MailArchiver.Services.Providers.Eml
         /// Resolves inline images in HTML by converting cid: references to data URLs.
         /// Searches for matching attachments by Content-ID or filename pattern.
         /// </summary>
-        public string ResolveInlineImagesInHtml(string htmlBody, List<EmailAttachment> attachments, string jobId)
+        public async Task<string> ResolveInlineImagesInHtml(string htmlBody, List<EmailAttachment> attachments, string jobId)
         {
             if (string.IsNullOrEmpty(htmlBody) || attachments == null || !attachments.Any())
                 return htmlBody;
@@ -124,11 +127,12 @@ namespace MailArchiver.Services.Providers.Eml
                          a.FileName.Contains($"_{cid}")));
                 }
 
-                if (attachment != null && attachment.Content != null && attachment.Content.Length > 0)
+                if (attachment != null && attachment.Content != null)
                 {
                     try
                     {
-                        var base64Content = Convert.ToBase64String(attachment.Content);
+                        var content = await attachment.GetContentAsync(_storageFactory);
+                        var base64Content = Convert.ToBase64String(content);
                         var dataUrl = $"data:{attachment.ContentType ?? "image/png"};base64,{base64Content}";
                         resultHtml = resultHtml.Replace(match.Groups[0].Value, $"src=\"{dataUrl}\"");
                         _logger.LogDebug("Job {JobId}: Resolved inline image CID: {Cid}", jobId, cid);

--- a/Services/Providers/Graph/GraphMailRestorer.cs
+++ b/Services/Providers/Graph/GraphMailRestorer.cs
@@ -1,6 +1,7 @@
 using MailArchiver.Data;
 using MailArchiver.Models;
 using MailArchiver.Services.Shared;
+using MailArchiver.Services.Storage;
 using MailArchiver.Utilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Graph;
@@ -19,19 +20,22 @@ namespace MailArchiver.Services.Providers.Graph
         private readonly MailArchiverDbContext _context;
         private readonly ILogger<GraphMailRestorer> _logger;
         private readonly DateTimeHelper _dateTimeHelper;
+        private readonly AttachmentStorageFactory _storageFactory;
 
         public GraphMailRestorer(
             GraphAuthClientFactory authFactory,
             IGraphFolderService folderService,
             MailArchiverDbContext context,
             ILogger<GraphMailRestorer> logger,
-            DateTimeHelper dateTimeHelper)
+            DateTimeHelper dateTimeHelper,
+            AttachmentStorageFactory storageFactory)
         {
             _authFactory = authFactory;
             _folderService = folderService;
             _context = context;
             _logger = logger;
             _dateTimeHelper = dateTimeHelper;
+            _storageFactory = storageFactory;
         }
 
         /// <summary>
@@ -281,7 +285,7 @@ namespace MailArchiver.Services.Providers.Graph
                             OdataType = "#microsoft.graph.fileAttachment",
                             Name = attachment.FileName,
                             ContentType = attachment.ContentType,
-                            ContentBytes = attachment.Content
+                            ContentBytes = await attachment.GetContentAsync(_storageFactory)
                         };
 
                         if (!string.IsNullOrEmpty(attachment.ContentId))

--- a/Services/Providers/Imap/ImapMailRestorer.cs
+++ b/Services/Providers/Imap/ImapMailRestorer.cs
@@ -1,5 +1,6 @@
 using MailArchiver.Data;
 using MailArchiver.Models;
+using MailArchiver.Services.Storage;
 using MailArchiver.Utilities;
 using MailKit;
 using MailKit.Net.Imap;
@@ -21,19 +22,22 @@ namespace MailArchiver.Services.Providers.Imap
         private readonly ImapConnectionFactory _connectionFactory;
         private readonly DateTimeHelper _dateTimeHelper;
         private readonly BatchOperationOptions _batchOptions;
+        private readonly AttachmentStorageFactory _storageFactory;
 
         public ImapMailRestorer(
             MailArchiverDbContext context,
             ILogger<ImapMailRestorer> logger,
             ImapConnectionFactory connectionFactory,
             DateTimeHelper dateTimeHelper,
-            IOptions<BatchOperationOptions> batchOptions)
+            IOptions<BatchOperationOptions> batchOptions,
+            AttachmentStorageFactory storageFactory)
         {
             _context = context;
             _logger = logger;
             _connectionFactory = connectionFactory;
             _dateTimeHelper = dateTimeHelper;
             _batchOptions = batchOptions.Value;
+            _storageFactory = storageFactory;
         }
 
         /// <summary>
@@ -797,8 +801,9 @@ namespace MailArchiver.Services.Providers.Imap
                     {
                         try
                         {
+                            var content = await attachment.GetContentAsync(_storageFactory);
                             var contentType = ContentType.Parse(attachment.ContentType);
-                            var mimePart = bodyBuilder.LinkedResources.Add(attachment.FileName, attachment.Content, contentType);
+                            var mimePart = bodyBuilder.LinkedResources.Add(attachment.FileName, content, contentType);
                             mimePart.ContentId = attachment.ContentId;
                         }
                         catch (Exception ex)
@@ -812,8 +817,9 @@ namespace MailArchiver.Services.Providers.Imap
                     {
                         try
                         {
+                            var content = await attachment.GetContentAsync(_storageFactory);
                             bodyBuilder.Attachments.Add(attachment.FileName,
-                                                       attachment.Content,
+                                                       content,
                                                        ContentType.Parse(attachment.ContentType));
                         }
                         catch (Exception ex)

--- a/Services/SelectedEmailsExportService.cs
+++ b/Services/SelectedEmailsExportService.cs
@@ -1,5 +1,6 @@
 using MailArchiver.Data;
 using MailArchiver.Models;
+using MailArchiver.Services.Storage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
@@ -21,18 +22,21 @@ namespace MailArchiver.Services
         private CancellationTokenSource? _currentJobCancellation;
         private readonly string _exportsPath;
         private readonly TimeZoneOptions _timeZoneOptions;
+        private readonly AttachmentStorageFactory _storageFactory;
 
         public SelectedEmailsExportService(
             IServiceProvider serviceProvider, 
             ILogger<SelectedEmailsExportService> logger, 
             IWebHostEnvironment environment, 
             IOptions<BatchOperationOptions> batchOptions,
-            IOptions<TimeZoneOptions> timeZoneOptions)
+            IOptions<TimeZoneOptions> timeZoneOptions,
+            AttachmentStorageFactory storageFactory)
         {
             _serviceProvider = serviceProvider;
             _logger = logger;
             _batchOptions = batchOptions.Value;
             _timeZoneOptions = timeZoneOptions.Value;
+            _storageFactory = storageFactory;
             _exportsPath = Path.Combine(environment.ContentRootPath, "exports");
 
             // Create exports directory if it doesn't exist
@@ -820,16 +824,17 @@ namespace MailArchiver.Services
                 // Add inline attachments first so they can be referenced in the HTML body
                 foreach (var attachment in inlineAttachments)
                 {
+                    var content = await attachment.GetContentAsync(_storageFactory);
                     try
                     {
                         var contentType = ContentType.Parse(attachment.ContentType);
-                        var mimePart = bodyBuilder.LinkedResources.Add(attachment.FileName, attachment.Content, contentType);
+                        var mimePart = bodyBuilder.LinkedResources.Add(attachment.FileName, content, contentType);
                         mimePart.ContentId = attachment.ContentId;
                     }
                     catch
                     {
                         // Fallback for invalid content types
-                        var mimePart = bodyBuilder.LinkedResources.Add(attachment.FileName, attachment.Content);
+                        var mimePart = bodyBuilder.LinkedResources.Add(attachment.FileName, content);
                         mimePart.ContentId = attachment.ContentId;
                     }
                 }
@@ -837,15 +842,16 @@ namespace MailArchiver.Services
                 // Add regular attachments
                 foreach (var attachment in regularAttachments)
                 {
+                    var content = await attachment.GetContentAsync(_storageFactory);
                     try
                     {
                         var contentType = ContentType.Parse(attachment.ContentType);
-                        bodyBuilder.Attachments.Add(attachment.FileName, attachment.Content, contentType);
+                        bodyBuilder.Attachments.Add(attachment.FileName, content, contentType);
                     }
                     catch
                     {
                         // Fallback for invalid content types
-                        bodyBuilder.Attachments.Add(attachment.FileName, attachment.Content);
+                        bodyBuilder.Attachments.Add(attachment.FileName, content);
                     }
                 }
             }

--- a/Services/Shared/MailContentHelper.cs
+++ b/Services/Shared/MailContentHelper.cs
@@ -385,56 +385,6 @@ namespace MailArchiver.Services.Shared
         }
 
         /// <summary>
-        /// Resolves inline images in HTML by converting cid: references to data URLs.
-        /// </summary>
-        public static string ResolveInlineImagesInHtml(string htmlBody, List<Models.EmailAttachment> attachments)
-        {
-            if (string.IsNullOrEmpty(htmlBody) || attachments == null || !attachments.Any())
-                return htmlBody;
-
-            var resultHtml = htmlBody;
-
-            var cidMatches = Regex.Matches(htmlBody,
-                @"src\s*=\s*[""']cid:([^""']+)[""']",
-                RegexOptions.IgnoreCase);
-
-            foreach (Match match in cidMatches)
-            {
-                var cid = match.Groups[1].Value;
-
-                var attachment = attachments.FirstOrDefault(a =>
-                    !string.IsNullOrEmpty(a.ContentId) &&
-                    (a.ContentId.Equals($"<{cid}>", StringComparison.OrdinalIgnoreCase) ||
-                     a.ContentId.Equals(cid, StringComparison.OrdinalIgnoreCase)));
-
-                if (attachment == null)
-                {
-                    attachment = attachments.FirstOrDefault(a =>
-                        !string.IsNullOrEmpty(a.FileName) &&
-                        (a.FileName.Equals($"inline_{cid}", StringComparison.OrdinalIgnoreCase) ||
-                         a.FileName.StartsWith($"inline_{cid}.", StringComparison.OrdinalIgnoreCase) ||
-                         a.FileName.Contains($"_{cid}")));
-                }
-
-                if (attachment != null && attachment.Content != null && attachment.Content.Length > 0)
-                {
-                    try
-                    {
-                        var base64Content = Convert.ToBase64String(attachment.Content);
-                        var dataUrl = $"data:{attachment.ContentType ?? "image/png"};base64,{base64Content}";
-                        resultHtml = resultHtml.Replace(match.Groups[0].Value, $"src=\"{dataUrl}\"");
-                    }
-                    catch
-                    {
-                        // Ignore resolution failures for individual images
-                    }
-                }
-            }
-
-            return resultHtml;
-        }
-
-        /// <summary>
         /// Processes HTML body to ensure inline images are properly referenced with Content-ID.
         /// </summary>
         public static string ProcessHtmlBodyForInlineImages(string htmlBody, ICollection<Models.EmailAttachment> attachments)

--- a/Services/Storage/AttachmentStorageFactory.cs
+++ b/Services/Storage/AttachmentStorageFactory.cs
@@ -1,0 +1,23 @@
+using MailArchiver.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MailArchiver.Services.Storage;
+
+public class AttachmentStorageFactory
+{
+    private readonly IAttachmentStorage _databaseStorage;
+
+    public AttachmentStorageFactory(IServiceScopeFactory scopeFactory)
+    {
+        _databaseStorage = new DatabaseStorage(scopeFactory);
+    }
+
+    public IAttachmentStorage ActiveStorage => _databaseStorage;
+
+    public IAttachmentStorage GetStorageFor(AttachmentContent content) =>
+        content.StorageType switch
+        {
+            AttachmentStorageType.Database => _databaseStorage,
+            _ => throw new InvalidOperationException($"No storage configured for StorageType={content.StorageType}.")
+        };
+}

--- a/Services/Storage/AttachmentStorageFactory.cs
+++ b/Services/Storage/AttachmentStorageFactory.cs
@@ -1,23 +1,54 @@
 using MailArchiver.Models;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace MailArchiver.Services.Storage;
 
 public class AttachmentStorageFactory
 {
-    private readonly IAttachmentStorage _databaseStorage;
+    public const string StoragePathConfigKey = "Attachments:FilesStoragePath";
+    public const string PreferredStorageConfigKey = "Attachments:PreferredStorage";
 
-    public AttachmentStorageFactory(IServiceScopeFactory scopeFactory)
+    private readonly IAttachmentStorage _databaseStorage;
+    private readonly IAttachmentStorage? _fileStorage;
+    private readonly IAttachmentStorage _activeStorage;
+
+    public AttachmentStorageFactory(IServiceScopeFactory scopeFactory, IConfiguration configuration, ILogger<FileStorage> fileLogger)
     {
         _databaseStorage = new DatabaseStorage(scopeFactory);
+
+        var basePath = configuration.GetValue<string>(StoragePathConfigKey);
+        if (!string.IsNullOrWhiteSpace(basePath))
+        {
+            Directory.CreateDirectory(basePath);
+
+            var probe = Path.Combine(basePath, ".write-probe");
+            File.WriteAllBytes(probe, []);
+            File.Delete(probe);
+
+            _fileStorage = new FileStorage(basePath, fileLogger);
+        }
+
+        var preferred = configuration.GetValue<string>(PreferredStorageConfigKey);
+        _activeStorage = preferred?.ToLowerInvariant() switch
+        {
+            "database" => _databaseStorage,
+            "file" => _fileStorage
+                ?? throw new InvalidOperationException(
+                    $"Preferred storage is 'file' but {StoragePathConfigKey} is not configured."),
+            null => _fileStorage ?? _databaseStorage,
+            _ => throw new InvalidOperationException(
+                $"Unknown value '{preferred}' for {PreferredStorageConfigKey}. Valid values: 'database', 'file'.")
+        };
     }
 
-    public IAttachmentStorage ActiveStorage => _databaseStorage;
+    public IAttachmentStorage ActiveStorage => _activeStorage;
 
     public IAttachmentStorage GetStorageFor(AttachmentContent content) =>
         content.StorageType switch
         {
             AttachmentStorageType.Database => _databaseStorage,
+            AttachmentStorageType.File => _fileStorage
+                ?? throw new InvalidOperationException(
+                    $"Contents {content.Id} has StorageType=File but {StoragePathConfigKey} is not configured."),
             _ => throw new InvalidOperationException($"No storage configured for StorageType={content.StorageType}.")
         };
 }

--- a/Services/Storage/DatabaseStorage.cs
+++ b/Services/Storage/DatabaseStorage.cs
@@ -1,0 +1,47 @@
+using MailArchiver.Data;
+using MailArchiver.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace MailArchiver.Services.Storage;
+
+public class DatabaseStorage : IAttachmentStorage
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public DatabaseStorage(IServiceScopeFactory scopeFactory)
+        => _scopeFactory = scopeFactory;
+
+    public AttachmentStorageType StorageType => AttachmentStorageType.Database;
+
+    public Task<byte[]> ReadAsync(AttachmentContent content, CancellationToken ct = default)
+    {
+        var bytes = content.Content ?? Array.Empty<byte>();
+        if (bytes.Length == 0 && content.Size != 0)
+            throw new InvalidOperationException(
+                $"AttachmentContent {content.Id} has no bytes in the database.");
+        return Task.FromResult(bytes);
+    }
+
+    public async Task WriteAsync(AttachmentContent content, byte[] data, CancellationToken ct = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<MailArchiverDbContext>();
+        var row = await context.AttachmentContents.FindAsync([content.Id], ct);
+        if (row == null)
+            throw new InvalidOperationException($"AttachmentContent {content.Id} not found.");
+        row.Content = data;
+        await context.SaveChangesAsync(ct);
+    }
+
+    public async Task DeleteAsync(AttachmentContent content, CancellationToken ct = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<MailArchiverDbContext>();
+        var row = await context.AttachmentContents.FindAsync([content.Id], ct);
+        if (row != null)
+        {
+            row.Content = null;
+            await context.SaveChangesAsync(ct);
+        }
+    }
+}

--- a/Services/Storage/FileStorage.cs
+++ b/Services/Storage/FileStorage.cs
@@ -1,0 +1,49 @@
+using MailArchiver.Models;
+using MailArchiver.Utilities;
+
+namespace MailArchiver.Services.Storage;
+
+public class FileStorage : IAttachmentStorage
+{
+    private readonly string _basePath;
+    private readonly ILogger<FileStorage> _logger;
+
+    public FileStorage(string basePath, ILogger<FileStorage> logger)
+    {
+        _basePath = basePath;
+        _logger = logger;
+    }
+
+    public AttachmentStorageType StorageType => AttachmentStorageType.File;
+
+    public async Task<byte[]> ReadAsync(AttachmentContent content, CancellationToken ct = default)
+    {
+        var path = DerivePath(content);
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"Attachment file not found at '{path}' for content {content.Id}.");
+        return await File.ReadAllBytesAsync(path, ct);
+    }
+
+    public async Task WriteAsync(AttachmentContent content, byte[] data, CancellationToken ct = default)
+    {
+        var path = DerivePath(content);
+        var tmp = path + ".tmp";
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllBytesAsync(tmp, data, ct);
+        File.Move(tmp, path, overwrite: true);
+        _logger.LogDebug("Written content {Id} to {Path}.", content.Id, path);
+    }
+
+    public Task DeleteAsync(AttachmentContent content, CancellationToken ct = default)
+    {
+        var path = DerivePath(content);
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+            _logger.LogDebug("Deleted content {Id} at {Path}.", content.Id, path);
+        }
+        return Task.CompletedTask;
+    }
+
+    private string DerivePath(AttachmentContent content) => Path.Combine(_basePath, content.Hash);
+}

--- a/Services/Storage/IAttachmentStorage.cs
+++ b/Services/Storage/IAttachmentStorage.cs
@@ -1,0 +1,14 @@
+using MailArchiver.Models;
+
+namespace MailArchiver.Services.Storage;
+
+public interface IAttachmentStorage
+{
+    AttachmentStorageType StorageType { get; }
+
+    Task<byte[]> ReadAsync(AttachmentContent content, CancellationToken ct = default);
+
+    Task WriteAsync(AttachmentContent content, byte[] data, CancellationToken ct = default);
+
+    Task DeleteAsync(AttachmentContent content, CancellationToken ct = default);
+}

--- a/ViewModels/DashboardViewModel.cs
+++ b/ViewModels/DashboardViewModel.cs
@@ -1,11 +1,14 @@
 namespace MailArchiver.Models.ViewModels
 {
+    public readonly record struct StorageSizes(long DatabaseSize, long AttachmentsSize);
+
     public class DashboardViewModel
     {
         public int TotalEmails { get; set; }
         public int TotalAccounts { get; set; }
         public int TotalAttachments { get; set; }
-        public string TotalStorageUsed { get; set; } // Formatiert als MB/GB
+        public string TotalStorageUsed { get; set; }
+        public string TotalAttachmentsStorageUsed { get; set; }
         public List<AccountStatistics> EmailsPerAccount { get; set; }
         public List<EmailCountByPeriod> EmailsByMonth { get; set; }
         public List<EmailCountByAddress> TopSenders { get; set; }

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -84,6 +84,7 @@
                         <div>
                             <h6 class="card-title mb-1">@Localizer["Storage"]</h6>
                             <h5 class="mb-0">@Model.TotalStorageUsed</h5>
+                            <small class="opacity-75">@Localizer["Attachments"]: @Model.TotalAttachmentsStorageUsed</small>
                         </div>
                         <i class="bi bi-hdd fs-1 opacity-75"></i>
                     </div>

--- a/appsettings.json
+++ b/appsettings.json
@@ -65,6 +65,11 @@
   "TimeZone": {
     "DisplayTimeZoneId": "Etc/UCT"
   },
+  "Attachments": {
+    "MigrationEnabled": true,
+    "MigrationBatchSize": 25,
+    "MigrationPauseSeconds": 1
+  },
   "DatabaseMaintenance": {
     "Enabled": false,
     "DailyExecutionTime": "02:00",

--- a/doc/Setup.md
+++ b/doc/Setup.md
@@ -95,6 +95,11 @@ services:
       - AttachmentDeduplication__StartupDelaySeconds=20
       - AttachmentDeduplication__OrphanCleanupIntervalHours=12
 
+      # Attachment Storage Migration Settings (Optional)
+      - Attachments__MigrationEnabled=true
+      - Attachments__MigrationBatchSize=25
+      - Attachments__MigrationPauseSeconds=1
+
       # ReleaseNotes Settings (Version Update Splash Screen)
       - ReleaseNotes__Enabled=true
 
@@ -276,6 +281,11 @@ docker compose restart
 
 ### 🎉 ReleaseNotes Settings (Version Update Splash Screen)
 - `ReleaseNotes__Enabled`: Enable or disable the version update splash screen (true/false). Default is `true`. When enabled, administrators will see a one-time changelog modal after an application update, showing the release notes fetched from GitHub Releases for the current version. Each administrator can dismiss the modal, and it will only reappear for a new version. Set to `false` to completely disable this feature.
+
+### 📎 Attachment Storage Migration Settings
+- `Attachments__MigrationEnabled`: Enable or disable the background attachment migration service (true/false). Default is `true`. Set to `false` to keep attachments in their current storage locations without any automatic migration.
+- `Attachments__MigrationBatchSize`: Number of attachments migrated per batch by the background migration service. Default is `25`.
+- `Attachments__MigrationPauseSeconds`: Seconds to pause between migration batches to reduce database load. Default is `1`.
 
 ### 🔧 Database Maintenance Settings
 - `DatabaseMaintenance__Enabled`: Enable or disable automatic daily database maintenance (true/false). Default is `false`. When enabled, the system will automatically run VACUUM ANALYZE operations to optimize database performance and prevent bloat. See [Database Maintenance Guide](DatabaseMaintenance.md) for more details.

--- a/doc/Setup.md
+++ b/doc/Setup.md
@@ -95,6 +95,12 @@ services:
       - AttachmentDeduplication__StartupDelaySeconds=20
       - AttachmentDeduplication__OrphanCleanupIntervalHours=12
 
+      # Attachment Storage Settings (Optional)
+      # Set FilesStoragePath to store attachments on the filesystem instead of the database.
+      # - Attachments__FilesStoragePath=/app/attachments
+      # Set PreferredStorage to explicitly control which storage is active: "database" or "file".
+      # - Attachments__PreferredStorage=file
+
       # Attachment Storage Migration Settings (Optional)
       - Attachments__MigrationEnabled=true
       - Attachments__MigrationBatchSize=25
@@ -281,6 +287,12 @@ docker compose restart
 
 ### 🎉 ReleaseNotes Settings (Version Update Splash Screen)
 - `ReleaseNotes__Enabled`: Enable or disable the version update splash screen (true/false). Default is `true`. When enabled, administrators will see a one-time changelog modal after an application update, showing the release notes fetched from GitHub Releases for the current version. Each administrator can dismiss the modal, and it will only reappear for a new version. Set to `false` to completely disable this feature.
+
+### 📎 Attachment Storage Settings
+- `Attachments__FilesStoragePath`: Path inside the container where attachment files will be stored. When set, the directory is created automatically if it doesn't exist. Required when using `PreferredStorage=file`.
+- `Attachments__PreferredStorage`: Explicitly sets the active storage backend for new attachments. Valid values are `database` (default when no path is configured) and `file`. When set to `file`, `FilesStoragePath` must also be configured or the application will fail to start. When not set, the active storage defaults to file if `FilesStoragePath` is configured, otherwise database. Once changed, the background migration service will automatically move existing attachments to the new active storage.
+
+> 💡 **Docker volume**: Add a volume mapping when using file storage, e.g. `- ./attachments:/app/attachments`, and set `Attachments__FilesStoragePath=/app/attachments`.
 
 ### 📎 Attachment Storage Migration Settings
 - `Attachments__MigrationEnabled`: Enable or disable the background attachment migration service (true/false). Default is `true`. Set to `false` to keep attachments in their current storage locations without any automatic migration.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - ./appsettings.json:/app/appsettings.json
       - ./logs:/app/logs
       - ./data-protection-keys:/app/DataProtection-Keys
+      # Uncomment to enable file-based attachment storage:
+      # - ./attachments:/app/attachments
     depends_on:
       - postgres
 


### PR DESCRIPTION
There were a few discussion on availability of external storage for attachments:
- https://github.com/s1t5/mail-archiver/discussions/289
- https://github.com/s1t5/mail-archiver/issues/56
- https://github.com/s1t5/mail-archiver/issues/173
- https://github.com/s1t5/mail-archiver/discussions/416

I'm aware this PR will be closed, but as I want to leave it as a proof of concept that code works and not as complex as it may seem.

It consists of 4 commits:
- Factoring out the attachment storage service: now we can read, write and remove attachments in an async way - regardless of where they are located. Database storage is the only available storage for the attachment.
- Adding a migration service. It runs a migration on startup: all the attachments located outside of the current target will slowly (tunable) migrate to a target service.
- Adding a file storage; a basic implementation to store attachment on fs.
- Adding statistics on attachment storage usage.

A disclaimer: this was written using LLMs, I'm not familiar enough with the language or the libraries to write it myself from the scratch.
I hope the quality of code is adequate for the project. And I also hope it will move the feature of storing attachments outside of the database to the release some day.