### PR TITLE
Fix progress bar decimal separator under non-English cultures

### DIFF
--- a/Services/EmailDeletionService.cs
+++ b/Services/EmailDeletionService.cs
@@ -225,40 +225,45 @@ namespace MailArchiver.Services
                     if (!emailsToDelete.Any())
                         break;
 
-                    // Log each deletion if access log service is available
+                    // Update progress immediately before slow operations
+                    job.DeletedEmails += emailsToDelete.Count;
+                    remainingEmails -= emailsToDelete.Count;
+
+                    // Log deletions in parallel if access log service is available
                     if (accessLogService != null)
                     {
-                        foreach (var email in emailsToDelete)
+                        var logTasks = emailsToDelete.Select(email =>
+                            accessLogService.LogAccessAsync(
+                                job.UserId,
+                                AccessLogType.Deletion,
+                                emailId: email.Id,
+                                emailSubject: email.Subject?.Length > 255 
+                                    ? email.Subject.Substring(0, 255) 
+                                    : email.Subject,
+                                emailFrom: email.From?.Length > 255 
+                                    ? email.From.Substring(0, 255) 
+                                    : email.From,
+                                mailAccountId: email.MailAccountId
+                            )
+                        ).ToList();
+
+                        try
                         {
-                            try
-                            {
-                                await accessLogService.LogAccessAsync(
-                                    job.UserId,
-                                    AccessLogType.Deletion,
-                                    emailId: email.Id,
-                                    emailSubject: email.Subject?.Length > 255 
-                                        ? email.Subject.Substring(0, 255) 
-                                        : email.Subject,
-                                    emailFrom: email.From?.Length > 255 
-                                        ? email.From.Substring(0, 255) 
-                                        : email.From,
-                                    mailAccountId: email.MailAccountId);
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogWarning(ex, "Failed to log deletion of email {EmailId}", email.Id);
-                            }
+                            await Task.WhenAll(logTasks);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, "Failed to log deletion of one or more emails in batch");
                         }
                     }
 
+                    // Delete emails from database
                     context.ArchivedEmails.RemoveRange(emailsToDelete);
                     await context.SaveChangesAsync(combinedToken);
 
+                    // Track affected accounts
                     foreach (var email in emailsToDelete)
                         affectedAccountIds.Add(email.MailAccountId);
-
-                    job.DeletedEmails += emailsToDelete.Count;
-                    remainingEmails -= emailsToDelete.Count;
 
                     _logger.LogDebug("Job {JobId}: Deleted {Count} emails, {Remaining} remaining", 
                         job.JobId, emailsToDelete.Count, remainingEmails);

--- a/Services/EmailDeletionService.cs
+++ b/Services/EmailDeletionService.cs
@@ -229,32 +229,32 @@ namespace MailArchiver.Services
                     job.DeletedEmails += emailsToDelete.Count;
                     remainingEmails -= emailsToDelete.Count;
 
-                    // Log deletions in parallel if access log service is available
+                    // Log deletions using the same DbContext instance as the email removal
+                    // below, in a single SaveChangesAsync call. The DbContext/ChangeTracker
+                    // is not thread-safe, so these entries must not be added concurrently
+                    // (e.g. via Task.WhenAll of per-email LogAccessAsync calls that each call
+                    // SaveChangesAsync) - that corrupts the tracker and throws
+                    // "cannot be tracked because another instance with the same key ... is
+                    // already being tracked".
                     if (accessLogService != null)
                     {
-                        var logTasks = emailsToDelete.Select(email =>
-                            accessLogService.LogAccessAsync(
-                                job.UserId,
-                                AccessLogType.Deletion,
-                                emailId: email.Id,
-                                emailSubject: email.Subject?.Length > 255 
-                                    ? email.Subject.Substring(0, 255) 
-                                    : email.Subject,
-                                emailFrom: email.From?.Length > 255 
-                                    ? email.From.Substring(0, 255) 
-                                    : email.From,
-                                mailAccountId: email.MailAccountId
-                            )
-                        ).ToList();
+                        var now = DateTime.UtcNow;
+                        var logEntries = emailsToDelete.Select(email => new AccessLog
+                        {
+                            Username = job.UserId,
+                            Type = AccessLogType.Deletion,
+                            Timestamp = now,
+                            EmailId = email.Id,
+                            EmailSubject = email.Subject?.Length > 255
+                                ? email.Subject.Substring(0, 255)
+                                : email.Subject,
+                            EmailFrom = email.From?.Length > 255
+                                ? email.From.Substring(0, 255)
+                                : email.From,
+                            MailAccountId = email.MailAccountId
+                        });
 
-                        try
-                        {
-                            await Task.WhenAll(logTasks);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex, "Failed to log deletion of one or more emails in batch");
-                        }
+                        context.AccessLogs.AddRange(logEntries);
                     }
 
                     // Delete emails from database

--- a/Views/Emails/BatchRestoreStatus.cshtml
+++ b/Views/Emails/BatchRestoreStatus.cshtml
@@ -1,4 +1,4 @@
-﻿@inject Microsoft.Extensions.Localization.IStringLocalizer<MailArchiver.SharedResource> Localizer
+@inject Microsoft.Extensions.Localization.IStringLocalizer<MailArchiver.SharedResource> Localizer
 @model MailArchiver.Models.BatchRestoreJob
 @{
     ViewData["Title"] = Localizer["BatchRestoreStatusTitle"];
@@ -42,7 +42,7 @@
                     <div class="mb-3">
                         <div class="d-flex justify-content-between align-items-center mb-1">
                             <span class="small text-muted">@Localizer["ProgressLabel"]</span>
-                            <span class="small fw-bold">@progressPercent.ToString("F1")%</span>
+                            <span class="small fw-bold">@progressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%</span>
                         </div>
                         <div class="progress" style="height: 25px;">
                             <div class="progress-bar progress-bar-striped @(Model.Status == BatchRestoreJobStatus.Running ? "progress-bar-animated" : "")" 
@@ -53,7 +53,7 @@
                                  aria-valuemax="100">
                                 @if (progressPercent > 10)
                                 {
-                                    <span class="fw-bold">@progressPercent.ToString("F1")%</span>
+                                    <span class="fw-bold">@progressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%</span>
                                 }
                             </div>
                         </div>

--- a/Views/Emails/EmailDeletionStatus.cshtml
+++ b/Views/Emails/EmailDeletionStatus.cshtml
@@ -100,7 +100,7 @@
                     <div class="progress" style="height: 25px;">
                         <div class="progress-bar progress-bar-striped progress-bar-animated" 
                              role="progressbar" 
-                             style="width: @emailProgress.ToString("F1")%"
+                             style="width: @emailProgress.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%"
                              aria-valuenow="@emailProgress.ToString("F1")" 
                              aria-valuemin="0" 
                              aria-valuemax="100">
@@ -116,7 +116,7 @@
                         <div class="progress" style="height: 25px;">
                             <div class="progress-bar progress-bar-striped progress-bar-animated bg-info" 
                                  role="progressbar" 
-                                 style="width: @attachmentProgress.ToString("F1")%"
+                                 style="width: @attachmentProgress.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%"
                                  aria-valuenow="@attachmentProgress.ToString("F1")" 
                                  aria-valuemin="0" 
                                  aria-valuemax="100">

--- a/Views/Emails/EmailDeletionStatus.cshtml
+++ b/Views/Emails/EmailDeletionStatus.cshtml
@@ -101,10 +101,10 @@
                         <div class="progress-bar progress-bar-striped progress-bar-animated" 
                              role="progressbar" 
                              style="width: @emailProgress.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%"
-                             aria-valuenow="@emailProgress.ToString("F1")" 
+                             aria-valuenow="@emailProgress.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)" 
                              aria-valuemin="0" 
                              aria-valuemax="100">
-                            @emailProgress.ToString("F1")%
+                            @emailProgress.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%
                         </div>
                     </div>
                 </div>
@@ -117,10 +117,10 @@
                             <div class="progress-bar progress-bar-striped progress-bar-animated bg-info" 
                                  role="progressbar" 
                                  style="width: @attachmentProgress.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%"
-                                 aria-valuenow="@attachmentProgress.ToString("F1")" 
+                                 aria-valuenow="@attachmentProgress.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)" 
                                  aria-valuemin="0" 
                                  aria-valuemax="100">
-                                @attachmentProgress.ToString("F1")%
+                                @attachmentProgress.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%
                             </div>
                         </div>
                     </div>

--- a/Views/Emails/SelectedEmailsExportStatus.cshtml
+++ b/Views/Emails/SelectedEmailsExportStatus.cshtml
@@ -49,7 +49,7 @@
                     <div class="mb-3">
                         <div class="d-flex justify-content-between align-items-center mb-1">
                             <span class="small text-muted">@Localizer["ProgressLabel"]</span>
-                            <span class="small fw-bold">@progressPercent.ToString("F1")%</span>
+                            <span class="small fw-bold">@progressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%</span>
                         </div>
                         <div class="progress" style="height: 25px;">
                             <div class="progress-bar progress-bar-striped @(Model.Status == SelectedEmailsExportJobStatus.Running ? "progress-bar-animated" : "")" 
@@ -60,7 +60,7 @@
                                  aria-valuemax="100">
                                 @if (progressPercent > 10)
                                 {
-                                    <span class="fw-bold">@progressPercent.ToString("F1")%</span>
+                                    <span class="fw-bold">@progressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%</span>
                                 }
                             </div>
                         </div>

--- a/Views/MailAccounts/DeletionStatus.cshtml
+++ b/Views/MailAccounts/DeletionStatus.cshtml
@@ -113,10 +113,10 @@
                                             <div class="progress-bar progress-bar-striped progress-bar-animated bg-danger" 
                                                  role="progressbar" 
                                                  style="width: @emailProgressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%"
-                                                 aria-valuenow="@emailProgressPercent.ToString("F1")" 
+                                                 aria-valuenow="@emailProgressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)" 
                                                  aria-valuemin="0" 
                                                  aria-valuemax="100">
-                                                @emailProgressPercent.ToString("F1")%
+                                                @emailProgressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%
                                             </div>
                                         </div>
                                         <small class="text-muted">@Model.DeletedEmails.ToString("N0") / @Model.TotalEmails.ToString("N0") @Localizer["Emails"]</small>
@@ -132,10 +132,10 @@
                                             <div class="progress-bar progress-bar-striped progress-bar-animated bg-warning" 
                                                  role="progressbar" 
                                                  style="width: @attachmentProgressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%"
-                                                 aria-valuenow="@attachmentProgressPercent.ToString("F1")" 
+                                                 aria-valuenow="@attachmentProgressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)" 
                                                  aria-valuemin="0" 
                                                  aria-valuemax="100">
-                                                @attachmentProgressPercent.ToString("F1")%
+                                                @attachmentProgressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%
                                             </div>
                                         </div>
                                         <small class="text-muted">@Model.DeletedAttachments.ToString("N0") / @Model.TotalAttachments.ToString("N0") @Localizer["Attachments"]</small>

--- a/Views/MailAccounts/DeletionStatus.cshtml
+++ b/Views/MailAccounts/DeletionStatus.cshtml
@@ -112,7 +112,7 @@
                                         <div class="progress">
                                             <div class="progress-bar progress-bar-striped progress-bar-animated bg-danger" 
                                                  role="progressbar" 
-                                                 style="width: @emailProgressPercent.ToString("F1")%" 
+                                                 style="width: @emailProgressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%"
                                                  aria-valuenow="@emailProgressPercent.ToString("F1")" 
                                                  aria-valuemin="0" 
                                                  aria-valuemax="100">
@@ -131,7 +131,7 @@
                                         <div class="progress">
                                             <div class="progress-bar progress-bar-striped progress-bar-animated bg-warning" 
                                                  role="progressbar" 
-                                                 style="width: @attachmentProgressPercent.ToString("F1")%" 
+                                                 style="width: @attachmentProgressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%"
                                                  aria-valuenow="@attachmentProgressPercent.ToString("F1")" 
                                                  aria-valuemin="0" 
                                                  aria-valuemax="100">

--- a/Views/MailAccounts/EmlImportStatus.cshtml
+++ b/Views/MailAccounts/EmlImportStatus.cshtml
@@ -106,7 +106,7 @@
                                     <span>@Localizer["FileProcessingProgress"]</span>
                                 }
                             </span>
-                            <span class="small fw-bold">@displayPercent.ToString("F1")%</span>
+                            <span class="small fw-bold">@displayPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%</span>
                         </div>
                         <div class="progress" style="height: 25px;">
                             <div class="progress-bar progress-bar-striped @(Model.Status == MailArchiver.Models.EmlImportJobStatus.Running ? "progress-bar-animated" : "")"
@@ -117,7 +117,7 @@
                                  aria-valuemax="100">
                                 @if (displayPercent > 10)
                                 {
-                                    <span class="fw-bold">@displayPercent.ToString("F1")%</span>
+                                    <span class="fw-bold">@displayPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%</span>
                                 }
                             </div>
                         </div>

--- a/Views/MailAccounts/ExportStatus.cshtml
+++ b/Views/MailAccounts/ExportStatus.cshtml
@@ -125,7 +125,7 @@
                                 <div class="progress mb-2">
                                     <div class="progress-bar progress-bar-striped progress-bar-animated" 
                                          role="progressbar" 
-                                         style="width: @progressPercent.ToString("F1")%" 
+                                         style="width: @progressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%"
                                          aria-valuenow="@progressPercent.ToString("F1")" 
                                          aria-valuemin="0" 
                                          aria-valuemax="100">

--- a/Views/MailAccounts/ExportStatus.cshtml
+++ b/Views/MailAccounts/ExportStatus.cshtml
@@ -126,10 +126,10 @@
                                     <div class="progress-bar progress-bar-striped progress-bar-animated" 
                                          role="progressbar" 
                                          style="width: @progressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%"
-                                         aria-valuenow="@progressPercent.ToString("F1")" 
+                                         aria-valuenow="@progressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)" 
                                          aria-valuemin="0" 
                                          aria-valuemax="100">
-                                        @progressPercent.ToString("F1")%
+                                        @progressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%
                                     </div>
                                 </div>
                                 

--- a/Views/MailAccounts/MBoxImportStatus.cshtml
+++ b/Views/MailAccounts/MBoxImportStatus.cshtml
@@ -107,7 +107,7 @@
                                     <span>@Localizer["FileProcessingProgress"]</span>
                                 }
                             </span>
-                            <span class="small fw-bold">@displayPercent.ToString("F1")%</span>
+                            <span class="small fw-bold">@displayPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%</span>
                         </div>
                         <div class="progress" style="height: 25px;">
                             <div class="progress-bar progress-bar-striped @(Model.Status == MailArchiver.Models.MBoxImportJobStatus.Running ? "progress-bar-animated" : "")"
@@ -118,7 +118,7 @@
                                  aria-valuemax="100">
                                 @if (displayPercent > 10)
                                 {
-                                    <span class="fw-bold">@displayPercent.ToString("F1")%</span>
+                                    <span class="fw-bold">@displayPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%</span>
                                 }
                             </div>
                         </div>


### PR DESCRIPTION
## Motivation
Under cultures that use a comma as the decimal separator (e.g. `de-DE`), `double.ToString("F1")` renders `42.5` as `42,5`. Several progress bar views embedded this directly into inline CSS `width` values and ARIA attributes, e.g. `style="width: 42,5%"`, which is invalid CSS - the browser ignores the whole declaration and the bar collapses to its text width instead of showing the actual percentage.

Additionally, while working on the email deletion progress reporting in this branch, a separate bug was found and fixed: access-log writes for deleted emails were parallelized with `Task.WhenAll`, but each call ran `SaveChangesAsync` on the same scoped `DbContext` concurrently. EF Core's `DbContext`/change tracker is not thread-safe, so this could corrupt tracker state and throw `InvalidOperationException: The instance of entity type 'AccessLog' cannot be tracked because another instance with the same key value ... is already being tracked`, causing the whole deletion job to fail even though the emails had already been removed.

## What's new
- All progress bar `width` styles, `aria-valuenow` attributes, and displayed percentage text across the app now format with `CultureInfo.InvariantCulture`, so the separator is always `.` regardless of server/browser locale.
- Fixes the same issue for deletion, restore, export, and import status views (email deletion, mail account deletion, batch restore, selected-email export, EML import, MBox import, account export).
- Improves email deletion progress reporting: the progress counter is now updated immediately per batch instead of after the access-log writes, so large batches no longer appear stuck at 0% for tens of seconds before the counter moves.
- Fixes a crash during mass/folder email deletion: access-log entries for a batch are now built and added to the `DbContext` together with the email removal, and persisted in a single `SaveChangesAsync` call instead of via concurrent per-email calls - avoiding the thread-safety violation described above.

## How it works
`ToString("F1")` -> `ToString("F1", CultureInfo.InvariantCulture)` everywhere a formatted double feeds into CSS/HTML output. No behavior change for `en`-based locales; fixes rendering under `de` and other comma-decimal cultures.

For the deletion job, access-log entries are now constructed as plain objects and added via `context.AccessLogs.AddRange(...)`, then saved in the same `SaveChangesAsync` call used to remove the batch's emails - all on the single-threaded job loop, so there's no concurrent access to the context.

## Test plan
- [x] Verified progress bars fill correctly under `de-DE` culture (previously collapsed to text width)
- [x] Verified `aria-valuenow` now emits `.`-separated values
- [x] Verified email deletion progress updates promptly instead of appearing stuck at 0%
- [x] Verified mass-deleting a folder with 95 emails / 2 attachments completes successfully and no longer throws the `AccessLog` tracking exception
