### PR TITLE
Add per-folder bulk email deletion

### DIFF
--- a/Controllers/EmailsController.cs
+++ b/Controllers/EmailsController.cs
@@ -225,6 +225,19 @@ namespace MailArchiver.Controllers
             model.SearchResults = emails;
             model.TotalResults = totalCount;
 
+            // Count of emails matching the active filter across ALL folders of the selected
+            // account, used by the "Delete filtered emails (all folders)" button/modal. Only
+            // computed when actually needed. When no folder is selected, the search above
+            // already ran without a folder filter, so totalCount already IS that count.
+            var hasActiveSearchFilter = !string.IsNullOrWhiteSpace(model.SearchTerm) || model.FromDate.HasValue || model.ToDate.HasValue || model.IsOutgoing.HasValue;
+            if (model.SelectedAccountId.HasValue && hasActiveSearchFilter)
+            {
+                ViewBag.AccountWideFilteredCount = string.IsNullOrEmpty(model.SelectedFolder)
+                    ? totalCount
+                    : await _emailCoreService.CountMatchingEmailsAsync(
+                        model.SearchTerm, model.FromDate, model.ToDate, model.SelectedAccountId, null, model.IsOutgoing, allowedAccountIds);
+            }
+
                     // Log the search action
                     if (_accessLogService != null && _serviceScopeFactory != null)
                     {
@@ -3010,7 +3023,111 @@ namespace MailArchiver.Controllers
             
             return Redirect(returnUrl ?? Url.Action("Index"));
         }
-        
+
+        // POST: Emails/DeleteFolder
+        // Deletes every email in the given account/folder, ignoring any active search filter.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [SelfManagerRequired]
+        public async Task<IActionResult> DeleteFolder(int accountId, string folderName, string returnUrl = null)
+        {
+            return await QueueFolderDeletionJob(accountId, folderName, requireFolder: true, applyFilters: false,
+                searchTerm: null, fromDate: null, toDate: null, isOutgoing: null, returnUrl);
+        }
+
+        // POST: Emails/DeleteFiltered
+        // Deletes only the emails in the given account/folder that match the supplied filters
+        // (same filters as the email list search).
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [SelfManagerRequired]
+        public async Task<IActionResult> DeleteFiltered(int accountId, string folderName, string searchTerm,
+            DateTime? fromDate, DateTime? toDate, bool? isOutgoing, string returnUrl = null)
+        {
+            return await QueueFolderDeletionJob(accountId, folderName, requireFolder: true, applyFilters: true,
+                searchTerm, fromDate, toDate, isOutgoing, returnUrl);
+        }
+
+        // POST: Emails/DeleteFilteredAllFolders
+        // Deletes every email in the given account that matches the supplied filters, across
+        // all of that account's folders (folder selection in the UI is irrelevant here).
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [SelfManagerRequired]
+        public async Task<IActionResult> DeleteFilteredAllFolders(int accountId, string searchTerm,
+            DateTime? fromDate, DateTime? toDate, bool? isOutgoing, string returnUrl = null)
+        {
+            return await QueueFolderDeletionJob(accountId, folderName: null, requireFolder: false, applyFilters: true,
+                searchTerm, fromDate, toDate, isOutgoing, returnUrl);
+        }
+
+        private async Task<IActionResult> QueueFolderDeletionJob(int accountId, string folderName, bool requireFolder, bool applyFilters,
+            string searchTerm, DateTime? fromDate, DateTime? toDate, bool? isOutgoing, string returnUrl)
+        {
+            if (requireFolder && string.IsNullOrEmpty(folderName))
+            {
+                TempData["ErrorMessage"] = "No folder selected for deletion.";
+                return Redirect(returnUrl ?? Url.Action("Index"));
+            }
+
+            if (!_deletionPolicy.DeletionAllowed)
+            {
+                _logger.LogWarning("Folder email deletion blocked by policy (DeletionPolicy:DeletionAllowed=false). Account: {AccountId}, Folder: {FolderName}", accountId, folderName);
+                TempData["ErrorMessage"] = _localizer?["DeletionDisabledMessage"] ?? "Email deletion is disabled by configuration.";
+                return Redirect(returnUrl ?? Url.Action("Index"));
+            }
+
+            if (_emailDeletionService == null)
+            {
+                TempData["ErrorMessage"] = "Email deletion service is not available.";
+                return Redirect(returnUrl ?? Url.Action("Index"));
+            }
+
+            // SECURITY: only admins or users explicitly assigned to this account may
+            // bulk-delete a whole folder (mirrors the account check DeleteSelected does
+            // per-email; here there is no email ID list to filter by, so the account
+            // itself must be checked directly).
+            if (!(_authService?.IsCurrentUserAdmin(HttpContext) ?? false))
+            {
+                var userService = HttpContext.RequestServices.GetService<IUserService>();
+                var username = _authService?.GetCurrentUserDisplayName(HttpContext);
+                var user = !string.IsNullOrEmpty(username) && userService != null
+                    ? await userService.GetUserByUsernameAsync(username)
+                    : null;
+                var hasAccess = user != null && userService != null
+                    && await userService.IsUserAuthorizedForAccountAsync(user.Id, accountId);
+
+                if (!hasAccess)
+                {
+                    TempData["ErrorMessage"] = "You do not have access to this account.";
+                    return Redirect(returnUrl ?? Url.Action("Index"));
+                }
+            }
+
+            _logger.LogInformation("User requesting to delete {Scope} emails in account {AccountId}, folder '{FolderName}'",
+                applyFilters ? "filtered" : "all", accountId, folderName ?? "(all folders)");
+
+            var currentUsername = _authService?.GetCurrentUserDisplayName(HttpContext);
+            var job = new EmailDeletionJob
+            {
+                UserId = currentUsername ?? "Anonymous",
+                Criteria = new EmailDeletionCriteria
+                {
+                    AccountId = accountId,
+                    FolderName = folderName ?? string.Empty,
+                    SearchTerm = applyFilters ? searchTerm : null,
+                    FromDate = applyFilters ? fromDate : null,
+                    ToDate = applyFilters ? toDate : null,
+                    IsOutgoing = applyFilters ? isOutgoing : null
+                }
+            };
+
+            var jobId = _emailDeletionService.QueueJob(job);
+            TempData["SuccessMessage"] = $"Email deletion job started. Job ID: {jobId}";
+
+            return RedirectToAction("EmailDeletionStatus", new { jobId });
+        }
+
         // GET: Emails/EmailDeletionStatus
         [HttpGet]
         [SelfManagerRequired]

--- a/Models/EmailDeletionJob.cs
+++ b/Models/EmailDeletionJob.cs
@@ -12,10 +12,26 @@ namespace MailArchiver.Models
         Cancelled
     }
 
+    /// <summary>
+    /// Selection criteria for a deletion job that targets a whole folder (optionally
+    /// narrowed by the same filters used in the email list search) instead of an
+    /// explicit list of email IDs. The matching IDs are resolved when the job runs.
+    /// </summary>
+    public class EmailDeletionCriteria
+    {
+        public int AccountId { get; set; }
+        public string FolderName { get; set; } = string.Empty;
+        public string? SearchTerm { get; set; }
+        public DateTime? FromDate { get; set; }
+        public DateTime? ToDate { get; set; }
+        public bool? IsOutgoing { get; set; }
+    }
+
     public class EmailDeletionJob
     {
         public string JobId { get; set; } = Guid.NewGuid().ToString();
         public List<int> EmailIds { get; set; } = new List<int>();
+        public EmailDeletionCriteria? Criteria { get; set; }
         public int TotalEmails { get; set; }
         public int DeletedEmails { get; set; }
         public int TotalAttachments { get; set; }

--- a/Resources/SharedResource.de.resx
+++ b/Resources/SharedResource.de.resx
@@ -2228,6 +2228,45 @@
   <data name="DeleteSelectedEmailsConfirm" xml:space="preserve">
     <value>Sind Sie sicher, dass Sie {0} ausgewählte E-Mail(s) dauerhaft löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden und jede Löschung wird zu Prüfzwecken protokolliert.</value>
   </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Ordner leeren</value>
+  </data>
+  <data name="DeleteFilteredEmails" xml:space="preserve">
+    <value>Gefilterte Mails löschen</value>
+  </data>
+  <data name="EmptyFolderConfirmTitle" xml:space="preserve">
+    <value>Ordner endgültig leeren</value>
+  </data>
+  <data name="DeleteFilteredConfirmTitle" xml:space="preserve">
+    <value>Gefilterte E-Mails endgültig löschen</value>
+  </data>
+  <data name="EmptyFolderConfirmWarning" xml:space="preserve">
+    <value>Dies löscht endgültig alle {0} E-Mail(s) im Ordner "{1}". Diese Aktion kann nicht rückgängig gemacht werden und jede Löschung wird protokolliert.</value>
+  </data>
+  <data name="DeleteFilteredConfirmWarning" xml:space="preserve">
+    <value>Dies löscht endgültig die {0} E-Mail(s), die dem aktuellen Filter im Ordner "{1}" entsprechen. Diese Aktion kann nicht rückgängig gemacht werden und jede Löschung wird protokolliert.</value>
+  </data>
+  <data name="TypeFolderNameToConfirm" xml:space="preserve">
+    <value>Zur Bestätigung den Ordnernamen unten eingeben (du kannst ihn aus dem Feld oben kopieren):</value>
+  </data>
+  <data name="PermanentlyDeleteConfirmButton" xml:space="preserve">
+    <value>Endgültig löschen</value>
+  </data>
+  <data name="DeleteAllFilteredEmails" xml:space="preserve">
+    <value>Gefilterte Mails löschen (alle Ordner)</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmTitle" xml:space="preserve">
+    <value>Gefilterte E-Mails kontoweit endgültig löschen</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmWarning" xml:space="preserve">
+    <value>Dies löscht endgültig alle {0} E-Mail(s), die dem aktuellen Filter entsprechen, über alle Ordner dieses Kontos hinweg. Diese Aktion kann nicht rückgängig gemacht werden und jede Löschung wird protokolliert.</value>
+  </data>
+  <data name="TypeDeleteWordToConfirm" xml:space="preserve">
+    <value>Zur Bestätigung unten "{0}" eingeben:</value>
+  </data>
+  <data name="DeleteConfirmationWord" xml:space="preserve">
+    <value>LÖSCHEN</value>
+  </data>
   <data name="EmailDeleted" xml:space="preserve">
     <value>E-Mail erfolgreich gelöscht</value>
   </data>

--- a/Resources/SharedResource.es.resx
+++ b/Resources/SharedResource.es.resx
@@ -2130,6 +2130,45 @@
   <data name="DeleteSelectedEmailsConfirm" xml:space="preserve">
     <value>¿Está seguro de que desea eliminar permanentemente {0} correo(s) seleccionado(s)? Esta acción no se puede deshacer y cada eliminación se registrará con fines de auditoría.</value>
   </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Vaciar carpeta</value>
+  </data>
+  <data name="DeleteFilteredEmails" xml:space="preserve">
+    <value>Eliminar correos filtrados</value>
+  </data>
+  <data name="EmptyFolderConfirmTitle" xml:space="preserve">
+    <value>Vaciar carpeta permanentemente</value>
+  </data>
+  <data name="DeleteFilteredConfirmTitle" xml:space="preserve">
+    <value>Eliminar permanentemente los correos filtrados</value>
+  </data>
+  <data name="EmptyFolderConfirmWarning" xml:space="preserve">
+    <value>Esto eliminará permanentemente los {0} correo(s) de la carpeta "{1}". Esta acción no se puede deshacer y cada eliminación quedará registrada.</value>
+  </data>
+  <data name="DeleteFilteredConfirmWarning" xml:space="preserve">
+    <value>Esto eliminará permanentemente los {0} correo(s) que coinciden con el filtro actual en la carpeta "{1}". Esta acción no se puede deshacer y cada eliminación quedará registrada.</value>
+  </data>
+  <data name="TypeFolderNameToConfirm" xml:space="preserve">
+    <value>Para confirmar, escribe el nombre de la carpeta a continuación (puedes copiarlo del campo de arriba):</value>
+  </data>
+  <data name="PermanentlyDeleteConfirmButton" xml:space="preserve">
+    <value>Eliminar permanentemente</value>
+  </data>
+  <data name="DeleteAllFilteredEmails" xml:space="preserve">
+    <value>Eliminar correos filtrados (todas las carpetas)</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmTitle" xml:space="preserve">
+    <value>Eliminar permanentemente los correos filtrados en todas las carpetas</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmWarning" xml:space="preserve">
+    <value>Esto eliminará permanentemente los {0} correo(s) que coinciden con el filtro actual en todas las carpetas de esta cuenta. Esta acción no se puede deshacer y cada eliminación quedará registrada.</value>
+  </data>
+  <data name="TypeDeleteWordToConfirm" xml:space="preserve">
+    <value>Para confirmar, escribe "{0}" a continuación:</value>
+  </data>
+  <data name="DeleteConfirmationWord" xml:space="preserve">
+    <value>ELIMINAR</value>
+  </data>
   <data name="EmailDeleted" xml:space="preserve">
     <value>Correo eliminado exitosamente</value>
   </data>

--- a/Resources/SharedResource.fr.resx
+++ b/Resources/SharedResource.fr.resx
@@ -2131,6 +2131,45 @@
   <data name="DeleteSelectedEmailsConfirm" xml:space="preserve">
     <value>Êtes-vous sûr de vouloir supprimer définitivement {0} email(s) sélectionné(s) ? Cette action ne peut pas être annulée et chaque suppression sera enregistrée à des fins d'audit.</value>
   </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Vider le dossier</value>
+  </data>
+  <data name="DeleteFilteredEmails" xml:space="preserve">
+    <value>Supprimer les e-mails filtrés</value>
+  </data>
+  <data name="EmptyFolderConfirmTitle" xml:space="preserve">
+    <value>Vider définitivement le dossier</value>
+  </data>
+  <data name="DeleteFilteredConfirmTitle" xml:space="preserve">
+    <value>Supprimer définitivement les e-mails filtrés</value>
+  </data>
+  <data name="EmptyFolderConfirmWarning" xml:space="preserve">
+    <value>Ceci supprimera définitivement les {0} e-mail(s) du dossier "{1}". Cette action est irréversible et chaque suppression sera consignée.</value>
+  </data>
+  <data name="DeleteFilteredConfirmWarning" xml:space="preserve">
+    <value>Ceci supprimera définitivement les {0} e-mail(s) correspondant au filtre actuel dans le dossier "{1}". Cette action est irréversible et chaque suppression sera consignée.</value>
+  </data>
+  <data name="TypeFolderNameToConfirm" xml:space="preserve">
+    <value>Pour confirmer, saisissez le nom du dossier ci-dessous (vous pouvez le copier depuis le champ ci-dessus) :</value>
+  </data>
+  <data name="PermanentlyDeleteConfirmButton" xml:space="preserve">
+    <value>Supprimer définitivement</value>
+  </data>
+  <data name="DeleteAllFilteredEmails" xml:space="preserve">
+    <value>Supprimer les e-mails filtrés (tous les dossiers)</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmTitle" xml:space="preserve">
+    <value>Supprimer définitivement les e-mails filtrés dans tous les dossiers</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmWarning" xml:space="preserve">
+    <value>Ceci supprimera définitivement les {0} e-mail(s) correspondant au filtre actuel dans tous les dossiers de ce compte. Cette action est irréversible et chaque suppression sera consignée.</value>
+  </data>
+  <data name="TypeDeleteWordToConfirm" xml:space="preserve">
+    <value>Pour confirmer, saisissez "{0}" ci-dessous :</value>
+  </data>
+  <data name="DeleteConfirmationWord" xml:space="preserve">
+    <value>SUPPRIMER</value>
+  </data>
   <data name="EmailDeleted" xml:space="preserve">
     <value>Email supprimé avec succès</value>
   </data>

--- a/Resources/SharedResource.hu.resx
+++ b/Resources/SharedResource.hu.resx
@@ -2123,6 +2123,45 @@
   <data name="DeleteSelectedEmailsConfirm" xml:space="preserve">
     <value>Biztosan véglegesen törölni szeretné a(z) {0} kiválasztott e-mailt? Ez a művelet nem vonható vissza és minden törlés naplózásra kerül audit célokból.</value>
   </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Mappa ürítése</value>
+  </data>
+  <data name="DeleteFilteredEmails" xml:space="preserve">
+    <value>Szűrt e-mailek törlése</value>
+  </data>
+  <data name="EmptyFolderConfirmTitle" xml:space="preserve">
+    <value>Mappa végleges ürítése</value>
+  </data>
+  <data name="DeleteFilteredConfirmTitle" xml:space="preserve">
+    <value>Szűrt e-mailek végleges törlése</value>
+  </data>
+  <data name="EmptyFolderConfirmWarning" xml:space="preserve">
+    <value>Ez véglegesen törli a(z) {0} e-mailt a(z) "{1}" mappából. Ez a művelet nem vonható vissza, és minden törlés naplózásra kerül.</value>
+  </data>
+  <data name="DeleteFilteredConfirmWarning" xml:space="preserve">
+    <value>Ez véglegesen törli az aktuális szűrőnek megfelelő {0} e-mailt a(z) "{1}" mappából. Ez a művelet nem vonható vissza, és minden törlés naplózásra kerül.</value>
+  </data>
+  <data name="TypeFolderNameToConfirm" xml:space="preserve">
+    <value>A megerősítéshez írja be alább a mappa nevét (a fenti mezőből átmásolhatja):</value>
+  </data>
+  <data name="PermanentlyDeleteConfirmButton" xml:space="preserve">
+    <value>Végleges törlés</value>
+  </data>
+  <data name="DeleteAllFilteredEmails" xml:space="preserve">
+    <value>Szűrt e-mailek törlése (összes mappa)</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmTitle" xml:space="preserve">
+    <value>Szűrt e-mailek végleges törlése az összes mappában</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmWarning" xml:space="preserve">
+    <value>Ez véglegesen törli az aktuális szűrőnek megfelelő összes ({0}) e-mailt a fiók valamennyi mappájában. Ez a művelet nem vonható vissza, és minden törlés naplózásra kerül.</value>
+  </data>
+  <data name="TypeDeleteWordToConfirm" xml:space="preserve">
+    <value>A megerősítéshez írja be alább: "{0}"</value>
+  </data>
+  <data name="DeleteConfirmationWord" xml:space="preserve">
+    <value>TÖRLÉS</value>
+  </data>
   <data name="EmailDeleted" xml:space="preserve">
     <value>E-mail sikeresen törölve</value>
   </data>

--- a/Resources/SharedResource.it.resx
+++ b/Resources/SharedResource.it.resx
@@ -2131,6 +2131,45 @@
   <data name="DeleteSelectedEmailsConfirm" xml:space="preserve">
     <value>Sei sicuro di voler eliminare definitivamente {0} email selezionate? Questa azione non può essere annullata e ogni eliminazione verrà registrata per scopi di audit.</value>
   </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Svuota cartella</value>
+  </data>
+  <data name="DeleteFilteredEmails" xml:space="preserve">
+    <value>Elimina email filtrate</value>
+  </data>
+  <data name="EmptyFolderConfirmTitle" xml:space="preserve">
+    <value>Svuota definitivamente la cartella</value>
+  </data>
+  <data name="DeleteFilteredConfirmTitle" xml:space="preserve">
+    <value>Elimina definitivamente le email filtrate</value>
+  </data>
+  <data name="EmptyFolderConfirmWarning" xml:space="preserve">
+    <value>Questa operazione eliminerà definitivamente tutte le {0} email nella cartella "{1}". Questa azione non può essere annullata e ogni eliminazione verrà registrata.</value>
+  </data>
+  <data name="DeleteFilteredConfirmWarning" xml:space="preserve">
+    <value>Questa operazione eliminerà definitivamente le {0} email corrispondenti al filtro attuale nella cartella "{1}". Questa azione non può essere annullata e ogni eliminazione verrà registrata.</value>
+  </data>
+  <data name="TypeFolderNameToConfirm" xml:space="preserve">
+    <value>Per confermare, digita il nome della cartella qui sotto (puoi copiarlo dal campo sopra):</value>
+  </data>
+  <data name="PermanentlyDeleteConfirmButton" xml:space="preserve">
+    <value>Elimina definitivamente</value>
+  </data>
+  <data name="DeleteAllFilteredEmails" xml:space="preserve">
+    <value>Elimina email filtrate (tutte le cartelle)</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmTitle" xml:space="preserve">
+    <value>Elimina definitivamente le email filtrate in tutte le cartelle</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmWarning" xml:space="preserve">
+    <value>Questa operazione eliminerà definitivamente tutte le {0} email corrispondenti al filtro attuale in tutte le cartelle di questo account. Questa azione non può essere annullata e ogni eliminazione verrà registrata.</value>
+  </data>
+  <data name="TypeDeleteWordToConfirm" xml:space="preserve">
+    <value>Per confermare, digita "{0}" qui sotto:</value>
+  </data>
+  <data name="DeleteConfirmationWord" xml:space="preserve">
+    <value>ELIMINA</value>
+  </data>
   <data name="EmailDeleted" xml:space="preserve">
     <value>Email eliminata con successo</value>
   </data>

--- a/Resources/SharedResource.nl.resx
+++ b/Resources/SharedResource.nl.resx
@@ -2131,6 +2131,45 @@
   <data name="DeleteSelectedEmailsConfirm" xml:space="preserve">
     <value>Weet u zeker dat u {0} geselecteerde e-mail(s) permanent wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt en elke verwijdering wordt gelogd voor auditdoeleinden.</value>
   </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Map leegmaken</value>
+  </data>
+  <data name="DeleteFilteredEmails" xml:space="preserve">
+    <value>Gefilterde e-mails verwijderen</value>
+  </data>
+  <data name="EmptyFolderConfirmTitle" xml:space="preserve">
+    <value>Map definitief leegmaken</value>
+  </data>
+  <data name="DeleteFilteredConfirmTitle" xml:space="preserve">
+    <value>Gefilterde e-mails definitief verwijderen</value>
+  </data>
+  <data name="EmptyFolderConfirmWarning" xml:space="preserve">
+    <value>Dit verwijdert definitief alle {0} e-mail(s) in map "{1}". Deze actie kan niet ongedaan worden gemaakt en elke verwijdering wordt gelogd.</value>
+  </data>
+  <data name="DeleteFilteredConfirmWarning" xml:space="preserve">
+    <value>Dit verwijdert definitief de {0} e-mail(s) die overeenkomen met het huidige filter in map "{1}". Deze actie kan niet ongedaan worden gemaakt en elke verwijdering wordt gelogd.</value>
+  </data>
+  <data name="TypeFolderNameToConfirm" xml:space="preserve">
+    <value>Typ ter bevestiging de mapnaam hieronder (je kunt deze kopiëren uit het veld hierboven):</value>
+  </data>
+  <data name="PermanentlyDeleteConfirmButton" xml:space="preserve">
+    <value>Definitief verwijderen</value>
+  </data>
+  <data name="DeleteAllFilteredEmails" xml:space="preserve">
+    <value>Gefilterde e-mails verwijderen (alle mappen)</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmTitle" xml:space="preserve">
+    <value>Gefilterde e-mails definitief verwijderen in alle mappen</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmWarning" xml:space="preserve">
+    <value>Dit verwijdert definitief alle {0} e-mail(s) die overeenkomen met het huidige filter, in alle mappen van dit account. Deze actie kan niet ongedaan worden gemaakt en elke verwijdering wordt gelogd.</value>
+  </data>
+  <data name="TypeDeleteWordToConfirm" xml:space="preserve">
+    <value>Typ ter bevestiging hieronder "{0}":</value>
+  </data>
+  <data name="DeleteConfirmationWord" xml:space="preserve">
+    <value>VERWIJDEREN</value>
+  </data>
   <data name="EmailDeleted" xml:space="preserve">
     <value>E-mail succesvol verwijderd</value>
   </data>

--- a/Resources/SharedResource.pl.resx
+++ b/Resources/SharedResource.pl.resx
@@ -1737,6 +1737,45 @@
   <data name="DeleteSelectedEmailsConfirm" xml:space="preserve">
     <value>Czy na pewno chcesz trwale usunąć {0} wybranych wiadomości e-mail? Tego działania nie można cofnąć, a każde usunięcie będzie rejestrowane do celów audytu.</value>
   </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Opróżnij folder</value>
+  </data>
+  <data name="DeleteFilteredEmails" xml:space="preserve">
+    <value>Usuń przefiltrowane e-maile</value>
+  </data>
+  <data name="EmptyFolderConfirmTitle" xml:space="preserve">
+    <value>Trwale opróżnij folder</value>
+  </data>
+  <data name="DeleteFilteredConfirmTitle" xml:space="preserve">
+    <value>Trwale usuń przefiltrowane e-maile</value>
+  </data>
+  <data name="EmptyFolderConfirmWarning" xml:space="preserve">
+    <value>Spowoduje to trwałe usunięcie wszystkich {0} e-maili w folderze "{1}". Tej czynności nie można cofnąć, a każde usunięcie zostanie zarejestrowane.</value>
+  </data>
+  <data name="DeleteFilteredConfirmWarning" xml:space="preserve">
+    <value>Spowoduje to trwałe usunięcie {0} e-maili pasujących do bieżącego filtra w folderze "{1}". Tej czynności nie można cofnąć, a każde usunięcie zostanie zarejestrowane.</value>
+  </data>
+  <data name="TypeFolderNameToConfirm" xml:space="preserve">
+    <value>Aby potwierdzić, wpisz poniżej nazwę folderu (możesz ją skopiować z pola powyżej):</value>
+  </data>
+  <data name="PermanentlyDeleteConfirmButton" xml:space="preserve">
+    <value>Usuń trwale</value>
+  </data>
+  <data name="DeleteAllFilteredEmails" xml:space="preserve">
+    <value>Usuń przefiltrowane e-maile (wszystkie foldery)</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmTitle" xml:space="preserve">
+    <value>Trwale usuń przefiltrowane e-maile we wszystkich folderach</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmWarning" xml:space="preserve">
+    <value>Spowoduje to trwałe usunięcie wszystkich {0} e-maili pasujących do bieżącego filtra we wszystkich folderach tego konta. Tej czynności nie można cofnąć, a każde usunięcie zostanie zarejestrowane.</value>
+  </data>
+  <data name="TypeDeleteWordToConfirm" xml:space="preserve">
+    <value>Aby potwierdzić, wpisz poniżej "{0}":</value>
+  </data>
+  <data name="DeleteConfirmationWord" xml:space="preserve">
+    <value>USUŃ</value>
+  </data>
   <data name="DeleteButton" xml:space="preserve">
     <value>Usuń</value>
   </data>

--- a/Resources/SharedResource.resx
+++ b/Resources/SharedResource.resx
@@ -1712,6 +1712,45 @@
   <data name="DeleteSelectedEmailsConfirm" xml:space="preserve">
     <value>Are you sure you want to permanently delete {0} selected email(s)? This action cannot be undone and each deletion will be logged for audit purposes.</value>
   </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Empty folder</value>
+  </data>
+  <data name="DeleteFilteredEmails" xml:space="preserve">
+    <value>Delete filtered emails</value>
+  </data>
+  <data name="EmptyFolderConfirmTitle" xml:space="preserve">
+    <value>Permanently empty folder</value>
+  </data>
+  <data name="DeleteFilteredConfirmTitle" xml:space="preserve">
+    <value>Permanently delete filtered emails</value>
+  </data>
+  <data name="EmptyFolderConfirmWarning" xml:space="preserve">
+    <value>This will permanently delete all {0} email(s) in folder "{1}". This action cannot be undone and each deletion will be logged for audit purposes.</value>
+  </data>
+  <data name="DeleteFilteredConfirmWarning" xml:space="preserve">
+    <value>This will permanently delete the {0} email(s) matching the current filter in folder "{1}". This action cannot be undone and each deletion will be logged for audit purposes.</value>
+  </data>
+  <data name="TypeFolderNameToConfirm" xml:space="preserve">
+    <value>To confirm, type the folder name below (you can copy it from the field above):</value>
+  </data>
+  <data name="PermanentlyDeleteConfirmButton" xml:space="preserve">
+    <value>Permanently delete</value>
+  </data>
+  <data name="DeleteAllFilteredEmails" xml:space="preserve">
+    <value>Delete filtered emails (all folders)</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmTitle" xml:space="preserve">
+    <value>Permanently delete filtered emails across all folders</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmWarning" xml:space="preserve">
+    <value>This will permanently delete all {0} email(s) matching the current filter across every folder of this account. This action cannot be undone and each deletion will be logged for audit purposes.</value>
+  </data>
+  <data name="TypeDeleteWordToConfirm" xml:space="preserve">
+    <value>To confirm, type "{0}" below:</value>
+  </data>
+  <data name="DeleteConfirmationWord" xml:space="preserve">
+    <value>DELETE</value>
+  </data>
   <data name="DeleteButton" xml:space="preserve">
     <value>Delete</value>
   </data>

--- a/Resources/SharedResource.ru.resx
+++ b/Resources/SharedResource.ru.resx
@@ -2131,6 +2131,45 @@
   <data name="DeleteSelectedEmailsConfirm" xml:space="preserve">
     <value>Вы уверены, что хотите безвозвратно удалить {0} выбранных писем? Это действие невозможно отменить и каждое удаление будет записано в журнал для целей аудита.</value>
   </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Очистить папку</value>
+  </data>
+  <data name="DeleteFilteredEmails" xml:space="preserve">
+    <value>Удалить отфильтрованные письма</value>
+  </data>
+  <data name="EmptyFolderConfirmTitle" xml:space="preserve">
+    <value>Безвозвратно очистить папку</value>
+  </data>
+  <data name="DeleteFilteredConfirmTitle" xml:space="preserve">
+    <value>Безвозвратно удалить отфильтрованные письма</value>
+  </data>
+  <data name="EmptyFolderConfirmWarning" xml:space="preserve">
+    <value>Это безвозвратно удалит все {0} писем в папке "{1}". Это действие нельзя отменить, каждое удаление будет зафиксировано в журнале.</value>
+  </data>
+  <data name="DeleteFilteredConfirmWarning" xml:space="preserve">
+    <value>Это безвозвратно удалит {0} писем, соответствующих текущему фильтру в папке "{1}". Это действие нельзя отменить, каждое удаление будет зафиксировано в журнале.</value>
+  </data>
+  <data name="TypeFolderNameToConfirm" xml:space="preserve">
+    <value>Для подтверждения введите название папки ниже (его можно скопировать из поля выше):</value>
+  </data>
+  <data name="PermanentlyDeleteConfirmButton" xml:space="preserve">
+    <value>Удалить безвозвратно</value>
+  </data>
+  <data name="DeleteAllFilteredEmails" xml:space="preserve">
+    <value>Удалить отфильтрованные письма (все папки)</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmTitle" xml:space="preserve">
+    <value>Безвозвратно удалить отфильтрованные письма во всех папках</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmWarning" xml:space="preserve">
+    <value>Это безвозвратно удалит все {0} писем, соответствующих текущему фильтру, во всех папках этого аккаунта. Это действие нельзя отменить, каждое удаление будет зафиксировано в журнале.</value>
+  </data>
+  <data name="TypeDeleteWordToConfirm" xml:space="preserve">
+    <value>Для подтверждения введите ниже «{0}»:</value>
+  </data>
+  <data name="DeleteConfirmationWord" xml:space="preserve">
+    <value>УДАЛИТЬ</value>
+  </data>
   <data name="EmailDeleted" xml:space="preserve">
     <value>Письмо успешно удалено</value>
   </data>

--- a/Resources/SharedResource.sl.resx
+++ b/Resources/SharedResource.sl.resx
@@ -2131,6 +2131,45 @@
   <data name="DeleteSelectedEmailsConfirm" xml:space="preserve">
     <value>Ali ste prepričani, da želite trajno izbrisati {0} izbranih e-poštnih sporočil? Tega dejanja ni mogoče razveljaviti in vsako brisanje bo zabeleženo za namene revizije.</value>
   </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Izprazni mapo</value>
+  </data>
+  <data name="DeleteFilteredEmails" xml:space="preserve">
+    <value>Izbriši filtrirana e-sporočila</value>
+  </data>
+  <data name="EmptyFolderConfirmTitle" xml:space="preserve">
+    <value>Trajno izprazni mapo</value>
+  </data>
+  <data name="DeleteFilteredConfirmTitle" xml:space="preserve">
+    <value>Trajno izbriši filtrirana e-sporočila</value>
+  </data>
+  <data name="EmptyFolderConfirmWarning" xml:space="preserve">
+    <value>S tem boste trajno izbrisali vseh {0} e-sporočil v mapi "{1}". Tega dejanja ni mogoče razveljaviti, vsak izbris pa bo zabeležen.</value>
+  </data>
+  <data name="DeleteFilteredConfirmWarning" xml:space="preserve">
+    <value>S tem boste trajno izbrisali {0} e-sporočil, ki ustrezajo trenutnemu filtru v mapi "{1}". Tega dejanja ni mogoče razveljaviti, vsak izbris pa bo zabeležen.</value>
+  </data>
+  <data name="TypeFolderNameToConfirm" xml:space="preserve">
+    <value>Za potrditev spodaj vnesite ime mape (lahko ga kopirate iz zgornjega polja):</value>
+  </data>
+  <data name="PermanentlyDeleteConfirmButton" xml:space="preserve">
+    <value>Trajno izbriši</value>
+  </data>
+  <data name="DeleteAllFilteredEmails" xml:space="preserve">
+    <value>Izbriši filtrirana e-sporočila (vse mape)</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmTitle" xml:space="preserve">
+    <value>Trajno izbriši filtrirana e-sporočila v vseh mapah</value>
+  </data>
+  <data name="DeleteAllFilteredConfirmWarning" xml:space="preserve">
+    <value>S tem boste trajno izbrisali vseh {0} e-sporočil, ki ustrezajo trenutnemu filtru, v vseh mapah tega računa. Tega dejanja ni mogoče razveljaviti, vsak izbris pa bo zabeležen.</value>
+  </data>
+  <data name="TypeDeleteWordToConfirm" xml:space="preserve">
+    <value>Za potrditev spodaj vnesite "{0}":</value>
+  </data>
+  <data name="DeleteConfirmationWord" xml:space="preserve">
+    <value>IZBRIŠI</value>
+  </data>
   <data name="EmailDeleted" xml:space="preserve">
     <value>E-pošta uspešno izbrisana</value>
   </data>

--- a/Services/Core/EmailCoreService.cs
+++ b/Services/Core/EmailCoreService.cs
@@ -90,6 +90,100 @@ namespace MailArchiver.Services.Core
             string sortOrder = "desc")
         {
             var startTime = DateTime.UtcNow;
+
+            var (whereClause, parameters, noResults) = BuildSearchWhereClause(searchTerm, fromDate, toDate, accountId, folderName, isOutgoing, allowedAccountIds);
+            if (noResults)
+            {
+                return (new List<ArchivedEmail>(), 0);
+            }
+            var paramCounter = parameters.Count;
+
+            // Count query
+            var countSql = $@"
+                SELECT COUNT(*)
+                FROM mail_archiver.""ArchivedEmails""
+                {whereClause}";
+
+            var totalCount = await ExecuteScalarQueryAsync<int>(countSql, CloneParameters(parameters));
+
+            // Build ORDER BY clause
+            var (orderByClause, sortColumn, isTimestampSort) = GetOrderByClause(sortBy, sortOrder);
+
+            // Parametrize LIMIT/OFFSET rather than interpolating integers, so
+            // the data query inherits the same SQL-injection defense as the
+            // filter parameters above even if a future caller skips clamping.
+            var limitParam = new Npgsql.NpgsqlParameter($"@param{paramCounter}", take);
+            var offsetParam = new Npgsql.NpgsqlParameter($"@param{paramCounter + 1}", skip);
+            var limitPlaceholder = $"@param{paramCounter}";
+            var offsetPlaceholder = $"@param{paramCounter + 1}";
+            paramCounter += 2;
+
+            // For timestamp sorts (SentDate/ReceivedDate), use a MATERIALIZED CTE to force the planner
+            // to use the GIN full-text index for the FTS predicate instead of doing a backward SentDate
+            // index scan with per-row re-tokenization of the body. The CTE selects only (Id, SortColumn)
+            // so no body detoasting happens during matching; the body is only detoasted for the final page.
+            // For text sorts, keep the flat form (no backward-index-scan antipattern there).
+            string dataSql;
+            if (isTimestampSort)
+            {
+                dataSql = $@"
+                    WITH ""matched"" AS MATERIALIZED (
+                        SELECT e.""Id"", e.""{sortColumn}""
+                        FROM mail_archiver.""ArchivedEmails"" e
+                        {whereClause}
+                    ),
+                    ""page"" AS (
+                        SELECT m.""Id"", m.""{sortColumn}""
+                        FROM ""matched"" m
+                        ORDER BY m.""{sortColumn}"" {(sortOrder?.ToLower() == "asc" ? "ASC" : "DESC")}
+                        LIMIT {limitPlaceholder} OFFSET {offsetPlaceholder}
+                    )
+                    SELECT e.""Id"", e.""MailAccountId"", e.""MessageId"", e.""Subject"", e.""Body"", e.""HtmlBody"",
+                           e.""From"", e.""To"", e.""Cc"", e.""Bcc"", e.""SentDate"", e.""ReceivedDate"",
+                           e.""IsOutgoing"", e.""HasAttachments"", e.""FolderName"", e.""IsLocked"",
+                           ma.""Id"" as ""AccountId"", ma.""Name"" as ""AccountName"", ma.""EmailAddress"" as ""AccountEmail""
+                    FROM ""page"" p
+                    INNER JOIN mail_archiver.""ArchivedEmails"" e ON e.""Id"" = p.""Id""
+                    INNER JOIN mail_archiver.""MailAccounts"" ma ON e.""MailAccountId"" = ma.""Id""
+                    ORDER BY p.""{sortColumn}"" {(sortOrder?.ToLower() == "asc" ? "ASC" : "DESC")}";
+            }
+            else
+            {
+                dataSql = $@"
+                    SELECT e.""Id"", e.""MailAccountId"", e.""MessageId"", e.""Subject"", e.""Body"", e.""HtmlBody"",
+                           e.""From"", e.""To"", e.""Cc"", e.""Bcc"", e.""SentDate"", e.""ReceivedDate"",
+                           e.""IsOutgoing"", e.""HasAttachments"", e.""FolderName"", e.""IsLocked"",
+                           ma.""Id"" as ""AccountId"", ma.""Name"" as ""AccountName"", ma.""EmailAddress"" as ""AccountEmail""
+                    FROM mail_archiver.""ArchivedEmails"" e
+                    INNER JOIN mail_archiver.""MailAccounts"" ma ON e.""MailAccountId"" = ma.""Id""
+                    {whereClause}
+                    {orderByClause}
+                    LIMIT {limitPlaceholder} OFFSET {offsetPlaceholder}";
+            }
+
+            parameters.Add(limitParam);
+            parameters.Add(offsetParam);
+
+            var emails = await ExecuteDataQueryAsync(dataSql, CloneParameters(parameters));
+
+            return (emails, totalCount);
+        }
+
+        /// <summary>
+        /// Builds the WHERE clause and parameter list shared by the paginated search and
+        /// <see cref="GetMatchingEmailIdsAsync"/>, so both use identical matching semantics.
+        /// NoResults is true when the caller has no access to the requested scope at all
+        /// (e.g. account not in allowedAccountIds), in which case the caller should short-circuit.
+        /// </summary>
+        private (string WhereClause, List<Npgsql.NpgsqlParameter> Parameters, bool NoResults) BuildSearchWhereClause(
+            string searchTerm,
+            DateTime? fromDate,
+            DateTime? toDate,
+            int? accountId,
+            string folderName,
+            bool? isOutgoing,
+            List<int> allowedAccountIds)
+        {
             var whereConditions = new List<string>();
             var parameters = new List<Npgsql.NpgsqlParameter>();
             var paramCounter = 0;
@@ -103,13 +197,13 @@ namespace MailArchiver.Services.Core
                 if (!string.IsNullOrEmpty(tsQuery))
                 {
                     searchConditions.Add($@"
-                        to_tsvector('simple', 
-                            COALESCE(""Subject"", '') || ' ' || 
-                            COALESCE(""Body"", '') || ' ' || 
-                            COALESCE(""From"", '') || ' ' || 
-                            COALESCE(""To"", '') || ' ' || 
-                            COALESCE(""Cc"", '') || ' ' || 
-                            COALESCE(""Bcc"", '')) 
+                        to_tsvector('simple',
+                            COALESCE(""Subject"", '') || ' ' ||
+                            COALESCE(""Body"", '') || ' ' ||
+                            COALESCE(""From"", '') || ' ' ||
+                            COALESCE(""To"", '') || ' ' ||
+                            COALESCE(""Cc"", '') || ' ' ||
+                            COALESCE(""Bcc"", ''))
                         @@ to_tsquery('simple', @param{paramCounter})");
                     parameters.Add(new Npgsql.NpgsqlParameter($"@param{paramCounter}", tsQuery));
                     paramCounter++;
@@ -121,13 +215,13 @@ namespace MailArchiver.Services.Core
                     if (!string.IsNullOrEmpty(phraseTsQuery))
                     {
                         searchConditions.Add($@"(
-                        to_tsvector('simple', 
-                            COALESCE(""Subject"", '') || ' ' || 
-                            COALESCE(""Body"", '') || ' ' || 
-                            COALESCE(""From"", '') || ' ' || 
-                            COALESCE(""To"", '') || ' ' || 
-                            COALESCE(""Cc"", '') || ' ' || 
-                            COALESCE(""Bcc"", '')) 
+                        to_tsvector('simple',
+                            COALESCE(""Subject"", '') || ' ' ||
+                            COALESCE(""Body"", '') || ' ' ||
+                            COALESCE(""From"", '') || ' ' ||
+                            COALESCE(""To"", '') || ' ' ||
+                            COALESCE(""Cc"", '') || ' ' ||
+                            COALESCE(""Bcc"", ''))
                         @@ to_tsquery('simple', @param{paramCounter})
                         AND (
                         POSITION(LOWER(@param{paramCounter + 1}) IN LOWER(COALESCE(""Subject"", ''))) > 0 OR
@@ -205,7 +299,7 @@ namespace MailArchiver.Services.Core
                 if (allowedAccountIds != null && !allowedAccountIds.Contains(accountId.Value))
                 {
                     _logger.LogWarning("User attempted to access account {AccountId} which is not in their allowed accounts list", accountId.Value);
-                    return (new List<ArchivedEmail>(), 0);
+                    return (null, null, true);
                 }
 
                 whereConditions.Add($@"""MailAccountId"" = @param{paramCounter}");
@@ -223,7 +317,7 @@ namespace MailArchiver.Services.Core
                 else
                 {
                     _logger.LogWarning("User has no allowed accounts, returning empty result set");
-                    return (new List<ArchivedEmail>(), 0);
+                    return (null, null, true);
                 }
             }
 
@@ -259,76 +353,86 @@ namespace MailArchiver.Services.Core
             }
 
             var whereClause = whereConditions.Any() ? "WHERE " + string.Join(" AND ", whereConditions) : "";
+            return (whereClause, parameters, false);
+        }
 
-            // Count query
-            var countSql = $@"
+        /// <summary>
+        /// Resolves every email ID matching the given filters, without pagination.
+        /// Used for folder-wide/filtered bulk deletion, where an offset/limit page-by-page
+        /// scan over a non-unique sort column (SentDate) could skip or double-count rows
+        /// across calls. Ordered by Id (a stable, unique key) instead.
+        /// </summary>
+        public async Task<List<int>> GetMatchingEmailIdsAsync(
+            string searchTerm,
+            DateTime? fromDate,
+            DateTime? toDate,
+            int? accountId,
+            string folderName,
+            bool? isOutgoing,
+            List<int> allowedAccountIds = null)
+        {
+            var (whereClause, parameters, noResults) = BuildSearchWhereClause(searchTerm, fromDate, toDate, accountId, folderName, isOutgoing, allowedAccountIds);
+            if (noResults)
+            {
+                return new List<int>();
+            }
+
+            var sql = $@"
+                SELECT ""Id""
+                FROM mail_archiver.""ArchivedEmails""
+                {whereClause}
+                ORDER BY ""Id""";
+
+            return await ExecuteIdListQueryAsync(sql, parameters);
+        }
+
+        /// <summary>
+        /// Counts every email matching the given filters, without loading rows or IDs.
+        /// Used to preview the size of a folder-wide/filtered deletion before it runs.
+        /// </summary>
+        public async Task<int> CountMatchingEmailsAsync(
+            string searchTerm,
+            DateTime? fromDate,
+            DateTime? toDate,
+            int? accountId,
+            string folderName,
+            bool? isOutgoing,
+            List<int> allowedAccountIds = null)
+        {
+            var (whereClause, parameters, noResults) = BuildSearchWhereClause(searchTerm, fromDate, toDate, accountId, folderName, isOutgoing, allowedAccountIds);
+            if (noResults)
+            {
+                return 0;
+            }
+
+            var sql = $@"
                 SELECT COUNT(*)
                 FROM mail_archiver.""ArchivedEmails""
                 {whereClause}";
 
-            var totalCount = await ExecuteScalarQueryAsync<int>(countSql, CloneParameters(parameters));
+            return await ExecuteScalarQueryAsync<int>(sql, parameters);
+        }
 
-            // Build ORDER BY clause
-            var (orderByClause, sortColumn, isTimestampSort) = GetOrderByClause(sortBy, sortOrder);
+        private async Task<List<int>> ExecuteIdListQueryAsync(string sql, List<Npgsql.NpgsqlParameter> parameters)
+        {
+            var ids = new List<int>();
 
-            // Parametrize LIMIT/OFFSET rather than interpolating integers, so
-            // the data query inherits the same SQL-injection defense as the
-            // filter parameters above even if a future caller skips clamping.
-            var limitParam = new Npgsql.NpgsqlParameter($"@param{paramCounter}", take);
-            var offsetParam = new Npgsql.NpgsqlParameter($"@param{paramCounter + 1}", skip);
-            var limitPlaceholder = $"@param{paramCounter}";
-            var offsetPlaceholder = $"@param{paramCounter + 1}";
-            paramCounter += 2;
+            using var connection = new Npgsql.NpgsqlConnection(_context.Database.GetConnectionString());
+            await connection.OpenAsync();
 
-            // For timestamp sorts (SentDate/ReceivedDate), use a MATERIALIZED CTE to force the planner
-            // to use the GIN full-text index for the FTS predicate instead of doing a backward SentDate
-            // index scan with per-row re-tokenization of the body. The CTE selects only (Id, SortColumn)
-            // so no body detoasting happens during matching; the body is only detoasted for the final page.
-            // For text sorts, keep the flat form (no backward-index-scan antipattern there).
-            string dataSql;
-            if (isTimestampSort)
+            using var command = new Npgsql.NpgsqlCommand(sql, connection);
+            foreach (var parameter in parameters)
             {
-                dataSql = $@"
-                    WITH ""matched"" AS MATERIALIZED (
-                        SELECT e.""Id"", e.""{sortColumn}""
-                        FROM mail_archiver.""ArchivedEmails"" e
-                        {whereClause}
-                    ),
-                    ""page"" AS (
-                        SELECT m.""Id"", m.""{sortColumn}""
-                        FROM ""matched"" m
-                        ORDER BY m.""{sortColumn}"" {(sortOrder?.ToLower() == "asc" ? "ASC" : "DESC")}
-                        LIMIT {limitPlaceholder} OFFSET {offsetPlaceholder}
-                    )
-                    SELECT e.""Id"", e.""MailAccountId"", e.""MessageId"", e.""Subject"", e.""Body"", e.""HtmlBody"",
-                           e.""From"", e.""To"", e.""Cc"", e.""Bcc"", e.""SentDate"", e.""ReceivedDate"",
-                           e.""IsOutgoing"", e.""HasAttachments"", e.""FolderName"", e.""IsLocked"",
-                           ma.""Id"" as ""AccountId"", ma.""Name"" as ""AccountName"", ma.""EmailAddress"" as ""AccountEmail""
-                    FROM ""page"" p
-                    INNER JOIN mail_archiver.""ArchivedEmails"" e ON e.""Id"" = p.""Id""
-                    INNER JOIN mail_archiver.""MailAccounts"" ma ON e.""MailAccountId"" = ma.""Id""
-                    ORDER BY p.""{sortColumn}"" {(sortOrder?.ToLower() == "asc" ? "ASC" : "DESC")}";
-            }
-            else
-            {
-                dataSql = $@"
-                    SELECT e.""Id"", e.""MailAccountId"", e.""MessageId"", e.""Subject"", e.""Body"", e.""HtmlBody"",
-                           e.""From"", e.""To"", e.""Cc"", e.""Bcc"", e.""SentDate"", e.""ReceivedDate"",
-                           e.""IsOutgoing"", e.""HasAttachments"", e.""FolderName"", e.""IsLocked"",
-                           ma.""Id"" as ""AccountId"", ma.""Name"" as ""AccountName"", ma.""EmailAddress"" as ""AccountEmail""
-                    FROM mail_archiver.""ArchivedEmails"" e
-                    INNER JOIN mail_archiver.""MailAccounts"" ma ON e.""MailAccountId"" = ma.""Id""
-                    {whereClause}
-                    {orderByClause}
-                    LIMIT {limitPlaceholder} OFFSET {offsetPlaceholder}";
+                command.Parameters.Add(parameter);
             }
 
-            parameters.Add(limitParam);
-            parameters.Add(offsetParam);
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                ids.Add(reader.GetInt32(0));
+            }
 
-            var emails = await ExecuteDataQueryAsync(dataSql, CloneParameters(parameters));
-
-            return (emails, totalCount);
+            return ids;
         }
 
         private async Task<T> ExecuteScalarQueryAsync<T>(string sql, List<Npgsql.NpgsqlParameter> parameters)

--- a/Services/EmailDeletionService.cs
+++ b/Services/EmailDeletionService.cs
@@ -60,8 +60,16 @@ namespace MailArchiver.Services
             job.TotalEmails = job.EmailIds.Count;
 
             _jobs.TryAdd(job.JobId, job);
-            _logger.LogInformation("Email deletion job {JobId} queued with {Count} emails", 
-                job.JobId, job.EmailIds.Count);
+            if (job.Criteria != null)
+            {
+                _logger.LogInformation("Email deletion job {JobId} queued for account {AccountId}, folder '{FolderName}'",
+                    job.JobId, job.Criteria.AccountId, job.Criteria.FolderName);
+            }
+            else
+            {
+                _logger.LogInformation("Email deletion job {JobId} queued with {Count} emails",
+                    job.JobId, job.EmailIds.Count);
+            }
 
             return job.JobId;
         }
@@ -162,8 +170,16 @@ namespace MailArchiver.Services
                 job.Started = DateTime.UtcNow;
                 job.CurrentPhase = "Starting deletion process";
 
-                _logger.LogInformation("Starting email deletion job {JobId} with {Count} emails",
-                    job.JobId, job.EmailIds.Count);
+                if (job.Criteria != null)
+                {
+                    _logger.LogInformation("Starting email deletion job {JobId} for account {AccountId}, folder '{FolderName}'",
+                        job.JobId, job.Criteria.AccountId, job.Criteria.FolderName);
+                }
+                else
+                {
+                    _logger.LogInformation("Starting email deletion job {JobId} with {Count} emails",
+                        job.JobId, job.EmailIds.Count);
+                }
 
                 using var scope = _serviceScopeFactory.CreateScope();
                 var context = scope.ServiceProvider.GetRequiredService<MailArchiverDbContext>();
@@ -172,6 +188,32 @@ namespace MailArchiver.Services
                 var combinedToken = CancellationTokenSource
                     .CreateLinkedTokenSource(stoppingToken, job.CancellationTokenSource.Token)
                     .Token;
+
+                // Phase 0: Resolve matching email IDs from the criteria (folder-wide or
+                // filtered deletion). Uses the same filter matching logic as the email list
+                // so the result matches exactly what the user saw before confirming.
+                if (job.Criteria != null)
+                {
+                    job.CurrentPhase = "Resolving matching emails";
+                    var emailCoreService = scope.ServiceProvider.GetRequiredService<MailArchiver.Services.Core.EmailCoreService>();
+                    var criteria = job.Criteria;
+
+                    combinedToken.ThrowIfCancellationRequested();
+
+                    var resolvedIds = await emailCoreService.GetMatchingEmailIdsAsync(
+                        criteria.SearchTerm,
+                        criteria.FromDate,
+                        criteria.ToDate,
+                        criteria.AccountId,
+                        criteria.FolderName,
+                        criteria.IsOutgoing);
+
+                    job.EmailIds = resolvedIds;
+                    job.TotalEmails = resolvedIds.Count;
+
+                    _logger.LogInformation("Job {JobId}: Resolved {Count} emails for account {AccountId}, folder '{FolderName}'",
+                        job.JobId, resolvedIds.Count, criteria.AccountId, criteria.FolderName);
+                }
 
                 // Phase 1: Count attachments
                 job.CurrentPhase = "Counting attachments";

--- a/Views/Emails/Index.cshtml
+++ b/Views/Emails/Index.cshtml
@@ -5,6 +5,36 @@
 @model MailArchiver.Models.ViewModels.SearchViewModel
 @{
     ViewData["Title"] = Localizer["EmailArchive"];
+
+    var hasActiveFilter = !string.IsNullOrWhiteSpace(Model.SearchTerm) || Model.FromDate.HasValue || Model.ToDate.HasValue || Model.IsOutgoing.HasValue;
+    var canDeleteEmails = User.IsInRole("Admin") || User.IsInRole("SelfManager");
+    var hasAccountAndFolder = Model.SelectedAccountId.HasValue && !string.IsNullOrEmpty(Model.SelectedFolder);
+
+    // "Empty folder" only appears when nothing is filtered, so it always matches exactly
+    // what's on screen (the whole folder) - never a hidden larger scope than what's visible.
+    var showEmptyFolderBtn = hasAccountAndFolder && !hasActiveFilter && canDeleteEmails;
+    var selectedFolderTotalCount = showEmptyFolderBtn ? FindFolderCount(Model.FolderTree, Model.SelectedFolder) : 0;
+
+    // "Delete filtered emails" is scoped to the single selected folder.
+    var showDeleteFilteredBtn = hasAccountAndFolder && hasActiveFilter && canDeleteEmails;
+
+    // "Delete filtered emails (all folders)" ignores folder selection entirely - it only
+    // needs an account and an active filter, and always targets every folder of that account.
+    var showDeleteAllFilteredBtn = Model.SelectedAccountId.HasValue && hasActiveFilter && canDeleteEmails;
+    var accountWideFilteredCount = showDeleteAllFilteredBtn ? (ViewBag.AccountWideFilteredCount ?? 0) : 0;
+}
+@functions {
+    private static int FindFolderCount(List<MailArchiver.Models.ViewModels.FolderTreeNode> nodes, string path)
+    {
+        if (nodes == null) return 0;
+        foreach (var node in nodes)
+        {
+            if (node.FullPath == path) return node.TotalCount;
+            var childCount = FindFolderCount(node.Children, path);
+            if (childCount > 0) return childCount;
+        }
+        return 0;
+    }
 }
 
 @* Anti-Forgery Token für JavaScript *@
@@ -209,7 +239,39 @@
                             </div>
                         </div>
                     </div>
-                    
+
+                    @if (showEmptyFolderBtn || showDeleteFilteredBtn || showDeleteAllFilteredBtn)
+                    {
+                        <div class="p-2 bg-light border-bottom d-flex flex-wrap gap-2 align-items-center">
+                            @if (showEmptyFolderBtn)
+                            {
+                                <button type="button" id="emptyFolderBtn" class="btn btn-sm btn-outline-danger" data-confirm-mode="folder"
+                                        data-account-id="@Model.SelectedAccountId" data-folder-name="@Model.SelectedFolder" data-total-count="@selectedFolderTotalCount">
+                                    <i class="bi bi-trash3"></i>
+                                    <span class="d-inline">@Localizer["EmptyFolder"]</span>
+                                </button>
+                            }
+                            @if (showDeleteFilteredBtn)
+                            {
+                                <button type="button" id="deleteFilteredBtn" class="btn btn-sm btn-outline-danger" data-confirm-mode="folder"
+                                        data-account-id="@Model.SelectedAccountId" data-folder-name="@Model.SelectedFolder" data-total-count="@Model.TotalResults"
+                                        data-search-term="@Model.SearchTerm" data-from-date="@Model.FromDate?.ToString("yyyy-MM-dd")" data-to-date="@Model.ToDate?.ToString("yyyy-MM-dd")" data-is-outgoing="@Model.IsOutgoing">
+                                    <i class="bi bi-trash3"></i>
+                                    <span class="d-inline">@Localizer["DeleteFilteredEmails"]</span>
+                                </button>
+                            }
+                            @if (showDeleteAllFilteredBtn)
+                            {
+                                <button type="button" id="deleteAllFilteredBtn" class="btn btn-sm btn-outline-danger" data-confirm-mode="word"
+                                        data-account-id="@Model.SelectedAccountId" data-total-count="@accountWideFilteredCount"
+                                        data-search-term="@Model.SearchTerm" data-from-date="@Model.FromDate?.ToString("yyyy-MM-dd")" data-to-date="@Model.ToDate?.ToString("yyyy-MM-dd")" data-is-outgoing="@Model.IsOutgoing">
+                                    <i class="bi bi-trash3"></i>
+                                    <span class="d-inline">@Localizer["DeleteAllFilteredEmails"]</span>
+                                </button>
+                            }
+                        </div>
+                    }
+
                     @if (Model.ShowSelectionControls)
                     {
                         <div class="p-2 bg-light border-bottom">
@@ -463,6 +525,38 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">@Localizer["Cancel"]</button>
                 <button type="button" class="btn btn-primary" id="confirmBatchRestoreBtn">@Localizer["Continue"]</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Folder-wide Deletion Confirmation Modal -->
+<div class="modal fade" id="folderDeleteConfirmModal" tabindex="-1" aria-labelledby="folderDeleteConfirmModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="folderDeleteConfirmModalLabel"></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-warning">
+                    <i class="bi bi-exclamation-triangle-fill me-2"></i>
+                    <span id="folderDeleteConfirmWarning"></span>
+                </div>
+                <div class="mb-2">
+                    <label class="form-label small" id="folderDeleteInputLabel"></label>
+                    <div class="input-group mb-2" id="folderDeleteNameGroup">
+                        <input type="text" class="form-control form-control-sm font-monospace" id="folderDeleteNameDisplay" readonly>
+                        <button type="button" class="btn btn-outline-dark btn-sm" id="folderDeleteCopyBtn">
+                            <i class="bi bi-clipboard"></i> @Localizer["Copy"]
+                        </button>
+                    </div>
+                    <input type="text" class="form-control" id="folderDeleteNameInput" autocomplete="off">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">@Localizer["Cancel"]</button>
+                <button type="button" class="btn btn-danger" id="folderDeleteConfirmBtn" disabled>@Localizer["PermanentlyDeleteConfirmButton"]</button>
             </div>
         </div>
     </div>
@@ -757,7 +851,16 @@
             tooManyEmailsSelected: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["TooManyEmailsSelected"].Value)),
             continueWithOperation: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ContinueWithOperation"].Value)),
             deleteSelectedEmailsConfirm: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["DeleteSelectedEmailsConfirm"].Value)),
-            loading: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Loading"].Value))
+            loading: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Loading"].Value)),
+            emptyFolderConfirmTitle: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["EmptyFolderConfirmTitle"].Value)),
+            deleteFilteredConfirmTitle: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["DeleteFilteredConfirmTitle"].Value)),
+            emptyFolderConfirmWarning: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["EmptyFolderConfirmWarning"].Value)),
+            deleteFilteredConfirmWarning: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["DeleteFilteredConfirmWarning"].Value)),
+            deleteAllFilteredConfirmTitle: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["DeleteAllFilteredConfirmTitle"].Value)),
+            deleteAllFilteredConfirmWarning: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["DeleteAllFilteredConfirmWarning"].Value)),
+            typeFolderNameToConfirm: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["TypeFolderNameToConfirm"].Value)),
+            typeDeleteWordToConfirm: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["TypeDeleteWordToConfirm"].Value)),
+            deleteConfirmationWord: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["DeleteConfirmationWord"].Value))
         };
         
         const toggleSelectionMode = document.getElementById('toggleSelectionMode');
@@ -1065,6 +1168,93 @@
             selectedIds.forEach(id => form.appendChild(createHiddenInput('ids', id)));
             document.body.appendChild(form);
             form.submit();
+        }
+
+        // Folder-wide / account-wide deletion buttons ("Empty folder", "Delete filtered
+        // emails", "Delete filtered emails (all folders)") share one confirmation modal.
+        // Two confirmation modes, from data-confirm-mode:
+        //   "folder" - must type the exact folder name (shown read-only + copyable above).
+        //   "word"   - must type the fixed localized confirmation word (no single folder to
+        //              name, since the action spans every folder of the account).
+        // The "filtered" buttons carry the active search filters as data attributes; "empty
+        // folder" does not, which is how the submit handler decides whether to include
+        // filter fields in the POST. Only "folder" mode buttons carry a folder name.
+        function setupFolderDeleteButton(buttonId, actionUrl, titleKey, warningKey) {
+            const btn = document.getElementById(buttonId);
+            if (!btn) return;
+
+            const mode = btn.dataset.confirmMode;
+
+            btn.addEventListener('click', function() {
+                const accountId = btn.dataset.accountId;
+                const folderName = btn.dataset.folderName;
+                const totalCount = Number(btn.dataset.totalCount || 0);
+                const requiredText = mode === 'word' ? i18n.deleteConfirmationWord : folderName;
+
+                document.getElementById('folderDeleteConfirmModalLabel').textContent = i18n[titleKey];
+                document.getElementById('folderDeleteConfirmWarning').textContent = i18n[warningKey]
+                    .replace('{0}', totalCount.toLocaleString())
+                    .replace('{1}', folderName || '');
+
+                const nameGroup = document.getElementById('folderDeleteNameGroup');
+                const inputLabel = document.getElementById('folderDeleteInputLabel');
+                const nameDisplay = document.getElementById('folderDeleteNameDisplay');
+                const nameInput = document.getElementById('folderDeleteNameInput');
+                const confirmBtn = document.getElementById('folderDeleteConfirmBtn');
+
+                if (mode === 'word') {
+                    nameGroup.style.display = 'none';
+                    inputLabel.textContent = i18n.typeDeleteWordToConfirm.replace('{0}', requiredText);
+                } else {
+                    nameGroup.style.display = '';
+                    inputLabel.textContent = i18n.typeFolderNameToConfirm;
+                    nameDisplay.value = folderName;
+                }
+                nameInput.value = '';
+                confirmBtn.disabled = true;
+
+                nameInput.oninput = function() {
+                    confirmBtn.disabled = nameInput.value !== requiredText;
+                };
+
+                confirmBtn.onclick = function() {
+                    if (nameInput.value !== requiredText) return;
+
+                    const form = document.createElement('form');
+                    form.method = 'post';
+                    form.action = actionUrl;
+                    form.appendChild(createHiddenInput('__RequestVerificationToken', document.querySelector('input[name="__RequestVerificationToken"]').value));
+                    form.appendChild(createHiddenInput('accountId', accountId));
+                    if (folderName !== undefined) {
+                        form.appendChild(createHiddenInput('folderName', folderName));
+                    }
+                    form.appendChild(createHiddenInput('returnUrl', '@Context.Request.Path@Context.Request.QueryString'));
+                    if (btn.dataset.searchTerm !== undefined) {
+                        form.appendChild(createHiddenInput('searchTerm', btn.dataset.searchTerm || ''));
+                        form.appendChild(createHiddenInput('fromDate', btn.dataset.fromDate || ''));
+                        form.appendChild(createHiddenInput('toDate', btn.dataset.toDate || ''));
+                        form.appendChild(createHiddenInput('isOutgoing', btn.dataset.isOutgoing || ''));
+                    }
+                    document.body.appendChild(form);
+                    form.submit();
+                };
+
+                new bootstrap.Modal(document.getElementById('folderDeleteConfirmModal')).show();
+            });
+        }
+
+        setupFolderDeleteButton('emptyFolderBtn', '@Url.Action("DeleteFolder", "Emails")', 'emptyFolderConfirmTitle', 'emptyFolderConfirmWarning');
+        setupFolderDeleteButton('deleteFilteredBtn', '@Url.Action("DeleteFiltered", "Emails")', 'deleteFilteredConfirmTitle', 'deleteFilteredConfirmWarning');
+        setupFolderDeleteButton('deleteAllFilteredBtn', '@Url.Action("DeleteFilteredAllFolders", "Emails")', 'deleteAllFilteredConfirmTitle', 'deleteAllFilteredConfirmWarning');
+
+        const folderDeleteCopyBtn = document.getElementById('folderDeleteCopyBtn');
+        if (folderDeleteCopyBtn) {
+            folderDeleteCopyBtn.addEventListener('click', function() {
+                const nameDisplay = document.getElementById('folderDeleteNameDisplay');
+                nameDisplay.select();
+                nameDisplay.setSelectionRange(0, 99999);
+                navigator.clipboard.writeText(nameDisplay.value);
+            });
         }
 
         @if (Model.ShowSelectionControls)

--- a/Views/Emails/Index.cshtml
+++ b/Views/Emails/Index.cshtml
@@ -1249,11 +1249,37 @@
 
         const folderDeleteCopyBtn = document.getElementById('folderDeleteCopyBtn');
         if (folderDeleteCopyBtn) {
+            const folderDeleteCopyIcon = folderDeleteCopyBtn.querySelector('i');
+            const showCopyFeedback = function(success) {
+                if (!folderDeleteCopyIcon) return;
+                const originalIconClass = 'bi bi-clipboard';
+                folderDeleteCopyBtn.classList.remove('btn-outline-dark');
+                folderDeleteCopyBtn.classList.toggle('btn-outline-success', success);
+                folderDeleteCopyBtn.classList.toggle('btn-outline-danger', !success);
+                folderDeleteCopyIcon.className = success ? 'bi bi-clipboard-check' : 'bi bi-clipboard-x';
+                setTimeout(function() {
+                    folderDeleteCopyBtn.classList.remove('btn-outline-success', 'btn-outline-danger');
+                    folderDeleteCopyBtn.classList.add('btn-outline-dark');
+                    folderDeleteCopyIcon.className = originalIconClass;
+                }, 1500);
+            };
+
             folderDeleteCopyBtn.addEventListener('click', function() {
                 const nameDisplay = document.getElementById('folderDeleteNameDisplay');
                 nameDisplay.select();
                 nameDisplay.setSelectionRange(0, 99999);
-                navigator.clipboard.writeText(nameDisplay.value);
+
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(nameDisplay.value).then(function() {
+                        showCopyFeedback(true);
+                    }, function() {
+                        showCopyFeedback(document.execCommand('copy'));
+                    });
+                } else {
+                    // navigator.clipboard requires a secure context (HTTPS/localhost);
+                    // fall back to the legacy selection-based copy for plain HTTP deployments.
+                    showCopyFeedback(document.execCommand('copy'));
+                }
             });
         }
 


### PR DESCRIPTION
## Motivation
There was previously no way to delete all emails in an archived folder at once — only single emails or a manually checked selection from the currently loaded page. Clearing out an old/large folder meant selecting emails page by page.

## What's new
Three new actions in the email list view (visible only to Admin/SelfManager users with access to the account, and only for a specifically selected account):

- **Empty folder** — deletes every email in the selected folder. Only shown when no search filter is active, so it always matches exactly what's visible (a folder full of unfiltered emails).
- **Delete filtered emails** — deletes only the emails in the selected folder that match the current search filter (term/date range/direction). Shown once a filter is active.
- **Delete filtered emails (all folders)** — same filter, but applied across every folder of the account, regardless of which folder is currently selected. Shown whenever an account is selected and a filter is active.

All three:
- Run as a background job (the job list/status page already used for other bulk operations), so large deletions don't block the request.
- Show a confirmation modal with the exact number of affected emails before anything happens.
- Require typing an exact confirmation text before the delete button unlocks — the folder name (copyable) for the first two actions, or a fixed word (e.g. "DELETE"/"LÖSCHEN", localized) for the account-wide action, since there's no single folder name to reference there.

## How it works under the hood
- The existing `EmailDeletionJob`/`EmailDeletionService` (used for selection-based deletion) now also accepts a filter criteria (account, folder, search term, date range, direction) instead of an explicit email ID list. When a job runs with criteria, it first resolves the matching IDs, then reuses the existing batched attachment/email deletion logic unchanged.
- ID resolution reuses the same WHERE-clause building as the regular email search (extracted into a shared method), so "what gets deleted" always matches exactly "what the search would show" — no separate/diverging filter logic. It intentionally does *not* reuse the search's paginated (skip/take) query, since that's sorted by a non-unique column (SentDate) and could skip or double-process rows across batches; instead it fetches all matching IDs sorted by the unique `Id` column.
- Translated into all 10 supported languages.

## Test plan
- [x] `dotnet build` succeeds, no new warnings introduced
- [x] Verified manually via `docker compose up -d --build`:
  - Buttons appear/disappear correctly across all filter/folder-selection states
  - Confirmation modal shows the correct count and blocks the delete button until the exact text is typed
  - All three deletion paths correctly queue a background job, show live progress, and only delete the intended emails
  - Deleting all emails in a folder correctly makes the folder disappear from the folder tree; it reappears automatically once new emails sync/import into it