### PR TITLE
Fix docker-compose local dev setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,12 +61,15 @@ credentials.json
 
 # DataProtection keys
 DataProtection-Keys/
+data-protection-keys/
 
 # Runtime data / volumes
 uploads/
 exports/
 docker-volumes/
 .docker/data/
+postgres-data/
+logs/
 
 # Documentation & meta files (not needed in image)
 doc/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ uploads/*
 
 # DataProtection Keys
 DataProtection-Keys/
+data-protection-keys/
+
+# Local Postgres data volume (docker-compose)
+postgres-data/
 
 # Build-Ergebnisse
 [Dd]ebug/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "5000:5000"
     networks:
       - postgres
+    volumes:
       # Uncomment the following line to mount a directory for local file imports
       # (also add the path to appsettings.json: LocalImport.AllowedPaths)
       # - /path/to/your/mbox/files:/data/import


### PR DESCRIPTION
## Summary
- `docker-compose.yml`: the volume mounts for `mailarchive-app` (appsettings.json, logs, DataProtection keys) were nested under `networks` instead of `volumes`, so `docker compose up` failed to parse the service at all.
- `.dockerignore`: `postgres-data/` (local Postgres volume) wasn't excluded, so a running local DB got pulled into the build context.
- `.gitignore`/`.dockerignore`: `DataProtection-Keys/` didn't match the actual `data-protection-keys/` mount folder (case mismatch).

## Test plan
- [x] `docker compose up -d --build` builds and starts both containers cleanly
- [x] App connects to Postgres and serves on :5000