### PR TITLE
fix(msa-oauth): default authority to /consumers for personal Microsoft accounts (AADSTS9002331)

### DIFF
--- a/Models/MsaOAuthOptions.cs
+++ b/Models/MsaOAuthOptions.cs
@@ -19,12 +19,13 @@ namespace MailArchiver.Models
         public string DefaultClientId { get; set; } = string.Empty;
 
         /// <summary>
-        /// OAuth2 authority endpoint. Defaults to the multi-tenant /common endpoint
-        /// so both personal (outlook.com/live.com) and organizational accounts work.
-        /// Use https://login.microsoftonline.com/consumers/oauth2/v2.0 to restrict
-        /// to personal accounts only.
+        /// OAuth2 authority endpoint. Defaults to the /consumers endpoint, matching the
+        /// documented "Personal Microsoft accounts only" app registration this feature
+        /// targets — the multi-tenant /common endpoint is rejected with AADSTS9002331 for
+        /// such apps. Set https://login.microsoftonline.com/common/oauth2/v2.0 for a
+        /// multi-tenant registration that must also serve organizational accounts.
         /// </summary>
-        public string Authority { get; set; } = "https://login.microsoftonline.com/common/oauth2/v2.0";
+        public string Authority { get; set; } = "https://login.microsoftonline.com/consumers/oauth2/v2.0";
 
         /// <summary>
         /// True when a shared default ClientId is configured and per-account ClientIds are optional.

--- a/Services/MsaOAuthService.cs
+++ b/Services/MsaOAuthService.cs
@@ -78,7 +78,7 @@ namespace MailArchiver.Services
         }
 
         private string Authority => string.IsNullOrWhiteSpace(_options.Authority)
-            ? "https://login.microsoftonline.com/common/oauth2/v2.0"
+            ? "https://login.microsoftonline.com/consumers/oauth2/v2.0"
             : _options.Authority;
 
         public string? GetDefaultClientId()

--- a/appsettings.json
+++ b/appsettings.json
@@ -105,8 +105,7 @@
     "AllowedPaths": ["/app/imports"]
   },
   "MsaOAuth": {
-    "DefaultClientId": "d0c86bbc-b89f-4539-a024-93a425ade844",
-    "Authority": "https://login.microsoftonline.com/common/oauth2/v2.0"
+    "DefaultClientId": "d0c86bbc-b89f-4539-a024-93a425ade844"
   },
   "CsvImport": {
     "MaxRows": 5000,


### PR DESCRIPTION
Fixes #477.

### Problem
The personal-account (MSA) sign-in fails during OAuth with `AADSTS9002331`, so a personal Microsoft account cannot be synced.

### Cause
The OAuth2 authority defaults to the multi-tenant `/common` endpoint (`MsaOAuthOptions.Authority`, the `MsaOAuthService` fallback, and `appsettings.json`). The app registration this feature targets is **"Personal Microsoft accounts only"**, and Microsoft rejects `/common` for such apps with `AADSTS9002331`. Personal-account apps must use the `/consumers` authority.

### Fix
- Default the authority to `/consumers` in `MsaOAuthOptions` and the `MsaOAuthService` fallback.
- Drop the explicit `/common` override in `appsettings.json` so the default applies.
- A multi-tenant registration that must also serve organizational accounts can set `/common` explicitly (documented in the option's XML doc comment).

Verified against a live personal Microsoft account; builds clean. Small, non-destructive change.

Thanks again for mail-archiver!
