### PR TITLE
Fix TestDbFixture configuration precedence

### DIFF
--- a/tests/MailArchiver.Tests/Infrastructure/TestDbFixture.cs
+++ b/tests/MailArchiver.Tests/Infrastructure/TestDbFixture.cs
@@ -109,13 +109,18 @@ public class TestDbFixture : IAsyncLifetime
         var baseDir = AppContext.BaseDirectory;
         var repoRoot = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", ".."));
 
+        // Order matters: later sources override earlier ones, so this list runs from
+        // lowest to highest precedence to match the order documented on the class.
+        // The repo-root files come first because appsettings.json is committed with the
+        // Docker default (Host=postgres); listing it after appsettings.Test.json would
+        // let it override every per-developer setting, which is what used to happen.
         var builder = new ConfigurationBuilder()
             .SetBasePath(baseDir)
+            .AddJsonFile(Path.Combine(repoRoot, "appsettings.json"), optional: true, reloadOnChange: false)
+            .AddJsonFile(Path.Combine(repoRoot, "appsettings.Development.json"), optional: true, reloadOnChange: false)
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
             .AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: false)
             .AddJsonFile("appsettings.Test.json", optional: true, reloadOnChange: false)
-            .AddJsonFile(Path.Combine(repoRoot, "appsettings.json"), optional: true, reloadOnChange: false)
-            .AddJsonFile(Path.Combine(repoRoot, "appsettings.Development.json"), optional: true, reloadOnChange: false)
             .AddEnvironmentVariables(prefix: "MailArchiverTest__");
 
         return builder.Build();


### PR DESCRIPTION
The class documents appsettings.Test.json as the highest-precedence source, but the repo-root appsettings.json was added to the ConfigurationBuilder after it. Later sources win, and the repo-root file is committed with the Docker default Host=postgres, so it overrode every per-developer setting and the documented override mechanism could never take effect.

Symptom: a correct tests/MailArchiver.Tests/appsettings.Test.json is ignored and the DB-backed tests fail with "Name or service not known" while trying to resolve the hostname "postgres".

The sources are now added lowest to highest precedence, matching the order the class documents. The environment variable source stays last.