### PR TITLE
Feature - Date-windowed offload into another mailbox

### DIFF
--- a/Controllers/MailAccountsController.cs
+++ b/Controllers/MailAccountsController.cs
@@ -4,6 +4,7 @@ using MailArchiver.Models.ViewModels;
 using MailArchiver.ViewModels;
 using MailArchiver.Services;
 using MailArchiver.Services.Providers;
+using MailArchiver.Services.Shared;
 using MailArchiver.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -121,6 +122,15 @@ namespace MailArchiver.Controllers
             _logger.LogInformation("User has no special permissions, denying access to account {AccountId}", accountId);
             return false;
         }
+
+        /// <summary>
+        /// The acting user's account scope, taken from the resolver the REST API and the MCP
+        /// server already delegate to, so the offload form does not grow a second notion of who
+        /// may use which mailbox. Null means admin, i.e. every account; an empty list means none.
+        /// </summary>
+        private async Task<List<int>?> GetAllowedAccountIdsAsync()
+            => await HttpContext.RequestServices.GetRequiredService<IAccountAccessResolver>()
+                .GetAllowedAccountIdsAsync(HttpContext);
 
         // GET: MailAccounts
         public async Task<IActionResult> Index()
@@ -1404,24 +1414,32 @@ namespace MailArchiver.Controllers
             var account = await _context.MailAccounts.FindAsync(id);
             if (account == null) return NotFound();
 
-            if (model.TargetAccountId == id)
-            {
-                ModelState.AddModelError(nameof(model.TargetAccountId), _localizer["OffloadTargetMustDiffer"].Value);
-            }
-
+            // This is the boundary, not the dropdown. A post can name any account ID, so the
+            // target is decided here, through the same rules that filtered the list.
+            var allowedAccountIds = await GetAllowedAccountIdsAsync();
             var target = await _context.MailAccounts.FindAsync(model.TargetAccountId);
-            if (target == null)
+            var rejection = OffloadTargetEligibility.Evaluate(
+                target == null ? null : new OffloadTargetCandidate
+                {
+                    Id = target.Id,
+                    // The Graph restore path is untouched by this feature.
+                    Provider = target.Provider,
+                    IsEnabled = target.IsEnabled,
+                    IsAccessible = OffloadTargetEligibility.IsAccessible(target.Id, allowedAccountIds),
+                },
+                id);
+
+            if (rejection != OffloadTargetRejection.None)
             {
-                ModelState.AddModelError(nameof(model.TargetAccountId), _localizer["OffloadTargetNotFound"].Value);
-            }
-            else if (target.Provider != ProviderType.IMAP)
-            {
-                // The Graph restore path is untouched by this feature.
-                ModelState.AddModelError(nameof(model.TargetAccountId), _localizer["OffloadTargetMustBeImap"].Value);
-            }
-            else if (!target.IsEnabled)
-            {
-                ModelState.AddModelError(nameof(model.TargetAccountId), _localizer["OffloadTargetDisabled"].Value);
+                // Being handed a target one may not use is worth noticing, and worth noticing
+                // repeatedly; picking the source or a disabled account is an ordinary form slip.
+                _logger.Log(
+                    rejection == OffloadTargetRejection.NotAccessible ? LogLevel.Warning : LogLevel.Information,
+                    "Rejected offload target {TargetId} for source {SourceId} requested by {User}: {Reason}",
+                    model.TargetAccountId, id, User?.Identity?.Name ?? "unknown", rejection);
+                ModelState.AddModelError(
+                    nameof(model.TargetAccountId),
+                    _localizer[OffloadTargetEligibility.MessageKey(rejection)].Value);
             }
 
             // Resolved to an absolute date here, once, so a repeat of this job selects the same
@@ -1515,16 +1533,38 @@ namespace MailArchiver.Controllers
 
         private async Task<OffloadViewModel> BuildOffloadViewModelAsync(MailAccount account)
         {
-            var targets = await _context.MailAccounts
-                .Where(a => a.Id != account.Id && a.IsEnabled && a.Provider == ProviderType.IMAP)
+            // Narrowed in SQL first, so a mailbox the user may not use is never even
+            // materialised, and then decided by OffloadTargetEligibility, so what this list
+            // offers and what the post accepts cannot drift apart.
+            var allowedAccountIds = await GetAllowedAccountIdsAsync();
+            var candidateQuery = _context.MailAccounts.AsQueryable();
+            if (allowedAccountIds != null)
+            {
+                candidateQuery = candidateQuery.Where(a => allowedAccountIds.Contains(a.Id));
+            }
+
+            var candidates = await candidateQuery
                 .OrderBy(a => a.Name)
+                .Select(a => new { a.Id, a.Name, a.EmailAddress, a.Provider, a.IsEnabled })
+                .ToListAsync();
+
+            var targets = candidates
+                .Where(a => OffloadTargetEligibility.IsEligible(
+                    new OffloadTargetCandidate
+                    {
+                        Id = a.Id,
+                        Provider = a.Provider,
+                        IsEnabled = a.IsEnabled,
+                        IsAccessible = OffloadTargetEligibility.IsAccessible(a.Id, allowedAccountIds),
+                    },
+                    account.Id))
                 .Select(a => new OffloadViewModel.TargetAccountOption
                 {
                     Id = a.Id,
                     Name = a.Name,
                     EmailAddress = a.EmailAddress,
                 })
-                .ToListAsync();
+                .ToList();
 
             return new OffloadViewModel
             {
@@ -1532,6 +1572,7 @@ namespace MailArchiver.Controllers
                 SourceAccountName = account.Name,
                 SourceTotalEmails = await _context.ArchivedEmails.CountAsync(e => e.MailAccountId == account.Id),
                 AvailableTargets = targets,
+                TargetsAreScopedToUser = allowedAccountIds != null,
                 ExcludedSourceFolders = _offloadOptions.ExcludedSourceFolders,
                 FolderRenameMap = _offloadOptions.FolderRenameMap,
                 MarkAsSeen = _offloadOptions.MarkAsSeen,

--- a/Controllers/MailAccountsController.cs
+++ b/Controllers/MailAccountsController.cs
@@ -59,7 +59,9 @@ namespace MailArchiver.Controllers
         IMsaOAuthService msaOAuthService,
         IOptions<MsaOAuthOptions> msaOptions,
         IAccountStorageService accountStorageService,
-        IOptions<CsvImportOptions> csvImportOptions)
+        IOptions<CsvImportOptions> csvImportOptions,
+        IOptions<OffloadOptions> offloadOptions,
+        IBatchRestoreService batchRestoreService)
     {
         _context = context;
         _emailCoreService = emailCoreService;
@@ -81,7 +83,12 @@ namespace MailArchiver.Controllers
         _msaOptions = msaOptions.Value;
         _accountStorageService = accountStorageService;
         _csvImportOptions = csvImportOptions.Value;
+        _offloadOptions = offloadOptions.Value;
+        _batchRestoreService = batchRestoreService;
     }
+
+        private readonly OffloadOptions _offloadOptions;
+        private readonly IBatchRestoreService _batchRestoreService;
 
         private async Task<bool> HasAccessToAccountAsync(int accountId)
         {
@@ -1372,6 +1379,163 @@ namespace MailArchiver.Controllers
             }
 
             return RedirectToAction(nameof(Details), new { id });
+        }
+
+        // GET: MailAccounts/Offload/5
+        [HttpGet]
+        public async Task<IActionResult> Offload(int id)
+        {
+            if (!await HasAccessToAccountAsync(id)) return NotFound();
+
+            var account = await _context.MailAccounts.FindAsync(id);
+            if (account == null) return NotFound();
+
+            var model = await BuildOffloadViewModelAsync(account);
+            return View(model);
+        }
+
+        // POST: MailAccounts/Offload/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Offload(int id, OffloadViewModel model)
+        {
+            if (!await HasAccessToAccountAsync(id)) return NotFound();
+
+            var account = await _context.MailAccounts.FindAsync(id);
+            if (account == null) return NotFound();
+
+            if (model.TargetAccountId == id)
+            {
+                ModelState.AddModelError(nameof(model.TargetAccountId), _localizer["OffloadTargetMustDiffer"].Value);
+            }
+
+            var target = await _context.MailAccounts.FindAsync(model.TargetAccountId);
+            if (target == null)
+            {
+                ModelState.AddModelError(nameof(model.TargetAccountId), _localizer["OffloadTargetNotFound"].Value);
+            }
+            else if (target.Provider != ProviderType.IMAP)
+            {
+                // The Graph restore path is untouched by this feature.
+                ModelState.AddModelError(nameof(model.TargetAccountId), _localizer["OffloadTargetMustBeImap"].Value);
+            }
+            else if (!target.IsEnabled)
+            {
+                ModelState.AddModelError(nameof(model.TargetAccountId), _localizer["OffloadTargetDisabled"].Value);
+            }
+
+            // Resolved to an absolute date here, once, so a repeat of this job selects the same
+            // mail even if it runs days later.
+            var nowDisplay = DateTime.UtcNow;
+            DateTime cutoffFrom;
+            if (model.CutoffFrom.HasValue)
+            {
+                cutoffFrom = MailArchiver.Services.Shared.OffloadCutoff.FromAbsolute(model.CutoffFrom.Value);
+            }
+            else if (model.WindowMonths > 0)
+            {
+                cutoffFrom = MailArchiver.Services.Shared.OffloadCutoff.FromRelativeMonths(nowDisplay, model.WindowMonths);
+            }
+            else
+            {
+                ModelState.AddModelError(nameof(model.CutoffFrom), _localizer["OffloadCutoffRequired"].Value);
+                cutoffFrom = default;
+            }
+
+            if (model.CutoffTo.HasValue && model.CutoffTo.Value.Date < cutoffFrom.Date)
+            {
+                ModelState.AddModelError(nameof(model.CutoffTo), _localizer["OffloadCutoffToBeforeFrom"].Value);
+            }
+
+            if (!ModelState.IsValid)
+            {
+                var redisplay = await BuildOffloadViewModelAsync(account);
+                redisplay.TargetAccountId = model.TargetAccountId;
+                redisplay.TargetFolder = model.TargetFolder;
+                redisplay.PreserveFolderStructure = model.PreserveFolderStructure;
+                redisplay.WindowMonths = model.WindowMonths;
+                redisplay.CutoffFrom = model.CutoffFrom;
+                redisplay.CutoffTo = model.CutoffTo;
+                redisplay.DryRun = model.DryRun;
+                redisplay.MarkAsSeen = model.MarkAsSeen;
+                return View(redisplay);
+            }
+
+            var upper = model.CutoffTo?.Date.AddDays(1).AddSeconds(-1);
+            var countQuery = _context.ArchivedEmails
+                .Where(e => e.MailAccountId == id && e.SentDate >= cutoffFrom);
+            if (upper.HasValue) countQuery = countQuery.Where(e => e.SentDate <= upper.Value);
+            var resolvedCount = await countQuery.CountAsync();
+
+            if (resolvedCount == 0)
+            {
+                TempData["ErrorMessage"] = _localizer["OffloadNothingInWindow"].Value;
+                return RedirectToAction(nameof(Offload), new { id });
+            }
+
+            // Kept as a sanity guard rather than the binding constraint it used to be: a date
+            // window brings even a very large mailbox well under this.
+            if (resolvedCount > _batchOptions.MaxAsyncEmails)
+            {
+                TempData["ErrorMessage"] = _localizer["TooManyEmailsInAccount", resolvedCount, _batchOptions.MaxAsyncEmails].Value;
+                return RedirectToAction(nameof(Offload), new { id });
+            }
+
+            var job = new BatchRestoreJob
+            {
+                TargetAccountId = model.TargetAccountId,
+                TargetFolder = string.IsNullOrWhiteSpace(model.TargetFolder) ? "INBOX" : model.TargetFolder.Trim(),
+                PreserveFolderStructure = model.PreserveFolderStructure,
+                UserId = User?.Identity?.Name ?? "System",
+                ReturnUrl = Url.Action(nameof(Details), new { id }) ?? "/",
+                Offload = new OffloadCriteria
+                {
+                    SourceAccountId = id,
+                    CutoffFrom = cutoffFrom,
+                    CutoffTo = model.CutoffTo,
+                    ExcludedSourceFolders = _offloadOptions.ExcludedSourceFolders,
+                    FolderRenameMap = _offloadOptions.FolderRenameMap,
+                    MarkAsSeen = model.MarkAsSeen,
+                    DryRun = model.DryRun,
+                },
+            };
+
+            var jobId = _batchRestoreService.QueueJob(job);
+
+            _logger.LogInformation(
+                "Queued offload job {JobId}: {Count} mails from account {SourceId} to {TargetId}, window {Window}, dry run {DryRun}",
+                jobId, resolvedCount, id, model.TargetAccountId, job.Offload.DescribeWindow(), model.DryRun);
+
+            TempData["SuccessMessage"] = model.DryRun
+                ? _localizer["OffloadDryRunQueued", resolvedCount].Value
+                : _localizer["OffloadQueued", resolvedCount].Value;
+
+            return RedirectToAction("BatchRestoreStatus", "Emails", new { jobId });
+        }
+
+        private async Task<OffloadViewModel> BuildOffloadViewModelAsync(MailAccount account)
+        {
+            var targets = await _context.MailAccounts
+                .Where(a => a.Id != account.Id && a.IsEnabled && a.Provider == ProviderType.IMAP)
+                .OrderBy(a => a.Name)
+                .Select(a => new OffloadViewModel.TargetAccountOption
+                {
+                    Id = a.Id,
+                    Name = a.Name,
+                    EmailAddress = a.EmailAddress,
+                })
+                .ToListAsync();
+
+            return new OffloadViewModel
+            {
+                SourceAccountId = account.Id,
+                SourceAccountName = account.Name,
+                SourceTotalEmails = await _context.ArchivedEmails.CountAsync(e => e.MailAccountId == account.Id),
+                AvailableTargets = targets,
+                ExcludedSourceFolders = _offloadOptions.ExcludedSourceFolders,
+                FolderRenameMap = _offloadOptions.FolderRenameMap,
+                MarkAsSeen = _offloadOptions.MarkAsSeen,
+            };
         }
 
         // POST: MailAccounts/MoveAllEmails/5

--- a/Models/BatchRestoreJob.cs
+++ b/Models/BatchRestoreJob.cs
@@ -24,6 +24,26 @@ namespace MailArchiver.Models
         public int FailedCount { get; set; }
         public string? ErrorMessage { get; set; }
         public string ReturnUrl { get; set; } = "";
+
+        /// <summary>
+        /// When set, the job is a date-windowed offload and resolves its own set of mail from
+        /// these criteria instead of carrying a materialised list in <see cref="EmailIds"/>.
+        /// Null keeps the existing behaviour exactly, so the checkbox selection path is
+        /// unaffected.
+        /// </summary>
+        public OffloadCriteria? Offload { get; set; }
+
+        public bool IsOffload => Offload != null;
+
+        // Offload counters, using the vocabulary of the import job so that repeating a finished
+        // job reads as a verification pass: nothing appended, everything already present.
+        public int AppendedCount { get; set; }
+        public int SkippedAlreadyPresentCount { get; set; }
+        public int MatchedByFingerprintCount { get; set; }
+        public int SkippedExcludedFolderCount { get; set; }
+
+        /// <summary>Per-folder report, shown for a dry run where the button is.</summary>
+        public string? Report { get; set; }
     }
 
     public enum BatchRestoreJobStatus

--- a/Models/OffloadCriteria.cs
+++ b/Models/OffloadCriteria.cs
@@ -1,0 +1,54 @@
+// Models/OffloadCriteria.cs
+namespace MailArchiver.Models
+{
+    /// <summary>
+    /// What an offload job selects and how it maps folders, carried instead of a materialised
+    /// list of email ids.
+    /// <para>
+    /// The worker resolves the ids itself from these criteria. That removes the need to push up
+    /// to fifty thousand ids through session state, and it turns the batch restore ceiling into
+    /// a sanity check on the resolved count rather than the binding constraint it is today.
+    /// </para>
+    /// <para>
+    /// The cutoffs are absolute. A relative expression such as "the last six months" is resolved
+    /// once, when the job is created, because a job may run for a long time and be repeated
+    /// afterwards and has to select the same mail every time.
+    /// </para>
+    /// </summary>
+    public class OffloadCriteria
+    {
+        public int SourceAccountId { get; set; }
+
+        /// <summary>
+        /// Inclusive lower bound on <c>SentDate</c>, interpreted in the configured display
+        /// timezone because that is the timezone the column is stored in.
+        /// </summary>
+        public DateTime CutoffFrom { get; set; }
+
+        /// <summary>
+        /// Optional upper bound. The whole of this day is inside the window, matching the
+        /// semantics of the existing search filter.
+        /// </summary>
+        public DateTime? CutoffTo { get; set; }
+
+        /// <summary>Source folders never offloaded. Matched before any rename is applied.</summary>
+        public List<string> ExcludedSourceFolders { get; set; } = new();
+
+        /// <summary>Rewrites the leading path segments of a source folder.</summary>
+        public Dictionary<string, string> FolderRenameMap { get; set; } = new();
+
+        /// <summary>Whether appended mail is flagged as read.</summary>
+        public bool MarkAsSeen { get; set; } = true;
+
+        /// <summary>
+        /// Resolves everything and reports what would happen, but appends nothing.
+        /// </summary>
+        public bool DryRun { get; set; }
+
+        /// <summary>Human readable description of the window, for logs and the job list.</summary>
+        public string DescribeWindow()
+            => CutoffTo.HasValue
+                ? $"{CutoffFrom:yyyy-MM-dd} .. {CutoffTo.Value:yyyy-MM-dd}"
+                : $"from {CutoffFrom:yyyy-MM-dd}";
+    }
+}

--- a/Models/OffloadOptions.cs
+++ b/Models/OffloadOptions.cs
@@ -1,0 +1,45 @@
+// Models/OffloadOptions.cs
+namespace MailArchiver.Models
+{
+    /// <summary>
+    /// Settings for the date-windowed offload of archived mail into another mailbox.
+    /// Every default reproduces the behaviour the application had before the feature
+    /// existed, so an installation that does not configure this section is unaffected.
+    /// </summary>
+    public class OffloadOptions
+    {
+        public const string Offload = "Offload";
+
+        /// <summary>
+        /// How many offload jobs may run at the same time. One keeps the strictly serial
+        /// processing the batch restore service has always used.
+        /// </summary>
+        public int MaxConcurrentJobs { get; set; } = 1;
+
+        /// <summary>
+        /// Upper bound on the number of messages indexed from a target mailbox before the
+        /// duplicate check narrows its scope from the whole mailbox to a single folder.
+        /// Guards memory on an unexpectedly large target.
+        /// </summary>
+        public int PrefetchMaxMessages { get; set; } = 500_000;
+
+        /// <summary>
+        /// Source folders that are never offloaded, matched before any rename is applied and
+        /// covering their descendants. Empty by default: rewriting or dropping folders without
+        /// being asked to would surprise existing users.
+        /// </summary>
+        public List<string> ExcludedSourceFolders { get; set; } = new();
+
+        /// <summary>
+        /// Rewrites the leading path segments of a source folder, for example
+        /// "Sent Items" to "Sent". Empty by default, for the same reason as above.
+        /// </summary>
+        public Dictionary<string, string> FolderRenameMap { get; set; } = new();
+
+        /// <summary>
+        /// Whether appended mail is flagged as read. True reproduces the behaviour of the
+        /// existing restore path, which always appended with <c>MessageFlags.Seen</c>.
+        /// </summary>
+        public bool MarkAsSeen { get; set; } = true;
+    }
+}

--- a/Models/OffloadOutcome.cs
+++ b/Models/OffloadOutcome.cs
@@ -80,7 +80,7 @@ namespace MailArchiver.Models
                 ? $"Would append:          {Appended}"
                 : $"Appended:              {Appended}");
             sb.AppendLine($"Already present:       {SkippedAlreadyPresent}");
-            sb.AppendLine($"  of those by finger.: {MatchedByFingerprint}");
+            sb.AppendLine($"  of those by fingerprint: {MatchedByFingerprint}");
             sb.AppendLine($"Excluded folder:       {SkippedExcludedFolder}");
             sb.AppendLine($"Failed:                {Failed}");
 

--- a/Models/OffloadOutcome.cs
+++ b/Models/OffloadOutcome.cs
@@ -1,0 +1,108 @@
+// Models/OffloadOutcome.cs
+using System.Text;
+
+namespace MailArchiver.Models
+{
+    /// <summary>
+    /// What an offload actually did, per target folder.
+    /// </summary>
+    public class OffloadFolderOutcome
+    {
+        public int Appended { get; set; }
+        public int SkippedAlreadyPresent { get; set; }
+        public int MatchedByFingerprint { get; set; }
+        public int Failed { get; set; }
+
+        public int Total => Appended + SkippedAlreadyPresent + Failed;
+    }
+
+    /// <summary>
+    /// Totals and a per-folder breakdown for one offload job.
+    /// <para>
+    /// The vocabulary follows the import job, which already reports a skipped-already-exists
+    /// count, so that repeating a finished job is a legitimate verification pass: a correct
+    /// implementation reports nothing appended and everything already present.
+    /// </para>
+    /// </summary>
+    public class OffloadOutcome
+    {
+        /// <summary>Messages appended to the target mailbox.</summary>
+        public int Appended { get; set; }
+
+        /// <summary>Messages the target mailbox already held, by either criterion.</summary>
+        public int SkippedAlreadyPresent { get; set; }
+
+        /// <summary>
+        /// How many of <see cref="SkippedAlreadyPresent"/> were recognised by the fingerprint
+        /// rather than by Message-ID. Reported separately because it is the criterion that can
+        /// fail silently, so a plausible number here is evidence that it works.
+        /// </summary>
+        public int MatchedByFingerprint { get; set; }
+
+        /// <summary>Messages skipped because their source folder is excluded.</summary>
+        public int SkippedExcludedFolder { get; set; }
+
+        /// <summary>Messages that could not be appended.</summary>
+        public int Failed { get; set; }
+
+        /// <summary>True when nothing was actually written.</summary>
+        public bool DryRun { get; set; }
+
+        /// <summary>
+        /// True when the duplicate index covered less than the whole target mailbox, so a
+        /// repeated run could append mail that is already present somewhere unindexed.
+        /// </summary>
+        public bool DuplicateScopeReduced { get; set; }
+
+        public Dictionary<string, OffloadFolderOutcome> PerFolder { get; } = new();
+
+        public int Considered => Appended + SkippedAlreadyPresent + SkippedExcludedFolder + Failed;
+
+        public OffloadFolderOutcome Folder(string path)
+        {
+            if (!PerFolder.TryGetValue(path, out var outcome))
+            {
+                outcome = new OffloadFolderOutcome();
+                PerFolder[path] = outcome;
+            }
+            return outcome;
+        }
+
+        /// <summary>Legacy shape, for the call sites that still expect a success/fail pair.</summary>
+        public (int Successful, int Failed) AsTuple() => (Appended, Failed);
+
+        public string Describe()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine(DryRun ? "=== Offload dry run ===" : "=== Offload ===");
+            sb.AppendLine($"Considered:            {Considered}");
+            sb.AppendLine(DryRun
+                ? $"Would append:          {Appended}"
+                : $"Appended:              {Appended}");
+            sb.AppendLine($"Already present:       {SkippedAlreadyPresent}");
+            sb.AppendLine($"  of those by finger.: {MatchedByFingerprint}");
+            sb.AppendLine($"Excluded folder:       {SkippedExcludedFolder}");
+            sb.AppendLine($"Failed:                {Failed}");
+
+            if (DuplicateScopeReduced)
+            {
+                sb.AppendLine("WARNING: the duplicate index did not cover the whole target mailbox.");
+            }
+
+            if (PerFolder.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("Per target folder:");
+                foreach (var entry in PerFolder.OrderBy(e => e.Key, StringComparer.OrdinalIgnoreCase))
+                {
+                    var f = entry.Value;
+                    sb.AppendLine($"  {entry.Key}");
+                    sb.AppendLine($"      appended {f.Appended}, already present {f.SkippedAlreadyPresent} " +
+                                  $"(fingerprint {f.MatchedByFingerprint}), failed {f.Failed}");
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -114,6 +114,9 @@ builder.Services.Configure<BatchOperationOptions>(
     builder.Configuration.GetSection(BatchOperationOptions.BatchOperation));
 
 // Add Tenant Management Options
+builder.Services.Configure<OffloadOptions>(
+    builder.Configuration.GetSection(OffloadOptions.Offload));
+
 builder.Services.Configure<TenantManagementOptions>(
     builder.Configuration.GetSection(TenantManagementOptions.TenantManagement));
 
@@ -692,6 +695,213 @@ if (cliArgs.Any(a => a == "--import-mbox" || a == "--import-eml"))
         cliLogger.LogError(ex, "CLI command failed");
         Console.WriteLine($"ERROR: {ex.Message}");
         Environment.Exit(1);
+    }
+}
+
+// Handle CLI command: date-windowed offload into another mailbox
+if (cliArgs.Any(a => a == "--offload"))
+{
+    using var offloadScope = app.Services.CreateScope();
+    var offloadServices = offloadScope.ServiceProvider;
+    var offloadLogger = offloadServices.GetRequiredService<ILogger<Program>>();
+
+    // Exit codes: 0 everything appended or already present, 1 a failure occurred,
+    // 2 the invocation itself was wrong. Distinguishing 2 from 1 matters when driving many
+    // mailboxes from a script.
+    const int ExitOk = 0, ExitFailed = 1, ExitBadArgs = 2;
+
+    string? Arg(string name)
+    {
+        var i = Array.IndexOf(cliArgs, name);
+        return i >= 0 && i + 1 < cliArgs.Length ? cliArgs[i + 1] : null;
+    }
+    bool Flag(string name) => cliArgs.Contains(name);
+
+    try
+    {
+        var sourceRaw = Arg("--source-account-id");
+        var targetRaw = Arg("--target-account-id");
+        var sinceRaw = Arg("--since");
+        var untilRaw = Arg("--until");
+        var targetFolder = Arg("--target-folder") ?? "INBOX";
+        var preserveFolders = Flag("--preserve-folders");
+        var dryRun = Flag("--dry-run");
+        var noMarkSeen = Flag("--no-mark-seen");
+
+        void Usage(string message)
+        {
+            Console.WriteLine($"ERROR: {message}");
+            Console.WriteLine();
+            Console.WriteLine("Usage:");
+            Console.WriteLine("  --offload --source-account-id N --target-account-id M --since YYYY-MM-DD");
+            Console.WriteLine("            [--until YYYY-MM-DD] [--target-folder INBOX]");
+            Console.WriteLine("            [--preserve-folders] [--dry-run] [--no-mark-seen]");
+            Console.WriteLine();
+            Console.WriteLine("Appends archived mail newer than --since into the target mailbox, skipping");
+            Console.WriteLine("anything already present there. Repeating a run is safe.");
+            Console.WriteLine();
+            Console.WriteLine("Folder exclusions and the folder rename map come from the Offload section of");
+            Console.WriteLine("appsettings.json; both are empty by default.");
+        }
+
+        if (!int.TryParse(sourceRaw, out var sourceAccountId))
+        {
+            Usage("--source-account-id <id> is required");
+            Environment.Exit(ExitBadArgs);
+        }
+        if (!int.TryParse(targetRaw, out var targetAccountId))
+        {
+            Usage("--target-account-id <id> is required");
+            Environment.Exit(ExitBadArgs);
+        }
+        if (sourceAccountId == targetAccountId)
+        {
+            Usage("source and target account must differ");
+            Environment.Exit(ExitBadArgs);
+        }
+        if (!DateTime.TryParse(sinceRaw, System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None, out var since))
+        {
+            Usage("--since <YYYY-MM-DD> is required");
+            Environment.Exit(ExitBadArgs);
+        }
+
+        DateTime? until = null;
+        if (!string.IsNullOrEmpty(untilRaw))
+        {
+            if (!DateTime.TryParse(untilRaw, System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.None, out var untilParsed))
+            {
+                Usage("--until must be YYYY-MM-DD");
+                Environment.Exit(ExitBadArgs);
+            }
+            until = untilParsed;
+            if (until.Value.Date < since.Date)
+            {
+                Usage("--until must not be earlier than --since");
+                Environment.Exit(ExitBadArgs);
+            }
+        }
+
+        var offloadDb = offloadServices.GetRequiredService<MailArchiverDbContext>();
+        var sourceAccount = await offloadDb.MailAccounts.FindAsync(sourceAccountId);
+        var targetAccount = await offloadDb.MailAccounts.FindAsync(targetAccountId);
+
+        if (sourceAccount == null)
+        {
+            Console.WriteLine($"ERROR: source account {sourceAccountId} not found");
+            Environment.Exit(ExitBadArgs);
+        }
+        if (targetAccount == null)
+        {
+            Console.WriteLine($"ERROR: target account {targetAccountId} not found");
+            Environment.Exit(ExitBadArgs);
+        }
+        if (targetAccount!.Provider != ProviderType.IMAP)
+        {
+            Console.WriteLine($"ERROR: target account '{targetAccount.Name}' is a {targetAccount.Provider} account; " +
+                              "offload targets must be IMAP");
+            Environment.Exit(ExitBadArgs);
+        }
+        // Same rule the queued job path and the UI apply, so all three agree.
+        if (!targetAccount.IsEnabled)
+        {
+            Console.WriteLine($"ERROR: target account '{targetAccount.Name}' is disabled");
+            Environment.Exit(ExitBadArgs);
+        }
+
+        var offloadOptions = offloadServices.GetRequiredService<IOptions<OffloadOptions>>().Value;
+        var batchRestoreOptions = offloadServices.GetRequiredService<IOptions<BatchRestoreOptions>>().Value;
+
+        var criteria = new OffloadCriteria
+        {
+            SourceAccountId = sourceAccountId,
+            // Resolved to an absolute date here, once, so that a repeated run selects the same mail.
+            CutoffFrom = MailArchiver.Services.Shared.OffloadCutoff.FromAbsolute(since),
+            CutoffTo = until,
+            ExcludedSourceFolders = offloadOptions.ExcludedSourceFolders,
+            FolderRenameMap = offloadOptions.FolderRenameMap,
+            MarkAsSeen = !noMarkSeen && offloadOptions.MarkAsSeen,
+            DryRun = dryRun,
+        };
+
+        var upperBound = until.HasValue ? until.Value.Date.AddDays(1).AddSeconds(-1) : (DateTime?)null;
+        var idsQuery = offloadDb.ArchivedEmails
+            .Where(e => e.MailAccountId == sourceAccountId && e.SentDate >= criteria.CutoffFrom);
+        if (upperBound.HasValue)
+            idsQuery = idsQuery.Where(e => e.SentDate <= upperBound.Value);
+
+        var emailIds = await idsQuery.OrderBy(e => e.Id).Select(e => e.Id).ToListAsync();
+
+        Console.WriteLine();
+        Console.WriteLine("=== Offload ===");
+        Console.WriteLine($"Source:         {sourceAccount!.Name} (ID {sourceAccountId})");
+        Console.WriteLine($"Target:         {targetAccount.Name} (ID {targetAccountId})");
+        Console.WriteLine($"Window:         {criteria.DescribeWindow()}");
+        Console.WriteLine($"Target folder:  {targetFolder}");
+        Console.WriteLine($"Preserve tree:  {preserveFolders}");
+        Console.WriteLine($"Mark as seen:   {criteria.MarkAsSeen}");
+        Console.WriteLine($"Excluded:       {(criteria.ExcludedSourceFolders.Count == 0 ? "(none)" : string.Join(", ", criteria.ExcludedSourceFolders))}");
+        Console.WriteLine($"Rename map:     {(criteria.FolderRenameMap.Count == 0 ? "(empty)" : string.Join(", ", criteria.FolderRenameMap.Select(kv => $"{kv.Key} -> {kv.Value}")))}");
+        Console.WriteLine($"Resolved mails: {emailIds.Count}");
+        Console.WriteLine($"Dry run:        {dryRun}");
+        Console.WriteLine();
+
+        if (emailIds.Count == 0)
+        {
+            Console.WriteLine("Nothing to do: no archived mail in that window.");
+            Environment.Exit(ExitOk);
+        }
+
+        // Kept as a sanity guard rather than a binding constraint: a date window brings a very
+        // large mailbox well under this, but an accidentally huge window should still be caught.
+        if (emailIds.Count > batchRestoreOptions.MaxAsyncEmails)
+        {
+            Console.WriteLine($"ERROR: {emailIds.Count} mails exceeds BatchRestore.MaxAsyncEmails " +
+                              $"({batchRestoreOptions.MaxAsyncEmails}). Narrow the window or raise the limit.");
+            Environment.Exit(ExitBadArgs);
+        }
+
+        var imapService = offloadServices.GetRequiredService<MailArchiver.Services.Providers.ImapEmailService>();
+
+        var lastReported = 0;
+        var outcome = await imapService.OffloadEmailsAsync(
+            emailIds, targetAccountId, targetFolder, preserveFolders, criteria,
+            (processed, appended, failed) =>
+            {
+                // One line per hundred keeps a multi-hour run readable in a log file.
+                if (processed - lastReported < 100 && processed != emailIds.Count) return;
+                lastReported = processed;
+                Console.WriteLine($"  {processed}/{emailIds.Count} processed, {appended} appended, {failed} failed");
+            },
+            CancellationToken.None);
+
+        Console.WriteLine();
+        Console.Write(outcome.Describe());
+
+        try
+        {
+            var accessLog = offloadServices.GetRequiredService<IAccessLogService>();
+            await accessLog.LogAccessAsync("CLI", AccessLogType.Restore,
+                mailAccountId: sourceAccountId,
+                searchParameters: $"offload source={sourceAccountId} target={targetAccountId} " +
+                                  $"window={criteria.DescribeWindow()} folder={targetFolder} " +
+                                  $"preserve={preserveFolders} dryRun={dryRun} " +
+                                  $"appended={outcome.Appended} alreadyPresent={outcome.SkippedAlreadyPresent} " +
+                                  $"failed={outcome.Failed}");
+        }
+        catch (Exception ex)
+        {
+            offloadLogger.LogWarning(ex, "Could not write the offload audit entry");
+        }
+
+        Environment.Exit(outcome.Failed == 0 ? ExitOk : ExitFailed);
+    }
+    catch (Exception ex)
+    {
+        offloadLogger.LogError(ex, "Offload failed");
+        Console.WriteLine($"ERROR: {ex.Message}");
+        Environment.Exit(ExitFailed);
     }
 }
 

--- a/Resources/SharedResource.de.resx
+++ b/Resources/SharedResource.de.resx
@@ -3204,6 +3204,18 @@
   <data name="OffloadSelectTarget" xml:space="preserve">
     <value>Zielpostfach auswählen...</value>
   </data>
+  <data name="OffloadLoadingFolders" xml:space="preserve">
+    <value>Ordner werden geladen…</value>
+  </data>
+  <data name="OffloadSelectFolder" xml:space="preserve">
+    <value>-- Zielordner wählen --</value>
+  </data>
+  <data name="OffloadErrorLoadingFolders" xml:space="preserve">
+    <value>Fehler beim Laden der Ordner</value>
+  </data>
+  <data name="OffloadSelectTargetFirst" xml:space="preserve">
+    <value>Ziel wählen</value>
+  </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Wurzelordner im Zielpostfach. Bei INBOX wird die Ordnerstruktur der Quelle auf oberster Ebene nachgebildet.</value>
   </data>

--- a/Resources/SharedResource.de.resx
+++ b/Resources/SharedResource.de.resx
@@ -3189,4 +3189,127 @@
   <data name="FailuresAcknowledged" xml:space="preserve">
     <value>Fehler bestätigt</value>
   </data>
+  <data name="OffloadTitle" xml:space="preserve">
+    <value>In anderes Postfach auslagern</value>
+  </data>
+  <data name="OffloadIntro" xml:space="preserve">
+    <value>Hängt archivierte Mails, die neuer als ein Stichtag sind, an ein anderes Postfach an und überspringt alles, was dort bereits liegt. Ältere Mails bleiben im Archiv. Ein erneuter Lauf ist unbedenklich und hängt nichts doppelt an.</value>
+  </data>
+  <data name="OffloadSourceAndTarget" xml:space="preserve">
+    <value>Quelle und Ziel</value>
+  </data>
+  <data name="SourceAccount" xml:space="preserve">
+    <value>Quellkonto</value>
+  </data>
+  <data name="OffloadSelectTarget" xml:space="preserve">
+    <value>Zielpostfach auswählen...</value>
+  </data>
+  <data name="OffloadTargetFolderHelp" xml:space="preserve">
+    <value>Wurzelordner im Zielpostfach. Bei INBOX wird die Ordnerstruktur der Quelle auf oberster Ebene nachgebildet.</value>
+  </data>
+  <data name="OffloadWindow" xml:space="preserve">
+    <value>Zeitfenster</value>
+  </data>
+  <data name="OffloadWindowMonths" xml:space="preserve">
+    <value>Letzte N Monate</value>
+  </data>
+  <data name="OffloadWindowMonthsHelp" xml:space="preserve">
+    <value>Wird beim Start des Auftrags in ein festes Datum aufgelöst, damit ein Wiederholungslauf dieselben Mails auswählt. 0 bedeutet: stattdessen das explizite Datum verwenden.</value>
+  </data>
+  <data name="OffloadCutoffFrom" xml:space="preserve">
+    <value>Von Datum</value>
+  </data>
+  <data name="OffloadCutoffFromHelp" xml:space="preserve">
+    <value>Überschreibt das Monatsfenster. Einschließlich, ab 00:00 dieses Tages.</value>
+  </data>
+  <data name="OffloadCutoffTo" xml:space="preserve">
+    <value>Bis Datum (optional)</value>
+  </data>
+  <data name="OffloadCutoffToHelp" xml:space="preserve">
+    <value>Einschließlich, bis 23:59:59 dieses Tages.</value>
+  </data>
+  <data name="OffloadOptions" xml:space="preserve">
+    <value>Optionen</value>
+  </data>
+  <data name="OffloadDryRun" xml:space="preserve">
+    <value>Testlauf</value>
+  </data>
+  <data name="OffloadDryRunHelp" xml:space="preserve">
+    <value>Löst alles auf und berichtet pro Ordner, was passieren würde, hängt aber nichts an. Vor einem echten Lauf empfohlen.</value>
+  </data>
+  <data name="OffloadMarkAsSeen" xml:space="preserve">
+    <value>Angehängte Mails als gelesen markieren</value>
+  </data>
+  <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
+    <value>Ausgeschaltet bleiben ungelesene Mails im Zielpostfach ungelesen.</value>
+  </data>
+  <data name="OffloadFolderHandling" xml:space="preserve">
+    <value>Ordnerbehandlung</value>
+  </data>
+  <data name="OffloadExcludedFolders" xml:space="preserve">
+    <value>Ausgeschlossene Quellordner</value>
+  </data>
+  <data name="OffloadRenameMap" xml:space="preserve">
+    <value>Ordner-Umbenennung</value>
+  </data>
+  <data name="OffloadNoneConfigured" xml:space="preserve">
+    <value>nicht konfiguriert</value>
+  </data>
+  <data name="OffloadFolderHandlingHelp" xml:space="preserve">
+    <value>Beides wird im Abschnitt Offload der appsettings.json konfiguriert und ist standardmäßig leer. Ausschlüsse werden vor dem Umbenennen geprüft und gelten auch für Unterordner.</value>
+  </data>
+  <data name="OffloadStart" xml:space="preserve">
+    <value>Auslagerung starten</value>
+  </data>
+  <data name="OffloadNoTargets" xml:space="preserve">
+    <value>Es ist kein weiteres aktives IMAP-Konto als Ziel verfügbar. Bitte zuerst eines anlegen.</value>
+  </data>
+  <data name="OffloadTargetRequired" xml:space="preserve">
+    <value>Bitte ein Zielpostfach auswählen.</value>
+  </data>
+  <data name="OffloadTargetMustDiffer" xml:space="preserve">
+    <value>Das Zielpostfach muss sich von der Quelle unterscheiden.</value>
+  </data>
+  <data name="OffloadTargetNotFound" xml:space="preserve">
+    <value>Das gewählte Zielpostfach existiert nicht mehr.</value>
+  </data>
+  <data name="OffloadTargetMustBeImap" xml:space="preserve">
+    <value>Das Zielpostfach muss ein IMAP-Konto sein.</value>
+  </data>
+  <data name="OffloadTargetDisabled" xml:space="preserve">
+    <value>Das gewählte Zielpostfach ist deaktiviert.</value>
+  </data>
+  <data name="OffloadCutoffRequired" xml:space="preserve">
+    <value>Bitte entweder ein Monatsfenster oder ein Von-Datum angeben.</value>
+  </data>
+  <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
+    <value>Das Bis-Datum darf nicht vor dem Von-Datum liegen.</value>
+  </data>
+  <data name="OffloadNothingInWindow" xml:space="preserve">
+    <value>In diesem Zeitfenster liegen keine archivierten Mails.</value>
+  </data>
+  <data name="OffloadQueued" xml:space="preserve">
+    <value>Auslagerung für {0} Mails eingeplant.</value>
+  </data>
+  <data name="OffloadDryRunQueued" xml:space="preserve">
+    <value>Testlauf für {0} Mails eingeplant. Es wird nichts angehängt.</value>
+  </data>
+  <data name="OffloadAppended" xml:space="preserve">
+    <value>Angehängt</value>
+  </data>
+  <data name="OffloadAlreadyPresent" xml:space="preserve">
+    <value>Bereits vorhanden</value>
+  </data>
+  <data name="OffloadByFingerprint" xml:space="preserve">
+    <value>per Fingerprint erkannt</value>
+  </data>
+  <data name="OffloadExcluded" xml:space="preserve">
+    <value>Ausgeschlossener Ordner</value>
+  </data>
+  <data name="OffloadReport" xml:space="preserve">
+    <value>Auslagerungsbericht</value>
+  </data>
+  <data name="OffloadJob" xml:space="preserve">
+    <value>Auslagerung</value>
+  </data>
 </root>

--- a/Resources/SharedResource.de.resx
+++ b/Resources/SharedResource.de.resx
@@ -3264,6 +3264,9 @@
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>Es ist kein weiteres aktives IMAP-Konto als Ziel verfügbar. Bitte zuerst eines anlegen.</value>
   </data>
+  <data name="OffloadNoTargetsAssigned" xml:space="preserve">
+    <value>Keines der Ihnen zugewiesenen Postfächer kann als Ziel verwendet werden. Bitte lassen Sie sich ein weiteres aktives IMAP-Konto zuweisen.</value>
+  </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Bitte ein Zielpostfach auswählen.</value>
   </data>

--- a/Resources/SharedResource.en-GB.resx
+++ b/Resources/SharedResource.en-GB.resx
@@ -584,4 +584,127 @@
   <data name="FailuresAcknowledged" xml:space="preserve">
     <value>Failures acknowledged</value>
   </data>
+  <data name="OffloadTitle" xml:space="preserve">
+    <value>Offload to Another Mailbox</value>
+  </data>
+  <data name="OffloadIntro" xml:space="preserve">
+    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+  </data>
+  <data name="OffloadSourceAndTarget" xml:space="preserve">
+    <value>Source and Target</value>
+  </data>
+  <data name="SourceAccount" xml:space="preserve">
+    <value>Source Account</value>
+  </data>
+  <data name="OffloadSelectTarget" xml:space="preserve">
+    <value>Select a target mailbox...</value>
+  </data>
+  <data name="OffloadTargetFolderHelp" xml:space="preserve">
+    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+  </data>
+  <data name="OffloadWindow" xml:space="preserve">
+    <value>Date Window</value>
+  </data>
+  <data name="OffloadWindowMonths" xml:space="preserve">
+    <value>Last N months</value>
+  </data>
+  <data name="OffloadWindowMonthsHelp" xml:space="preserve">
+    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+  </data>
+  <data name="OffloadCutoffFrom" xml:space="preserve">
+    <value>From date</value>
+  </data>
+  <data name="OffloadCutoffFromHelp" xml:space="preserve">
+    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+  </data>
+  <data name="OffloadCutoffTo" xml:space="preserve">
+    <value>To date (optional)</value>
+  </data>
+  <data name="OffloadCutoffToHelp" xml:space="preserve">
+    <value>Inclusive, up to 23:59:59 of this day.</value>
+  </data>
+  <data name="OffloadOptions" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="OffloadDryRun" xml:space="preserve">
+    <value>Dry run</value>
+  </data>
+  <data name="OffloadDryRunHelp" xml:space="preserve">
+    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+  </data>
+  <data name="OffloadMarkAsSeen" xml:space="preserve">
+    <value>Mark appended mail as read</value>
+  </data>
+  <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
+    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+  </data>
+  <data name="OffloadFolderHandling" xml:space="preserve">
+    <value>Folder Handling</value>
+  </data>
+  <data name="OffloadExcludedFolders" xml:space="preserve">
+    <value>Excluded source folders</value>
+  </data>
+  <data name="OffloadRenameMap" xml:space="preserve">
+    <value>Folder rename map</value>
+  </data>
+  <data name="OffloadNoneConfigured" xml:space="preserve">
+    <value>none configured</value>
+  </data>
+  <data name="OffloadFolderHandlingHelp" xml:space="preserve">
+    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+  </data>
+  <data name="OffloadStart" xml:space="preserve">
+    <value>Start Offload</value>
+  </data>
+  <data name="OffloadNoTargets" xml:space="preserve">
+    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+  </data>
+  <data name="OffloadTargetRequired" xml:space="preserve">
+    <value>Please choose a target mailbox.</value>
+  </data>
+  <data name="OffloadTargetMustDiffer" xml:space="preserve">
+    <value>The target mailbox must be different from the source.</value>
+  </data>
+  <data name="OffloadTargetNotFound" xml:space="preserve">
+    <value>The selected target mailbox no longer exists.</value>
+  </data>
+  <data name="OffloadTargetMustBeImap" xml:space="preserve">
+    <value>The target mailbox must be an IMAP account.</value>
+  </data>
+  <data name="OffloadTargetDisabled" xml:space="preserve">
+    <value>The selected target mailbox is disabled.</value>
+  </data>
+  <data name="OffloadCutoffRequired" xml:space="preserve">
+    <value>Please give either a month window or a from date.</value>
+  </data>
+  <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
+    <value>The to date must not be earlier than the from date.</value>
+  </data>
+  <data name="OffloadNothingInWindow" xml:space="preserve">
+    <value>No archived mail falls inside that date window.</value>
+  </data>
+  <data name="OffloadQueued" xml:space="preserve">
+    <value>Offload queued for {0} mails.</value>
+  </data>
+  <data name="OffloadDryRunQueued" xml:space="preserve">
+    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+  </data>
+  <data name="OffloadAppended" xml:space="preserve">
+    <value>Appended</value>
+  </data>
+  <data name="OffloadAlreadyPresent" xml:space="preserve">
+    <value>Already present</value>
+  </data>
+  <data name="OffloadByFingerprint" xml:space="preserve">
+    <value>matched by fingerprint</value>
+  </data>
+  <data name="OffloadExcluded" xml:space="preserve">
+    <value>Excluded folder</value>
+  </data>
+  <data name="OffloadReport" xml:space="preserve">
+    <value>Offload Report</value>
+  </data>
+  <data name="OffloadJob" xml:space="preserve">
+    <value>Offload</value>
+  </data>
 </root>

--- a/Resources/SharedResource.en-GB.resx
+++ b/Resources/SharedResource.en-GB.resx
@@ -599,6 +599,18 @@
   <data name="OffloadSelectTarget" xml:space="preserve">
     <value>Select a target mailbox…</value>
   </data>
+  <data name="OffloadLoadingFolders" xml:space="preserve">
+    <value>Loading folders…</value>
+  </data>
+  <data name="OffloadSelectFolder" xml:space="preserve">
+    <value>-- Select a target folder --</value>
+  </data>
+  <data name="OffloadErrorLoadingFolders" xml:space="preserve">
+    <value>Error loading folders</value>
+  </data>
+  <data name="OffloadSelectTargetFirst" xml:space="preserve">
+    <value>Select a target mailbox first</value>
+  </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
   </data>

--- a/Resources/SharedResource.en-GB.resx
+++ b/Resources/SharedResource.en-GB.resx
@@ -585,25 +585,25 @@
     <value>Failures acknowledged</value>
   </data>
   <data name="OffloadTitle" xml:space="preserve">
-    <value>Offload to Another Mailbox</value>
+    <value>Offload to another mailbox</value>
   </data>
   <data name="OffloadIntro" xml:space="preserve">
-    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+    <value>Appends archived mail newer than a cut-off into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that has already arrived.</value>
   </data>
   <data name="OffloadSourceAndTarget" xml:space="preserve">
-    <value>Source and Target</value>
+    <value>Source and target</value>
   </data>
   <data name="SourceAccount" xml:space="preserve">
-    <value>Source Account</value>
+    <value>Source account</value>
   </data>
   <data name="OffloadSelectTarget" xml:space="preserve">
-    <value>Select a target mailbox...</value>
+    <value>Select a target mailbox…</value>
   </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
   </data>
   <data name="OffloadWindow" xml:space="preserve">
-    <value>Date Window</value>
+    <value>Date window</value>
   </data>
   <data name="OffloadWindowMonths" xml:space="preserve">
     <value>Last N months</value>
@@ -639,7 +639,7 @@
     <value>Turning this off keeps unread mail unread in the target mailbox.</value>
   </data>
   <data name="OffloadFolderHandling" xml:space="preserve">
-    <value>Folder Handling</value>
+    <value>Folder handling</value>
   </data>
   <data name="OffloadExcludedFolders" xml:space="preserve">
     <value>Excluded source folders</value>
@@ -654,7 +654,7 @@
     <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
   </data>
   <data name="OffloadStart" xml:space="preserve">
-    <value>Start Offload</value>
+    <value>Start offload</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>No other enabled IMAP account is available as a target. Create one first.</value>
@@ -678,7 +678,7 @@
     <value>The selected target mailbox is disabled.</value>
   </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
-    <value>Please give either a month window or a from date.</value>
+    <value>Please provide either a month window or a from date.</value>
   </data>
   <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
     <value>The to date must not be earlier than the from date.</value>
@@ -705,7 +705,7 @@
     <value>Excluded folder</value>
   </data>
   <data name="OffloadReport" xml:space="preserve">
-    <value>Offload Report</value>
+    <value>Offload report</value>
   </data>
   <data name="OffloadJob" xml:space="preserve">
     <value>Offload</value>

--- a/Resources/SharedResource.en-GB.resx
+++ b/Resources/SharedResource.en-GB.resx
@@ -659,6 +659,9 @@
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>No other enabled IMAP account is available as a target. Create one first.</value>
   </data>
+  <data name="OffloadNoTargetsAssigned" xml:space="preserve">
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+  </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>
   </data>

--- a/Resources/SharedResource.es.resx
+++ b/Resources/SharedResource.es.resx
@@ -3262,6 +3262,9 @@
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>No other enabled IMAP account is available as a target. Create one first.</value>
   </data>
+  <data name="OffloadNoTargetsAssigned" xml:space="preserve">
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+  </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>
   </data>

--- a/Resources/SharedResource.es.resx
+++ b/Resources/SharedResource.es.resx
@@ -3188,129 +3188,129 @@
     <value>Fallos reconocidos</value>
   </data>
   <data name="OffloadTitle" xml:space="preserve">
-    <value>Offload to Another Mailbox</value>
+    <value>Volcar a otro buzón</value>
   </data>
   <data name="OffloadIntro" xml:space="preserve">
-    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+    <value>Añade el correo archivado más reciente que un fecha de corte a otro buzón, omitiendo lo que ese buzón ya contiene. El correo más antiguo permanece en el archivo. Ejecutarlo de nuevo es seguro y no añade nada que ya haya llegado.</value>
   </data>
   <data name="OffloadSourceAndTarget" xml:space="preserve">
-    <value>Source and Target</value>
+    <value>Origen y destino</value>
   </data>
   <data name="SourceAccount" xml:space="preserve">
-    <value>Source Account</value>
+    <value>Cuenta de origen</value>
   </data>
   <data name="OffloadSelectTarget" xml:space="preserve">
-    <value>Select a target mailbox...</value>
+    <value>Seleccionar un buzón de destino…</value>
   </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
-    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+    <value>Carpeta raíz en el buzón de destino. Con INBOX la estructura de carpetas de origen se recrea en el nivel superior.</value>
   </data>
   <data name="OffloadWindow" xml:space="preserve">
-    <value>Date Window</value>
+    <value>Ventana de fechas</value>
   </data>
   <data name="OffloadWindowMonths" xml:space="preserve">
-    <value>Last N months</value>
+    <value>Últimos N meses</value>
   </data>
   <data name="OffloadWindowMonthsHelp" xml:space="preserve">
-    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+    <value>Se resuelve a una fecha fija al iniciar el trabajo, de modo que repetir el trabajo selecciona el mismo correo. Establézcalo en 0 para usar una fecha explícita.</value>
   </data>
   <data name="OffloadCutoffFrom" xml:space="preserve">
-    <value>From date</value>
+    <value>Desde la fecha</value>
   </data>
   <data name="OffloadCutoffFromHelp" xml:space="preserve">
-    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+    <value>Sobrescribe la ventana de meses. Inclusivo, desde las 00:00 de este día.</value>
   </data>
   <data name="OffloadCutoffTo" xml:space="preserve">
-    <value>To date (optional)</value>
+    <value>Hasta la fecha (opcional)</value>
   </data>
   <data name="OffloadCutoffToHelp" xml:space="preserve">
-    <value>Inclusive, up to 23:59:59 of this day.</value>
+    <value>Inclusivo, hasta las 23:59:59 de este día.</value>
   </data>
   <data name="OffloadOptions" xml:space="preserve">
-    <value>Options</value>
+    <value>Opciones</value>
   </data>
   <data name="OffloadDryRun" xml:space="preserve">
-    <value>Dry run</value>
+    <value>Ejecución de prueba</value>
   </data>
   <data name="OffloadDryRunHelp" xml:space="preserve">
-    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+    <value>Resuelve todo e informa de lo que ocurriría por carpeta, pero no añade nada. Recomendado antes de una ejecución real.</value>
   </data>
   <data name="OffloadMarkAsSeen" xml:space="preserve">
-    <value>Mark appended mail as read</value>
+    <value>Marcar el correo añadido como leído</value>
   </data>
   <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
-    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+    <value>Desactivar esto mantiene el correo no leído como no leído en el buzón de destino.</value>
   </data>
   <data name="OffloadFolderHandling" xml:space="preserve">
-    <value>Folder Handling</value>
+    <value>Gestión de carpetas</value>
   </data>
   <data name="OffloadExcludedFolders" xml:space="preserve">
-    <value>Excluded source folders</value>
+    <value>Carpetas de origen excluidas</value>
   </data>
   <data name="OffloadRenameMap" xml:space="preserve">
-    <value>Folder rename map</value>
+    <value>Mapa de renombrado de carpetas</value>
   </data>
   <data name="OffloadNoneConfigured" xml:space="preserve">
-    <value>none configured</value>
+    <value>ninguno configurado</value>
   </data>
   <data name="OffloadFolderHandlingHelp" xml:space="preserve">
-    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+    <value>Ambos se configuran en la sección Offload de appsettings.json y están vacíos por defecto. Las exclusiones se aplican antes del renombrado y cubren las subcarpetas.</value>
   </data>
   <data name="OffloadStart" xml:space="preserve">
-    <value>Start Offload</value>
+    <value>Iniciar volcado</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+    <value>No hay otra cuenta IMAP habilitada disponible como destino. Cree una primero.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+    <value>Ninguno de los buzones asignados a usted puede usarse como destino. Pida a un administrador que le asigne otra cuenta IMAP habilitada.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
-    <value>Please choose a target mailbox.</value>
+    <value>Elija un buzón de destino.</value>
   </data>
   <data name="OffloadTargetMustDiffer" xml:space="preserve">
-    <value>The target mailbox must be different from the source.</value>
+    <value>El buzón de destino debe ser distinto del de origen.</value>
   </data>
   <data name="OffloadTargetNotFound" xml:space="preserve">
-    <value>The selected target mailbox no longer exists.</value>
+    <value>El buzón de destino seleccionado ya no existe.</value>
   </data>
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
-    <value>The target mailbox must be an IMAP account.</value>
+    <value>El buzón de destino debe ser una cuenta IMAP.</value>
   </data>
   <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>The selected target mailbox is disabled.</value>
+    <value>El buzón de destino seleccionado está deshabilitado.</value>
   </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
-    <value>Please give either a month window or a from date.</value>
+    <value>Indique una ventana de meses o una fecha de inicio.</value>
   </data>
   <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
-    <value>The to date must not be earlier than the from date.</value>
+    <value>La fecha «hasta» no puede ser anterior a la fecha «desde».</value>
   </data>
   <data name="OffloadNothingInWindow" xml:space="preserve">
-    <value>No archived mail falls inside that date window.</value>
+    <value>Ningún correo archivado cae dentro de esa ventana de fechas.</value>
   </data>
   <data name="OffloadQueued" xml:space="preserve">
-    <value>Offload queued for {0} mails.</value>
+    <value>Volcado encolado para {0} correos.</value>
   </data>
   <data name="OffloadDryRunQueued" xml:space="preserve">
-    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+    <value>Ejecución de prueba encolada para {0} correos. No se añadirá nada.</value>
   </data>
   <data name="OffloadAppended" xml:space="preserve">
-    <value>Appended</value>
+    <value>Añadidos</value>
   </data>
   <data name="OffloadAlreadyPresent" xml:space="preserve">
-    <value>Already present</value>
+    <value>Ya presentes</value>
   </data>
   <data name="OffloadByFingerprint" xml:space="preserve">
-    <value>matched by fingerprint</value>
+    <value>coincidencia por huella</value>
   </data>
   <data name="OffloadExcluded" xml:space="preserve">
-    <value>Excluded folder</value>
+    <value>Carpeta excluida</value>
   </data>
   <data name="OffloadReport" xml:space="preserve">
-    <value>Offload Report</value>
+    <value>Informe de volcado</value>
   </data>
   <data name="OffloadJob" xml:space="preserve">
-    <value>Offload</value>
+    <value>Volcado</value>
   </data>
 </root>

--- a/Resources/SharedResource.es.resx
+++ b/Resources/SharedResource.es.resx
@@ -3202,6 +3202,18 @@
   <data name="OffloadSelectTarget" xml:space="preserve">
     <value>Seleccionar un buzón de destino…</value>
   </data>
+  <data name="OffloadLoadingFolders" xml:space="preserve">
+    <value>Cargando carpetas…</value>
+  </data>
+  <data name="OffloadSelectFolder" xml:space="preserve">
+    <value>-- Seleccione una carpeta de destino --</value>
+  </data>
+  <data name="OffloadErrorLoadingFolders" xml:space="preserve">
+    <value>Error al cargar las carpetas</value>
+  </data>
+  <data name="OffloadSelectTargetFirst" xml:space="preserve">
+    <value>Seleccione un buzón de destino primero</value>
+  </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Carpeta raíz en el buzón de destino. Con INBOX la estructura de carpetas de origen se recrea en el nivel superior.</value>
   </data>

--- a/Resources/SharedResource.es.resx
+++ b/Resources/SharedResource.es.resx
@@ -3187,4 +3187,127 @@
   <data name="FailuresAcknowledged" xml:space="preserve">
     <value>Fallos reconocidos</value>
   </data>
+  <data name="OffloadTitle" xml:space="preserve">
+    <value>Offload to Another Mailbox</value>
+  </data>
+  <data name="OffloadIntro" xml:space="preserve">
+    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+  </data>
+  <data name="OffloadSourceAndTarget" xml:space="preserve">
+    <value>Source and Target</value>
+  </data>
+  <data name="SourceAccount" xml:space="preserve">
+    <value>Source Account</value>
+  </data>
+  <data name="OffloadSelectTarget" xml:space="preserve">
+    <value>Select a target mailbox...</value>
+  </data>
+  <data name="OffloadTargetFolderHelp" xml:space="preserve">
+    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+  </data>
+  <data name="OffloadWindow" xml:space="preserve">
+    <value>Date Window</value>
+  </data>
+  <data name="OffloadWindowMonths" xml:space="preserve">
+    <value>Last N months</value>
+  </data>
+  <data name="OffloadWindowMonthsHelp" xml:space="preserve">
+    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+  </data>
+  <data name="OffloadCutoffFrom" xml:space="preserve">
+    <value>From date</value>
+  </data>
+  <data name="OffloadCutoffFromHelp" xml:space="preserve">
+    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+  </data>
+  <data name="OffloadCutoffTo" xml:space="preserve">
+    <value>To date (optional)</value>
+  </data>
+  <data name="OffloadCutoffToHelp" xml:space="preserve">
+    <value>Inclusive, up to 23:59:59 of this day.</value>
+  </data>
+  <data name="OffloadOptions" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="OffloadDryRun" xml:space="preserve">
+    <value>Dry run</value>
+  </data>
+  <data name="OffloadDryRunHelp" xml:space="preserve">
+    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+  </data>
+  <data name="OffloadMarkAsSeen" xml:space="preserve">
+    <value>Mark appended mail as read</value>
+  </data>
+  <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
+    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+  </data>
+  <data name="OffloadFolderHandling" xml:space="preserve">
+    <value>Folder Handling</value>
+  </data>
+  <data name="OffloadExcludedFolders" xml:space="preserve">
+    <value>Excluded source folders</value>
+  </data>
+  <data name="OffloadRenameMap" xml:space="preserve">
+    <value>Folder rename map</value>
+  </data>
+  <data name="OffloadNoneConfigured" xml:space="preserve">
+    <value>none configured</value>
+  </data>
+  <data name="OffloadFolderHandlingHelp" xml:space="preserve">
+    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+  </data>
+  <data name="OffloadStart" xml:space="preserve">
+    <value>Start Offload</value>
+  </data>
+  <data name="OffloadNoTargets" xml:space="preserve">
+    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+  </data>
+  <data name="OffloadTargetRequired" xml:space="preserve">
+    <value>Please choose a target mailbox.</value>
+  </data>
+  <data name="OffloadTargetMustDiffer" xml:space="preserve">
+    <value>The target mailbox must be different from the source.</value>
+  </data>
+  <data name="OffloadTargetNotFound" xml:space="preserve">
+    <value>The selected target mailbox no longer exists.</value>
+  </data>
+  <data name="OffloadTargetMustBeImap" xml:space="preserve">
+    <value>The target mailbox must be an IMAP account.</value>
+  </data>
+  <data name="OffloadTargetDisabled" xml:space="preserve">
+    <value>The selected target mailbox is disabled.</value>
+  </data>
+  <data name="OffloadCutoffRequired" xml:space="preserve">
+    <value>Please give either a month window or a from date.</value>
+  </data>
+  <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
+    <value>The to date must not be earlier than the from date.</value>
+  </data>
+  <data name="OffloadNothingInWindow" xml:space="preserve">
+    <value>No archived mail falls inside that date window.</value>
+  </data>
+  <data name="OffloadQueued" xml:space="preserve">
+    <value>Offload queued for {0} mails.</value>
+  </data>
+  <data name="OffloadDryRunQueued" xml:space="preserve">
+    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+  </data>
+  <data name="OffloadAppended" xml:space="preserve">
+    <value>Appended</value>
+  </data>
+  <data name="OffloadAlreadyPresent" xml:space="preserve">
+    <value>Already present</value>
+  </data>
+  <data name="OffloadByFingerprint" xml:space="preserve">
+    <value>matched by fingerprint</value>
+  </data>
+  <data name="OffloadExcluded" xml:space="preserve">
+    <value>Excluded folder</value>
+  </data>
+  <data name="OffloadReport" xml:space="preserve">
+    <value>Offload Report</value>
+  </data>
+  <data name="OffloadJob" xml:space="preserve">
+    <value>Offload</value>
+  </data>
 </root>

--- a/Resources/SharedResource.fr.resx
+++ b/Resources/SharedResource.fr.resx
@@ -3189,129 +3189,129 @@
     <value>Échecs reconnus</value>
   </data>
   <data name="OffloadTitle" xml:space="preserve">
-    <value>Offload to Another Mailbox</value>
+    <value>Décharger vers une autre boîte aux lettres</value>
   </data>
   <data name="OffloadIntro" xml:space="preserve">
-    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+    <value>Ajoute le courriel archivé plus récent qu'une date de coupure dans une autre boîte aux lettres, en ignorant ce que cette boîte contient déjà. Le courriel plus ancien reste dans l'archive. Relancer est sans risque et n'ajoute rien de ce qui est déjà arrivé.</value>
   </data>
   <data name="OffloadSourceAndTarget" xml:space="preserve">
-    <value>Source and Target</value>
+    <value>Source et destination</value>
   </data>
   <data name="SourceAccount" xml:space="preserve">
-    <value>Source Account</value>
+    <value>Compte source</value>
   </data>
   <data name="OffloadSelectTarget" xml:space="preserve">
-    <value>Select a target mailbox...</value>
+    <value>Sélectionner une boîte aux lettres de destination…</value>
   </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
-    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+    <value>Dossier racine dans la boîte aux lettres de destination. Avec INBOX la structure des dossiers source est recréée au niveau supérieur.</value>
   </data>
   <data name="OffloadWindow" xml:space="preserve">
-    <value>Date Window</value>
+    <value>Plage de dates</value>
   </data>
   <data name="OffloadWindowMonths" xml:space="preserve">
-    <value>Last N months</value>
+    <value>N derniers mois</value>
   </data>
   <data name="OffloadWindowMonthsHelp" xml:space="preserve">
-    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+    <value>Résolu en une date fixe au démarrage de la tâche, de sorte que relancer la tâche sélectionne le même courriel. Mettez à 0 pour utiliser une date explicite.</value>
   </data>
   <data name="OffloadCutoffFrom" xml:space="preserve">
-    <value>From date</value>
+    <value>Date de début</value>
   </data>
   <data name="OffloadCutoffFromHelp" xml:space="preserve">
-    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+    <value>Remplace la fenêtre de mois. Inclusif, à partir de 00:00 de ce jour.</value>
   </data>
   <data name="OffloadCutoffTo" xml:space="preserve">
-    <value>To date (optional)</value>
+    <value>Date de fin (facultatif)</value>
   </data>
   <data name="OffloadCutoffToHelp" xml:space="preserve">
-    <value>Inclusive, up to 23:59:59 of this day.</value>
+    <value>Inclusif, jusqu'à 23:59:59 de ce jour.</value>
   </data>
   <data name="OffloadOptions" xml:space="preserve">
     <value>Options</value>
   </data>
   <data name="OffloadDryRun" xml:space="preserve">
-    <value>Dry run</value>
+    <value>Simulation</value>
   </data>
   <data name="OffloadDryRunHelp" xml:space="preserve">
-    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+    <value>Résout tout et indique ce qui se passerait par dossier, mais n'ajoute rien. Recommandé avant un vrai lancement.</value>
   </data>
   <data name="OffloadMarkAsSeen" xml:space="preserve">
-    <value>Mark appended mail as read</value>
+    <value>Marquer le courriel ajouté comme lu</value>
   </data>
   <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
-    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+    <value>Désactiver ceci garde le courriel non lu comme non lu dans la boîte aux lettres de destination.</value>
   </data>
   <data name="OffloadFolderHandling" xml:space="preserve">
-    <value>Folder Handling</value>
+    <value>Gestion des dossiers</value>
   </data>
   <data name="OffloadExcludedFolders" xml:space="preserve">
-    <value>Excluded source folders</value>
+    <value>Dossiers source exclus</value>
   </data>
   <data name="OffloadRenameMap" xml:space="preserve">
-    <value>Folder rename map</value>
+    <value>Table de renommage des dossiers</value>
   </data>
   <data name="OffloadNoneConfigured" xml:space="preserve">
-    <value>none configured</value>
+    <value>aucun configuré</value>
   </data>
   <data name="OffloadFolderHandlingHelp" xml:space="preserve">
-    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+    <value>Les deux se configurent dans la section Offload de appsettings.json et sont vides par défaut. Les exclusions sont appliquées avant le renommage et couvrent les sous-dossiers.</value>
   </data>
   <data name="OffloadStart" xml:space="preserve">
-    <value>Start Offload</value>
+    <value>Lancer la décharge</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+    <value>Aucun autre compte IMAP activé n'est disponible comme destination. Créez-en un d'abord.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+    <value>Aucune des boîtes aux lettres qui vous sont attribuées ne peut servir de destination. Demandez à un administrateur de vous attribuer un autre compte IMAP activé.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
-    <value>Please choose a target mailbox.</value>
+    <value>Veuillez choisir une boîte aux lettres de destination.</value>
   </data>
   <data name="OffloadTargetMustDiffer" xml:space="preserve">
-    <value>The target mailbox must be different from the source.</value>
+    <value>La boîte aux lettres de destination doit être différente de la source.</value>
   </data>
   <data name="OffloadTargetNotFound" xml:space="preserve">
-    <value>The selected target mailbox no longer exists.</value>
+    <value>La boîte aux lettres de destination sélectionnée n'existe plus.</value>
   </data>
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
-    <value>The target mailbox must be an IMAP account.</value>
+    <value>La boîte aux lettres de destination doit être un compte IMAP.</value>
   </data>
   <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>The selected target mailbox is disabled.</value>
+    <value>La boîte aux lettres de destination sélectionnée est désactivée.</value>
   </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
-    <value>Please give either a month window or a from date.</value>
+    <value>Veuillez fournir soit une fenêtre de mois, soit une date de début.</value>
   </data>
   <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
-    <value>The to date must not be earlier than the from date.</value>
+    <value>La date de fin ne doit pas être antérieure à la date de début.</value>
   </data>
   <data name="OffloadNothingInWindow" xml:space="preserve">
-    <value>No archived mail falls inside that date window.</value>
+    <value>Aucun courriel archivé ne tombe dans cette plage de dates.</value>
   </data>
   <data name="OffloadQueued" xml:space="preserve">
-    <value>Offload queued for {0} mails.</value>
+    <value>Décharge en file d'attente pour {0} courriels.</value>
   </data>
   <data name="OffloadDryRunQueued" xml:space="preserve">
-    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+    <value>Simulation en file d'attente pour {0} courriels. Rien ne sera ajouté.</value>
   </data>
   <data name="OffloadAppended" xml:space="preserve">
-    <value>Appended</value>
+    <value>Ajoutés</value>
   </data>
   <data name="OffloadAlreadyPresent" xml:space="preserve">
-    <value>Already present</value>
+    <value>Déjà présents</value>
   </data>
   <data name="OffloadByFingerprint" xml:space="preserve">
-    <value>matched by fingerprint</value>
+    <value>correspondance par empreinte</value>
   </data>
   <data name="OffloadExcluded" xml:space="preserve">
-    <value>Excluded folder</value>
+    <value>Dossier exclu</value>
   </data>
   <data name="OffloadReport" xml:space="preserve">
-    <value>Offload Report</value>
+    <value>Rapport de décharge</value>
   </data>
   <data name="OffloadJob" xml:space="preserve">
-    <value>Offload</value>
+    <value>Décharge</value>
   </data>
 </root>

--- a/Resources/SharedResource.fr.resx
+++ b/Resources/SharedResource.fr.resx
@@ -3203,6 +3203,18 @@
   <data name="OffloadSelectTarget" xml:space="preserve">
     <value>Sélectionner une boîte aux lettres de destination…</value>
   </data>
+  <data name="OffloadLoadingFolders" xml:space="preserve">
+    <value>Chargement des dossiers…</value>
+  </data>
+  <data name="OffloadSelectFolder" xml:space="preserve">
+    <value>-- Sélectionner un dossier de destination --</value>
+  </data>
+  <data name="OffloadErrorLoadingFolders" xml:space="preserve">
+    <value>Erreur lors du chargement des dossiers</value>
+  </data>
+  <data name="OffloadSelectTargetFirst" xml:space="preserve">
+    <value>Sélectionnez d'abord une boîte aux lettres</value>
+  </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Dossier racine dans la boîte aux lettres de destination. Avec INBOX la structure des dossiers source est recréée au niveau supérieur.</value>
   </data>

--- a/Resources/SharedResource.fr.resx
+++ b/Resources/SharedResource.fr.resx
@@ -3263,6 +3263,9 @@
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>No other enabled IMAP account is available as a target. Create one first.</value>
   </data>
+  <data name="OffloadNoTargetsAssigned" xml:space="preserve">
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+  </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>
   </data>

--- a/Resources/SharedResource.fr.resx
+++ b/Resources/SharedResource.fr.resx
@@ -3188,4 +3188,127 @@
   <data name="FailuresAcknowledged" xml:space="preserve">
     <value>Échecs reconnus</value>
   </data>
+  <data name="OffloadTitle" xml:space="preserve">
+    <value>Offload to Another Mailbox</value>
+  </data>
+  <data name="OffloadIntro" xml:space="preserve">
+    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+  </data>
+  <data name="OffloadSourceAndTarget" xml:space="preserve">
+    <value>Source and Target</value>
+  </data>
+  <data name="SourceAccount" xml:space="preserve">
+    <value>Source Account</value>
+  </data>
+  <data name="OffloadSelectTarget" xml:space="preserve">
+    <value>Select a target mailbox...</value>
+  </data>
+  <data name="OffloadTargetFolderHelp" xml:space="preserve">
+    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+  </data>
+  <data name="OffloadWindow" xml:space="preserve">
+    <value>Date Window</value>
+  </data>
+  <data name="OffloadWindowMonths" xml:space="preserve">
+    <value>Last N months</value>
+  </data>
+  <data name="OffloadWindowMonthsHelp" xml:space="preserve">
+    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+  </data>
+  <data name="OffloadCutoffFrom" xml:space="preserve">
+    <value>From date</value>
+  </data>
+  <data name="OffloadCutoffFromHelp" xml:space="preserve">
+    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+  </data>
+  <data name="OffloadCutoffTo" xml:space="preserve">
+    <value>To date (optional)</value>
+  </data>
+  <data name="OffloadCutoffToHelp" xml:space="preserve">
+    <value>Inclusive, up to 23:59:59 of this day.</value>
+  </data>
+  <data name="OffloadOptions" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="OffloadDryRun" xml:space="preserve">
+    <value>Dry run</value>
+  </data>
+  <data name="OffloadDryRunHelp" xml:space="preserve">
+    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+  </data>
+  <data name="OffloadMarkAsSeen" xml:space="preserve">
+    <value>Mark appended mail as read</value>
+  </data>
+  <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
+    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+  </data>
+  <data name="OffloadFolderHandling" xml:space="preserve">
+    <value>Folder Handling</value>
+  </data>
+  <data name="OffloadExcludedFolders" xml:space="preserve">
+    <value>Excluded source folders</value>
+  </data>
+  <data name="OffloadRenameMap" xml:space="preserve">
+    <value>Folder rename map</value>
+  </data>
+  <data name="OffloadNoneConfigured" xml:space="preserve">
+    <value>none configured</value>
+  </data>
+  <data name="OffloadFolderHandlingHelp" xml:space="preserve">
+    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+  </data>
+  <data name="OffloadStart" xml:space="preserve">
+    <value>Start Offload</value>
+  </data>
+  <data name="OffloadNoTargets" xml:space="preserve">
+    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+  </data>
+  <data name="OffloadTargetRequired" xml:space="preserve">
+    <value>Please choose a target mailbox.</value>
+  </data>
+  <data name="OffloadTargetMustDiffer" xml:space="preserve">
+    <value>The target mailbox must be different from the source.</value>
+  </data>
+  <data name="OffloadTargetNotFound" xml:space="preserve">
+    <value>The selected target mailbox no longer exists.</value>
+  </data>
+  <data name="OffloadTargetMustBeImap" xml:space="preserve">
+    <value>The target mailbox must be an IMAP account.</value>
+  </data>
+  <data name="OffloadTargetDisabled" xml:space="preserve">
+    <value>The selected target mailbox is disabled.</value>
+  </data>
+  <data name="OffloadCutoffRequired" xml:space="preserve">
+    <value>Please give either a month window or a from date.</value>
+  </data>
+  <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
+    <value>The to date must not be earlier than the from date.</value>
+  </data>
+  <data name="OffloadNothingInWindow" xml:space="preserve">
+    <value>No archived mail falls inside that date window.</value>
+  </data>
+  <data name="OffloadQueued" xml:space="preserve">
+    <value>Offload queued for {0} mails.</value>
+  </data>
+  <data name="OffloadDryRunQueued" xml:space="preserve">
+    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+  </data>
+  <data name="OffloadAppended" xml:space="preserve">
+    <value>Appended</value>
+  </data>
+  <data name="OffloadAlreadyPresent" xml:space="preserve">
+    <value>Already present</value>
+  </data>
+  <data name="OffloadByFingerprint" xml:space="preserve">
+    <value>matched by fingerprint</value>
+  </data>
+  <data name="OffloadExcluded" xml:space="preserve">
+    <value>Excluded folder</value>
+  </data>
+  <data name="OffloadReport" xml:space="preserve">
+    <value>Offload Report</value>
+  </data>
+  <data name="OffloadJob" xml:space="preserve">
+    <value>Offload</value>
+  </data>
 </root>

--- a/Resources/SharedResource.hu.resx
+++ b/Resources/SharedResource.hu.resx
@@ -3180,4 +3180,127 @@
   <data name="FailuresAcknowledged" xml:space="preserve">
     <value>Hibák elismerve</value>
   </data>
+  <data name="OffloadTitle" xml:space="preserve">
+    <value>Offload to Another Mailbox</value>
+  </data>
+  <data name="OffloadIntro" xml:space="preserve">
+    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+  </data>
+  <data name="OffloadSourceAndTarget" xml:space="preserve">
+    <value>Source and Target</value>
+  </data>
+  <data name="SourceAccount" xml:space="preserve">
+    <value>Source Account</value>
+  </data>
+  <data name="OffloadSelectTarget" xml:space="preserve">
+    <value>Select a target mailbox...</value>
+  </data>
+  <data name="OffloadTargetFolderHelp" xml:space="preserve">
+    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+  </data>
+  <data name="OffloadWindow" xml:space="preserve">
+    <value>Date Window</value>
+  </data>
+  <data name="OffloadWindowMonths" xml:space="preserve">
+    <value>Last N months</value>
+  </data>
+  <data name="OffloadWindowMonthsHelp" xml:space="preserve">
+    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+  </data>
+  <data name="OffloadCutoffFrom" xml:space="preserve">
+    <value>From date</value>
+  </data>
+  <data name="OffloadCutoffFromHelp" xml:space="preserve">
+    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+  </data>
+  <data name="OffloadCutoffTo" xml:space="preserve">
+    <value>To date (optional)</value>
+  </data>
+  <data name="OffloadCutoffToHelp" xml:space="preserve">
+    <value>Inclusive, up to 23:59:59 of this day.</value>
+  </data>
+  <data name="OffloadOptions" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="OffloadDryRun" xml:space="preserve">
+    <value>Dry run</value>
+  </data>
+  <data name="OffloadDryRunHelp" xml:space="preserve">
+    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+  </data>
+  <data name="OffloadMarkAsSeen" xml:space="preserve">
+    <value>Mark appended mail as read</value>
+  </data>
+  <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
+    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+  </data>
+  <data name="OffloadFolderHandling" xml:space="preserve">
+    <value>Folder Handling</value>
+  </data>
+  <data name="OffloadExcludedFolders" xml:space="preserve">
+    <value>Excluded source folders</value>
+  </data>
+  <data name="OffloadRenameMap" xml:space="preserve">
+    <value>Folder rename map</value>
+  </data>
+  <data name="OffloadNoneConfigured" xml:space="preserve">
+    <value>none configured</value>
+  </data>
+  <data name="OffloadFolderHandlingHelp" xml:space="preserve">
+    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+  </data>
+  <data name="OffloadStart" xml:space="preserve">
+    <value>Start Offload</value>
+  </data>
+  <data name="OffloadNoTargets" xml:space="preserve">
+    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+  </data>
+  <data name="OffloadTargetRequired" xml:space="preserve">
+    <value>Please choose a target mailbox.</value>
+  </data>
+  <data name="OffloadTargetMustDiffer" xml:space="preserve">
+    <value>The target mailbox must be different from the source.</value>
+  </data>
+  <data name="OffloadTargetNotFound" xml:space="preserve">
+    <value>The selected target mailbox no longer exists.</value>
+  </data>
+  <data name="OffloadTargetMustBeImap" xml:space="preserve">
+    <value>The target mailbox must be an IMAP account.</value>
+  </data>
+  <data name="OffloadTargetDisabled" xml:space="preserve">
+    <value>The selected target mailbox is disabled.</value>
+  </data>
+  <data name="OffloadCutoffRequired" xml:space="preserve">
+    <value>Please give either a month window or a from date.</value>
+  </data>
+  <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
+    <value>The to date must not be earlier than the from date.</value>
+  </data>
+  <data name="OffloadNothingInWindow" xml:space="preserve">
+    <value>No archived mail falls inside that date window.</value>
+  </data>
+  <data name="OffloadQueued" xml:space="preserve">
+    <value>Offload queued for {0} mails.</value>
+  </data>
+  <data name="OffloadDryRunQueued" xml:space="preserve">
+    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+  </data>
+  <data name="OffloadAppended" xml:space="preserve">
+    <value>Appended</value>
+  </data>
+  <data name="OffloadAlreadyPresent" xml:space="preserve">
+    <value>Already present</value>
+  </data>
+  <data name="OffloadByFingerprint" xml:space="preserve">
+    <value>matched by fingerprint</value>
+  </data>
+  <data name="OffloadExcluded" xml:space="preserve">
+    <value>Excluded folder</value>
+  </data>
+  <data name="OffloadReport" xml:space="preserve">
+    <value>Offload Report</value>
+  </data>
+  <data name="OffloadJob" xml:space="preserve">
+    <value>Offload</value>
+  </data>
 </root>

--- a/Resources/SharedResource.hu.resx
+++ b/Resources/SharedResource.hu.resx
@@ -3181,129 +3181,129 @@
     <value>Hibák elismerve</value>
   </data>
   <data name="OffloadTitle" xml:space="preserve">
-    <value>Offload to Another Mailbox</value>
+    <value>Átvitel másik postafiókba</value>
   </data>
   <data name="OffloadIntro" xml:space="preserve">
-    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+    <value>A levágási dátumnál újabb archivált leveleket fűzi egy másik postafiókba, átugorva azt, ami már ott van. A régebbi levelek az archívumban maradnak. Újrafuttatás biztonságos, és nem duplikálja a már megérkezett leveleket.</value>
   </data>
   <data name="OffloadSourceAndTarget" xml:space="preserve">
-    <value>Source and Target</value>
+    <value>Forrás és cél</value>
   </data>
   <data name="SourceAccount" xml:space="preserve">
-    <value>Source Account</value>
+    <value>Forrásfiók</value>
   </data>
   <data name="OffloadSelectTarget" xml:space="preserve">
-    <value>Select a target mailbox...</value>
+    <value>Célpostafiók kiválasztása…</value>
   </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
-    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+    <value>Gyökérmappa a célpostafiókban. INBOX esetén a forrásmappa-struktúra felső szinten újraépül.</value>
   </data>
   <data name="OffloadWindow" xml:space="preserve">
-    <value>Date Window</value>
+    <value>Időablak</value>
   </data>
   <data name="OffloadWindowMonths" xml:space="preserve">
-    <value>Last N months</value>
+    <value>Utolsó N hónap</value>
   </data>
   <data name="OffloadWindowMonthsHelp" xml:space="preserve">
-    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+    <value>A feladat indításakor egy fix dátumra feloldódik, így a megismételt futtatás ugyanazokat a leveleket választja. 0 esetén explicit dátum használata.</value>
   </data>
   <data name="OffloadCutoffFrom" xml:space="preserve">
-    <value>From date</value>
+    <value>Dátumtól</value>
   </data>
   <data name="OffloadCutoffFromHelp" xml:space="preserve">
-    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+    <value>Felülírja a hónap-ablakot. Befoglaló, a nap 00:00 órájától.</value>
   </data>
   <data name="OffloadCutoffTo" xml:space="preserve">
-    <value>To date (optional)</value>
+    <value>Dátumig (opcionális)</value>
   </data>
   <data name="OffloadCutoffToHelp" xml:space="preserve">
-    <value>Inclusive, up to 23:59:59 of this day.</value>
+    <value>Befoglaló, a nap 23:59:59 órájáig.</value>
   </data>
   <data name="OffloadOptions" xml:space="preserve">
-    <value>Options</value>
+    <value>Beállítások</value>
   </data>
   <data name="OffloadDryRun" xml:space="preserve">
-    <value>Dry run</value>
+    <value>Tesztfuttatás</value>
   </data>
   <data name="OffloadDryRunHelp" xml:space="preserve">
-    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+    <value>Mindent felold és mappánként jelenti, mi történne, de nem fűz hozzá semmit. Valódi futtatás előtt javasolt.</value>
   </data>
   <data name="OffloadMarkAsSeen" xml:space="preserve">
-    <value>Mark appended mail as read</value>
+    <value>Hozzáfűzött levelek megjelölése olvasottként</value>
   </data>
   <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
-    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+    <value>Kikapcsolva a olvasatlan levelek olvasatlanok maradnak a célpostafiókban.</value>
   </data>
   <data name="OffloadFolderHandling" xml:space="preserve">
-    <value>Folder Handling</value>
+    <value>Mappakezelés</value>
   </data>
   <data name="OffloadExcludedFolders" xml:space="preserve">
-    <value>Excluded source folders</value>
+    <value>Kizárt forrásmappák</value>
   </data>
   <data name="OffloadRenameMap" xml:space="preserve">
-    <value>Folder rename map</value>
+    <value>Mappa-átnevezési térkép</value>
   </data>
   <data name="OffloadNoneConfigured" xml:space="preserve">
-    <value>none configured</value>
+    <value>nincs beállítva</value>
   </data>
   <data name="OffloadFolderHandlingHelp" xml:space="preserve">
-    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+    <value>Mindkettő az appsettings.json Offload szakaszában állítható be, és alapértelmezetten üres. A kizárások az átnevezés előtt kerülnek ellenőrzésre, és az almappákra is vonatkoznak.</value>
   </data>
   <data name="OffloadStart" xml:space="preserve">
-    <value>Start Offload</value>
+    <value>Átvitel indítása</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+    <value>Nincs másik engedélyezett IMAP-fiók célként. Hozzon létre először egyet.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+    <value>Az Önhöz rendelt postafiókok egyike sem használható célként. Kérjen egy másik engedélyezett IMAP-fiók hozzárendelését az adminisztrátortól.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
-    <value>Please choose a target mailbox.</value>
+    <value>Válasszon célpostafiókot.</value>
   </data>
   <data name="OffloadTargetMustDiffer" xml:space="preserve">
-    <value>The target mailbox must be different from the source.</value>
+    <value>A célpostafiók nem egyezhet a forrással.</value>
   </data>
   <data name="OffloadTargetNotFound" xml:space="preserve">
-    <value>The selected target mailbox no longer exists.</value>
+    <value>A kiválasztott célpostafiók már nem létezik.</value>
   </data>
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
-    <value>The target mailbox must be an IMAP account.</value>
+    <value>A célpostafióknak IMAP-fióknak kell lennie.</value>
   </data>
   <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>The selected target mailbox is disabled.</value>
+    <value>A kiválasztott célpostafiók le van tiltva.</value>
   </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
-    <value>Please give either a month window or a from date.</value>
+    <value>Adjon meg hónap-ablakot vagy dátumtól értéket.</value>
   </data>
   <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
-    <value>The to date must not be earlier than the from date.</value>
+    <value>A dátumig nem lehet korábbi a dátumtól-nál.</value>
   </data>
   <data name="OffloadNothingInWindow" xml:space="preserve">
-    <value>No archived mail falls inside that date window.</value>
+    <value>Ebbe az időablakba nem esik archivált levél.</value>
   </data>
   <data name="OffloadQueued" xml:space="preserve">
-    <value>Offload queued for {0} mails.</value>
+    <value>Átvitel sorba állítva {0} levélhez.</value>
   </data>
   <data name="OffloadDryRunQueued" xml:space="preserve">
-    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+    <value>Tesztfuttatás sorba állítva {0} levélhez. Semmi sem lesz hozzáfűzve.</value>
   </data>
   <data name="OffloadAppended" xml:space="preserve">
-    <value>Appended</value>
+    <value>Hozzáfűzve</value>
   </data>
   <data name="OffloadAlreadyPresent" xml:space="preserve">
-    <value>Already present</value>
+    <value>Már jelenlévő</value>
   </data>
   <data name="OffloadByFingerprint" xml:space="preserve">
-    <value>matched by fingerprint</value>
+    <value>ujjlenyomat alapján illesztve</value>
   </data>
   <data name="OffloadExcluded" xml:space="preserve">
-    <value>Excluded folder</value>
+    <value>Kizárt mappa</value>
   </data>
   <data name="OffloadReport" xml:space="preserve">
-    <value>Offload Report</value>
+    <value>Átviteli jelentés</value>
   </data>
   <data name="OffloadJob" xml:space="preserve">
-    <value>Offload</value>
+    <value>Átvitel</value>
   </data>
 </root>

--- a/Resources/SharedResource.hu.resx
+++ b/Resources/SharedResource.hu.resx
@@ -3195,6 +3195,18 @@
   <data name="OffloadSelectTarget" xml:space="preserve">
     <value>Célpostafiók kiválasztása…</value>
   </data>
+  <data name="OffloadLoadingFolders" xml:space="preserve">
+    <value>Mappák betöltése…</value>
+  </data>
+  <data name="OffloadSelectFolder" xml:space="preserve">
+    <value>-- Válasszon cél-mappát --</value>
+  </data>
+  <data name="OffloadErrorLoadingFolders" xml:space="preserve">
+    <value>Hiba a mappák betöltésekor</value>
+  </data>
+  <data name="OffloadSelectTargetFirst" xml:space="preserve">
+    <value>Először válasszon cél-postafiókot</value>
+  </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Gyökérmappa a célpostafiókban. INBOX esetén a forrásmappa-struktúra felső szinten újraépül.</value>
   </data>

--- a/Resources/SharedResource.hu.resx
+++ b/Resources/SharedResource.hu.resx
@@ -3255,6 +3255,9 @@
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>No other enabled IMAP account is available as a target. Create one first.</value>
   </data>
+  <data name="OffloadNoTargetsAssigned" xml:space="preserve">
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+  </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>
   </data>

--- a/Resources/SharedResource.it.resx
+++ b/Resources/SharedResource.it.resx
@@ -3188,4 +3188,127 @@
   <data name="FailuresAcknowledged" xml:space="preserve">
     <value>Errori riconosciuti</value>
   </data>
+  <data name="OffloadTitle" xml:space="preserve">
+    <value>Offload to Another Mailbox</value>
+  </data>
+  <data name="OffloadIntro" xml:space="preserve">
+    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+  </data>
+  <data name="OffloadSourceAndTarget" xml:space="preserve">
+    <value>Source and Target</value>
+  </data>
+  <data name="SourceAccount" xml:space="preserve">
+    <value>Source Account</value>
+  </data>
+  <data name="OffloadSelectTarget" xml:space="preserve">
+    <value>Select a target mailbox...</value>
+  </data>
+  <data name="OffloadTargetFolderHelp" xml:space="preserve">
+    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+  </data>
+  <data name="OffloadWindow" xml:space="preserve">
+    <value>Date Window</value>
+  </data>
+  <data name="OffloadWindowMonths" xml:space="preserve">
+    <value>Last N months</value>
+  </data>
+  <data name="OffloadWindowMonthsHelp" xml:space="preserve">
+    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+  </data>
+  <data name="OffloadCutoffFrom" xml:space="preserve">
+    <value>From date</value>
+  </data>
+  <data name="OffloadCutoffFromHelp" xml:space="preserve">
+    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+  </data>
+  <data name="OffloadCutoffTo" xml:space="preserve">
+    <value>To date (optional)</value>
+  </data>
+  <data name="OffloadCutoffToHelp" xml:space="preserve">
+    <value>Inclusive, up to 23:59:59 of this day.</value>
+  </data>
+  <data name="OffloadOptions" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="OffloadDryRun" xml:space="preserve">
+    <value>Dry run</value>
+  </data>
+  <data name="OffloadDryRunHelp" xml:space="preserve">
+    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+  </data>
+  <data name="OffloadMarkAsSeen" xml:space="preserve">
+    <value>Mark appended mail as read</value>
+  </data>
+  <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
+    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+  </data>
+  <data name="OffloadFolderHandling" xml:space="preserve">
+    <value>Folder Handling</value>
+  </data>
+  <data name="OffloadExcludedFolders" xml:space="preserve">
+    <value>Excluded source folders</value>
+  </data>
+  <data name="OffloadRenameMap" xml:space="preserve">
+    <value>Folder rename map</value>
+  </data>
+  <data name="OffloadNoneConfigured" xml:space="preserve">
+    <value>none configured</value>
+  </data>
+  <data name="OffloadFolderHandlingHelp" xml:space="preserve">
+    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+  </data>
+  <data name="OffloadStart" xml:space="preserve">
+    <value>Start Offload</value>
+  </data>
+  <data name="OffloadNoTargets" xml:space="preserve">
+    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+  </data>
+  <data name="OffloadTargetRequired" xml:space="preserve">
+    <value>Please choose a target mailbox.</value>
+  </data>
+  <data name="OffloadTargetMustDiffer" xml:space="preserve">
+    <value>The target mailbox must be different from the source.</value>
+  </data>
+  <data name="OffloadTargetNotFound" xml:space="preserve">
+    <value>The selected target mailbox no longer exists.</value>
+  </data>
+  <data name="OffloadTargetMustBeImap" xml:space="preserve">
+    <value>The target mailbox must be an IMAP account.</value>
+  </data>
+  <data name="OffloadTargetDisabled" xml:space="preserve">
+    <value>The selected target mailbox is disabled.</value>
+  </data>
+  <data name="OffloadCutoffRequired" xml:space="preserve">
+    <value>Please give either a month window or a from date.</value>
+  </data>
+  <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
+    <value>The to date must not be earlier than the from date.</value>
+  </data>
+  <data name="OffloadNothingInWindow" xml:space="preserve">
+    <value>No archived mail falls inside that date window.</value>
+  </data>
+  <data name="OffloadQueued" xml:space="preserve">
+    <value>Offload queued for {0} mails.</value>
+  </data>
+  <data name="OffloadDryRunQueued" xml:space="preserve">
+    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+  </data>
+  <data name="OffloadAppended" xml:space="preserve">
+    <value>Appended</value>
+  </data>
+  <data name="OffloadAlreadyPresent" xml:space="preserve">
+    <value>Already present</value>
+  </data>
+  <data name="OffloadByFingerprint" xml:space="preserve">
+    <value>matched by fingerprint</value>
+  </data>
+  <data name="OffloadExcluded" xml:space="preserve">
+    <value>Excluded folder</value>
+  </data>
+  <data name="OffloadReport" xml:space="preserve">
+    <value>Offload Report</value>
+  </data>
+  <data name="OffloadJob" xml:space="preserve">
+    <value>Offload</value>
+  </data>
 </root>

--- a/Resources/SharedResource.it.resx
+++ b/Resources/SharedResource.it.resx
@@ -3203,6 +3203,18 @@
   <data name="OffloadSelectTarget" xml:space="preserve">
     <value>Seleziona una casella di destinazione…</value>
   </data>
+  <data name="OffloadLoadingFolders" xml:space="preserve">
+    <value>Caricamento cartelle…</value>
+  </data>
+  <data name="OffloadSelectFolder" xml:space="preserve">
+    <value>-- Seleziona una cartella di destinazione --</value>
+  </data>
+  <data name="OffloadErrorLoadingFolders" xml:space="preserve">
+    <value>Errore nel caricamento delle cartelle</value>
+  </data>
+  <data name="OffloadSelectTargetFirst" xml:space="preserve">
+    <value>Selezionare prima una casella di destinazione</value>
+  </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Cartella radice nella casella di destinazione. Con INBOX la struttura delle cartelle di origine viene ricreata al livello principale.</value>
   </data>

--- a/Resources/SharedResource.it.resx
+++ b/Resources/SharedResource.it.resx
@@ -3189,129 +3189,129 @@
     <value>Errori riconosciuti</value>
   </data>
   <data name="OffloadTitle" xml:space="preserve">
-    <value>Offload to Another Mailbox</value>
+    <value>Scarica in un'altra casella</value>
   </data>
   <data name="OffloadIntro" xml:space="preserve">
-    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+    <value>Aggiunge la posta archiviata più recente di una data di taglio in un'altra casella, saltando ciò che quella casella contiene già. La posta più vecchia resta nell'archivio. Rieseguirlo è sicuro e non aggiunge nulla di già arrivato.</value>
   </data>
   <data name="OffloadSourceAndTarget" xml:space="preserve">
-    <value>Source and Target</value>
+    <value>Origine e destinazione</value>
   </data>
   <data name="SourceAccount" xml:space="preserve">
-    <value>Source Account</value>
+    <value>Account di origine</value>
   </data>
   <data name="OffloadSelectTarget" xml:space="preserve">
-    <value>Select a target mailbox...</value>
+    <value>Seleziona una casella di destinazione…</value>
   </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
-    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+    <value>Cartella radice nella casella di destinazione. Con INBOX la struttura delle cartelle di origine viene ricreata al livello principale.</value>
   </data>
   <data name="OffloadWindow" xml:space="preserve">
-    <value>Date Window</value>
+    <value>Finestra date</value>
   </data>
   <data name="OffloadWindowMonths" xml:space="preserve">
-    <value>Last N months</value>
+    <value>Ultimi N mesi</value>
   </data>
   <data name="OffloadWindowMonthsHelp" xml:space="preserve">
-    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+    <value>Risolto in una data fissa all'avvio del job, così rieseguire il job seleziona la stessa posta. Imposta a 0 per usare una data esplicita.</value>
   </data>
   <data name="OffloadCutoffFrom" xml:space="preserve">
-    <value>From date</value>
+    <value>Data da</value>
   </data>
   <data name="OffloadCutoffFromHelp" xml:space="preserve">
-    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+    <value>Sostituisce la finestra dei mesi. Inclusivo, dalle 00:00 di questo giorno.</value>
   </data>
   <data name="OffloadCutoffTo" xml:space="preserve">
-    <value>To date (optional)</value>
+    <value>Data a (facoltativo)</value>
   </data>
   <data name="OffloadCutoffToHelp" xml:space="preserve">
-    <value>Inclusive, up to 23:59:59 of this day.</value>
+    <value>Inclusivo, fino alle 23:59:59 di questo giorno.</value>
   </data>
   <data name="OffloadOptions" xml:space="preserve">
-    <value>Options</value>
+    <value>Opzioni</value>
   </data>
   <data name="OffloadDryRun" xml:space="preserve">
-    <value>Dry run</value>
+    <value>Esecuzione di prova</value>
   </data>
   <data name="OffloadDryRunHelp" xml:space="preserve">
-    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+    <value>Risolve tutto e segnala per cartella cosa accadrebbe, ma non aggiunge nulla. Consigliato prima di un'esecuzione reale.</value>
   </data>
   <data name="OffloadMarkAsSeen" xml:space="preserve">
-    <value>Mark appended mail as read</value>
+    <value>Segna la posta aggiunta come letta</value>
   </data>
   <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
-    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+    <value>Disattivandolo la posta non letta resta non letta nella casella di destinazione.</value>
   </data>
   <data name="OffloadFolderHandling" xml:space="preserve">
-    <value>Folder Handling</value>
+    <value>Gestione cartelle</value>
   </data>
   <data name="OffloadExcludedFolders" xml:space="preserve">
-    <value>Excluded source folders</value>
+    <value>Cartelle di origine escluse</value>
   </data>
   <data name="OffloadRenameMap" xml:space="preserve">
-    <value>Folder rename map</value>
+    <value>Mappa di rinomina cartelle</value>
   </data>
   <data name="OffloadNoneConfigured" xml:space="preserve">
-    <value>none configured</value>
+    <value>nessuno configurato</value>
   </data>
   <data name="OffloadFolderHandlingHelp" xml:space="preserve">
-    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+    <value>Entrambi sono configurati nella sezione Offload di appsettings.json e sono vuoti per impostazione predefinita. Le esclusioni sono applicate prima della rinomina e coprono le sottocartelle.</value>
   </data>
   <data name="OffloadStart" xml:space="preserve">
-    <value>Start Offload</value>
+    <value>Avvia scaricamento</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+    <value>Nessun altro account IMAP abilitato disponibile come destinazione. Crearne uno prima.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+    <value>Nessuna delle caselle assegnate a te può essere usata come destinazione. Chiedi a un amministratore di assegnarti un altro account IMAP abilitato.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
-    <value>Please choose a target mailbox.</value>
+    <value>Scegliere una casella di destinazione.</value>
   </data>
   <data name="OffloadTargetMustDiffer" xml:space="preserve">
-    <value>The target mailbox must be different from the source.</value>
+    <value>La casella di destinazione deve essere diversa dall'origine.</value>
   </data>
   <data name="OffloadTargetNotFound" xml:space="preserve">
-    <value>The selected target mailbox no longer exists.</value>
+    <value>La casella di destinazione selezionata non esiste più.</value>
   </data>
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
-    <value>The target mailbox must be an IMAP account.</value>
+    <value>La casella di destinazione deve essere un account IMAP.</value>
   </data>
   <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>The selected target mailbox is disabled.</value>
+    <value>La casella di destinazione selezionata è disabilitata.</value>
   </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
-    <value>Please give either a month window or a from date.</value>
+    <value>Fornire una finestra di mesi o una data di inizio.</value>
   </data>
   <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
-    <value>The to date must not be earlier than the from date.</value>
+    <value>La data di fine non deve essere precedente alla data di inizio.</value>
   </data>
   <data name="OffloadNothingInWindow" xml:space="preserve">
-    <value>No archived mail falls inside that date window.</value>
+    <value>Nessuna posta archiviata rientra in quella finestra di date.</value>
   </data>
   <data name="OffloadQueued" xml:space="preserve">
-    <value>Offload queued for {0} mails.</value>
+    <value>Scaricamento accodato per {0} messaggi.</value>
   </data>
   <data name="OffloadDryRunQueued" xml:space="preserve">
-    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+    <value>Esecuzione di prova accodata per {0} messaggi. Non sarà aggiunto nulla.</value>
   </data>
   <data name="OffloadAppended" xml:space="preserve">
-    <value>Appended</value>
+    <value>Aggiunti</value>
   </data>
   <data name="OffloadAlreadyPresent" xml:space="preserve">
-    <value>Already present</value>
+    <value>Già presenti</value>
   </data>
   <data name="OffloadByFingerprint" xml:space="preserve">
-    <value>matched by fingerprint</value>
+    <value>corrispondenza per impronta</value>
   </data>
   <data name="OffloadExcluded" xml:space="preserve">
-    <value>Excluded folder</value>
+    <value>Cartella esclusa</value>
   </data>
   <data name="OffloadReport" xml:space="preserve">
-    <value>Offload Report</value>
+    <value>Report scaricamento</value>
   </data>
   <data name="OffloadJob" xml:space="preserve">
-    <value>Offload</value>
+    <value>Scaricamento</value>
   </data>
 </root>

--- a/Resources/SharedResource.it.resx
+++ b/Resources/SharedResource.it.resx
@@ -3263,6 +3263,9 @@
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>No other enabled IMAP account is available as a target. Create one first.</value>
   </data>
+  <data name="OffloadNoTargetsAssigned" xml:space="preserve">
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+  </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>
   </data>

--- a/Resources/SharedResource.nl.resx
+++ b/Resources/SharedResource.nl.resx
@@ -3188,4 +3188,127 @@
   <data name="FailuresAcknowledged" xml:space="preserve">
     <value>Fouten erkend</value>
   </data>
+  <data name="OffloadTitle" xml:space="preserve">
+    <value>Offload to Another Mailbox</value>
+  </data>
+  <data name="OffloadIntro" xml:space="preserve">
+    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+  </data>
+  <data name="OffloadSourceAndTarget" xml:space="preserve">
+    <value>Source and Target</value>
+  </data>
+  <data name="SourceAccount" xml:space="preserve">
+    <value>Source Account</value>
+  </data>
+  <data name="OffloadSelectTarget" xml:space="preserve">
+    <value>Select a target mailbox...</value>
+  </data>
+  <data name="OffloadTargetFolderHelp" xml:space="preserve">
+    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+  </data>
+  <data name="OffloadWindow" xml:space="preserve">
+    <value>Date Window</value>
+  </data>
+  <data name="OffloadWindowMonths" xml:space="preserve">
+    <value>Last N months</value>
+  </data>
+  <data name="OffloadWindowMonthsHelp" xml:space="preserve">
+    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+  </data>
+  <data name="OffloadCutoffFrom" xml:space="preserve">
+    <value>From date</value>
+  </data>
+  <data name="OffloadCutoffFromHelp" xml:space="preserve">
+    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+  </data>
+  <data name="OffloadCutoffTo" xml:space="preserve">
+    <value>To date (optional)</value>
+  </data>
+  <data name="OffloadCutoffToHelp" xml:space="preserve">
+    <value>Inclusive, up to 23:59:59 of this day.</value>
+  </data>
+  <data name="OffloadOptions" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="OffloadDryRun" xml:space="preserve">
+    <value>Dry run</value>
+  </data>
+  <data name="OffloadDryRunHelp" xml:space="preserve">
+    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+  </data>
+  <data name="OffloadMarkAsSeen" xml:space="preserve">
+    <value>Mark appended mail as read</value>
+  </data>
+  <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
+    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+  </data>
+  <data name="OffloadFolderHandling" xml:space="preserve">
+    <value>Folder Handling</value>
+  </data>
+  <data name="OffloadExcludedFolders" xml:space="preserve">
+    <value>Excluded source folders</value>
+  </data>
+  <data name="OffloadRenameMap" xml:space="preserve">
+    <value>Folder rename map</value>
+  </data>
+  <data name="OffloadNoneConfigured" xml:space="preserve">
+    <value>none configured</value>
+  </data>
+  <data name="OffloadFolderHandlingHelp" xml:space="preserve">
+    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+  </data>
+  <data name="OffloadStart" xml:space="preserve">
+    <value>Start Offload</value>
+  </data>
+  <data name="OffloadNoTargets" xml:space="preserve">
+    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+  </data>
+  <data name="OffloadTargetRequired" xml:space="preserve">
+    <value>Please choose a target mailbox.</value>
+  </data>
+  <data name="OffloadTargetMustDiffer" xml:space="preserve">
+    <value>The target mailbox must be different from the source.</value>
+  </data>
+  <data name="OffloadTargetNotFound" xml:space="preserve">
+    <value>The selected target mailbox no longer exists.</value>
+  </data>
+  <data name="OffloadTargetMustBeImap" xml:space="preserve">
+    <value>The target mailbox must be an IMAP account.</value>
+  </data>
+  <data name="OffloadTargetDisabled" xml:space="preserve">
+    <value>The selected target mailbox is disabled.</value>
+  </data>
+  <data name="OffloadCutoffRequired" xml:space="preserve">
+    <value>Please give either a month window or a from date.</value>
+  </data>
+  <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
+    <value>The to date must not be earlier than the from date.</value>
+  </data>
+  <data name="OffloadNothingInWindow" xml:space="preserve">
+    <value>No archived mail falls inside that date window.</value>
+  </data>
+  <data name="OffloadQueued" xml:space="preserve">
+    <value>Offload queued for {0} mails.</value>
+  </data>
+  <data name="OffloadDryRunQueued" xml:space="preserve">
+    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+  </data>
+  <data name="OffloadAppended" xml:space="preserve">
+    <value>Appended</value>
+  </data>
+  <data name="OffloadAlreadyPresent" xml:space="preserve">
+    <value>Already present</value>
+  </data>
+  <data name="OffloadByFingerprint" xml:space="preserve">
+    <value>matched by fingerprint</value>
+  </data>
+  <data name="OffloadExcluded" xml:space="preserve">
+    <value>Excluded folder</value>
+  </data>
+  <data name="OffloadReport" xml:space="preserve">
+    <value>Offload Report</value>
+  </data>
+  <data name="OffloadJob" xml:space="preserve">
+    <value>Offload</value>
+  </data>
 </root>

--- a/Resources/SharedResource.nl.resx
+++ b/Resources/SharedResource.nl.resx
@@ -3189,129 +3189,129 @@
     <value>Fouten erkend</value>
   </data>
   <data name="OffloadTitle" xml:space="preserve">
-    <value>Offload to Another Mailbox</value>
+    <value>Naar ander postvak overbrengen</value>
   </data>
   <data name="OffloadIntro" xml:space="preserve">
-    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+    <value>Voegt gearchiveerde mail nieuwer dan een afkapdatum toe aan een ander postvak en slaat over wat dat postvak al bevat. Oudere mail blijft in het archief. Opnieuw uitvoeren is veilig en voegt niets toe wat al is aangekomen.</value>
   </data>
   <data name="OffloadSourceAndTarget" xml:space="preserve">
-    <value>Source and Target</value>
+    <value>Bron en doel</value>
   </data>
   <data name="SourceAccount" xml:space="preserve">
-    <value>Source Account</value>
+    <value>Bronaccount</value>
   </data>
   <data name="OffloadSelectTarget" xml:space="preserve">
-    <value>Select a target mailbox...</value>
+    <value>Selecteer een doelpostvak…</value>
   </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
-    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+    <value>Hoofdmap in het doelpostvak. Met INBOX wordt de bronmapstructuur op het hoogste niveau gereconstrueerd.</value>
   </data>
   <data name="OffloadWindow" xml:space="preserve">
-    <value>Date Window</value>
+    <value>Datumvenster</value>
   </data>
   <data name="OffloadWindowMonths" xml:space="preserve">
-    <value>Last N months</value>
+    <value>Laatste N maanden</value>
   </data>
   <data name="OffloadWindowMonthsHelp" xml:space="preserve">
-    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+    <value>Wordt bij start van de taak omgezet naar een vaste datum, zodat herhaling dezelfde mail selecteert. Stel in op 0 om een expliciete datum te gebruiken.</value>
   </data>
   <data name="OffloadCutoffFrom" xml:space="preserve">
-    <value>From date</value>
+    <value>Vanaf datum</value>
   </data>
   <data name="OffloadCutoffFromHelp" xml:space="preserve">
-    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+    <value>Negeert het maandvenster. Inclusief, vanaf 00:00 van deze dag.</value>
   </data>
   <data name="OffloadCutoffTo" xml:space="preserve">
-    <value>To date (optional)</value>
+    <value>Tot datum (optioneel)</value>
   </data>
   <data name="OffloadCutoffToHelp" xml:space="preserve">
-    <value>Inclusive, up to 23:59:59 of this day.</value>
+    <value>Inclusief, tot 23:59:59 van deze dag.</value>
   </data>
   <data name="OffloadOptions" xml:space="preserve">
-    <value>Options</value>
+    <value>Opties</value>
   </data>
   <data name="OffloadDryRun" xml:space="preserve">
-    <value>Dry run</value>
+    <value>Proefrun</value>
   </data>
   <data name="OffloadDryRunHelp" xml:space="preserve">
-    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+    <value>Lost alles op en meldt per map wat er zou gebeuren, maar voegt niets toe. Aanbevolen voor een echte run.</value>
   </data>
   <data name="OffloadMarkAsSeen" xml:space="preserve">
-    <value>Mark appended mail as read</value>
+    <value>Toegevoegde mail markeren als gelezen</value>
   </data>
   <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
-    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+    <value>Schakel dit uit om ongelezen mail in het doelpostvak ongelezen te houden.</value>
   </data>
   <data name="OffloadFolderHandling" xml:space="preserve">
-    <value>Folder Handling</value>
+    <value>Mapafhandeling</value>
   </data>
   <data name="OffloadExcludedFolders" xml:space="preserve">
-    <value>Excluded source folders</value>
+    <value>Uitgesloten bronmappen</value>
   </data>
   <data name="OffloadRenameMap" xml:space="preserve">
-    <value>Folder rename map</value>
+    <value>Mapnaam wijzigingstabel</value>
   </data>
   <data name="OffloadNoneConfigured" xml:space="preserve">
-    <value>none configured</value>
+    <value>geen geconfigureerd</value>
   </data>
   <data name="OffloadFolderHandlingHelp" xml:space="preserve">
-    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+    <value>Beide worden in de sectie Offload van appsettings.json geconfigureerd en zijn standaard leeg. Uitsluitingen worden vóór het hernoemen toegepast en dekken submappen.</value>
   </data>
   <data name="OffloadStart" xml:space="preserve">
-    <value>Start Offload</value>
+    <value>Overbrengen starten</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+    <value>Geen ander ingeschakeld IMAP-account beschikbaar als doel. Maak er eerst een aan.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+    <value>Geen van de aan u toegewezen postvakken kan als doel worden gebruikt. Vraag een beheerder om een ander ingeschakeld IMAP-account toe te wijzen.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
-    <value>Please choose a target mailbox.</value>
+    <value>Kies een doelpostvak.</value>
   </data>
   <data name="OffloadTargetMustDiffer" xml:space="preserve">
-    <value>The target mailbox must be different from the source.</value>
+    <value>Het doelpostvak moet verschillen van de bron.</value>
   </data>
   <data name="OffloadTargetNotFound" xml:space="preserve">
-    <value>The selected target mailbox no longer exists.</value>
+    <value>Het geselecteerde doelpostvak bestaat niet meer.</value>
   </data>
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
-    <value>The target mailbox must be an IMAP account.</value>
+    <value>Het doelpostvak moet een IMAP-account zijn.</value>
   </data>
   <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>The selected target mailbox is disabled.</value>
+    <value>Het geselecteerde doelpostvak is uitgeschakeld.</value>
   </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
-    <value>Please give either a month window or a from date.</value>
+    <value>Geef een maandvenster of een vanaf-datum op.</value>
   </data>
   <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
-    <value>The to date must not be earlier than the from date.</value>
+    <value>De tot-datum mag niet vóór de vanaf-datum liggen.</value>
   </data>
   <data name="OffloadNothingInWindow" xml:space="preserve">
-    <value>No archived mail falls inside that date window.</value>
+    <value>Er valt geen gearchiveerde mail binnen dat datumvenster.</value>
   </data>
   <data name="OffloadQueued" xml:space="preserve">
-    <value>Offload queued for {0} mails.</value>
+    <value>Overbrengen in de wachtrij voor {0} mails.</value>
   </data>
   <data name="OffloadDryRunQueued" xml:space="preserve">
-    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+    <value>Proefrun in de wachtrij voor {0} mails. Er wordt niets toegevoegd.</value>
   </data>
   <data name="OffloadAppended" xml:space="preserve">
-    <value>Appended</value>
+    <value>Toegevoegd</value>
   </data>
   <data name="OffloadAlreadyPresent" xml:space="preserve">
-    <value>Already present</value>
+    <value>Reeds aanwezig</value>
   </data>
   <data name="OffloadByFingerprint" xml:space="preserve">
-    <value>matched by fingerprint</value>
+    <value>gedetecteerd via vingerafdruk</value>
   </data>
   <data name="OffloadExcluded" xml:space="preserve">
-    <value>Excluded folder</value>
+    <value>Uitgesloten map</value>
   </data>
   <data name="OffloadReport" xml:space="preserve">
-    <value>Offload Report</value>
+    <value>Overbrengingsrapport</value>
   </data>
   <data name="OffloadJob" xml:space="preserve">
-    <value>Offload</value>
+    <value>Overbrengen</value>
   </data>
 </root>

--- a/Resources/SharedResource.nl.resx
+++ b/Resources/SharedResource.nl.resx
@@ -3263,6 +3263,9 @@
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>No other enabled IMAP account is available as a target. Create one first.</value>
   </data>
+  <data name="OffloadNoTargetsAssigned" xml:space="preserve">
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+  </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>
   </data>

--- a/Resources/SharedResource.nl.resx
+++ b/Resources/SharedResource.nl.resx
@@ -3203,6 +3203,18 @@
   <data name="OffloadSelectTarget" xml:space="preserve">
     <value>Selecteer een doelpostvak…</value>
   </data>
+  <data name="OffloadLoadingFolders" xml:space="preserve">
+    <value>Mappen laden…</value>
+  </data>
+  <data name="OffloadSelectFolder" xml:space="preserve">
+    <value>-- Kies een doelmap --</value>
+  </data>
+  <data name="OffloadErrorLoadingFolders" xml:space="preserve">
+    <value>Fout bij laden van mappen</value>
+  </data>
+  <data name="OffloadSelectTargetFirst" xml:space="preserve">
+    <value>Kies eerst een doelpostvak</value>
+  </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Hoofdmap in het doelpostvak. Met INBOX wordt de bronmapstructuur op het hoogste niveau gereconstrueerd.</value>
   </data>

--- a/Resources/SharedResource.pl.resx
+++ b/Resources/SharedResource.pl.resx
@@ -3249,6 +3249,18 @@
   <data name="OffloadSelectTarget" xml:space="preserve">
     <value>Wybierz skrzynkę docelową…</value>
   </data>
+  <data name="OffloadLoadingFolders" xml:space="preserve">
+    <value>Ładowanie folderów…</value>
+  </data>
+  <data name="OffloadSelectFolder" xml:space="preserve">
+    <value>-- Wybierz folder docelowy --</value>
+  </data>
+  <data name="OffloadErrorLoadingFolders" xml:space="preserve">
+    <value>Błąd ładowania folderów</value>
+  </data>
+  <data name="OffloadSelectTargetFirst" xml:space="preserve">
+    <value>Najpierw wybierz skrzynkę docelową</value>
+  </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Folder główny w skrzynce docelowej. Przy INBOX struktura folderów źródłowych jest odtwarzana na najwyższym poziomie.</value>
   </data>

--- a/Resources/SharedResource.pl.resx
+++ b/Resources/SharedResource.pl.resx
@@ -3234,4 +3234,127 @@
   <data name="FailuresAcknowledged" xml:space="preserve">
     <value>Błędy uznane</value>
   </data>
+  <data name="OffloadTitle" xml:space="preserve">
+    <value>Offload to Another Mailbox</value>
+  </data>
+  <data name="OffloadIntro" xml:space="preserve">
+    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+  </data>
+  <data name="OffloadSourceAndTarget" xml:space="preserve">
+    <value>Source and Target</value>
+  </data>
+  <data name="SourceAccount" xml:space="preserve">
+    <value>Source Account</value>
+  </data>
+  <data name="OffloadSelectTarget" xml:space="preserve">
+    <value>Select a target mailbox...</value>
+  </data>
+  <data name="OffloadTargetFolderHelp" xml:space="preserve">
+    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+  </data>
+  <data name="OffloadWindow" xml:space="preserve">
+    <value>Date Window</value>
+  </data>
+  <data name="OffloadWindowMonths" xml:space="preserve">
+    <value>Last N months</value>
+  </data>
+  <data name="OffloadWindowMonthsHelp" xml:space="preserve">
+    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+  </data>
+  <data name="OffloadCutoffFrom" xml:space="preserve">
+    <value>From date</value>
+  </data>
+  <data name="OffloadCutoffFromHelp" xml:space="preserve">
+    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+  </data>
+  <data name="OffloadCutoffTo" xml:space="preserve">
+    <value>To date (optional)</value>
+  </data>
+  <data name="OffloadCutoffToHelp" xml:space="preserve">
+    <value>Inclusive, up to 23:59:59 of this day.</value>
+  </data>
+  <data name="OffloadOptions" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="OffloadDryRun" xml:space="preserve">
+    <value>Dry run</value>
+  </data>
+  <data name="OffloadDryRunHelp" xml:space="preserve">
+    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+  </data>
+  <data name="OffloadMarkAsSeen" xml:space="preserve">
+    <value>Mark appended mail as read</value>
+  </data>
+  <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
+    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+  </data>
+  <data name="OffloadFolderHandling" xml:space="preserve">
+    <value>Folder Handling</value>
+  </data>
+  <data name="OffloadExcludedFolders" xml:space="preserve">
+    <value>Excluded source folders</value>
+  </data>
+  <data name="OffloadRenameMap" xml:space="preserve">
+    <value>Folder rename map</value>
+  </data>
+  <data name="OffloadNoneConfigured" xml:space="preserve">
+    <value>none configured</value>
+  </data>
+  <data name="OffloadFolderHandlingHelp" xml:space="preserve">
+    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+  </data>
+  <data name="OffloadStart" xml:space="preserve">
+    <value>Start Offload</value>
+  </data>
+  <data name="OffloadNoTargets" xml:space="preserve">
+    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+  </data>
+  <data name="OffloadTargetRequired" xml:space="preserve">
+    <value>Please choose a target mailbox.</value>
+  </data>
+  <data name="OffloadTargetMustDiffer" xml:space="preserve">
+    <value>The target mailbox must be different from the source.</value>
+  </data>
+  <data name="OffloadTargetNotFound" xml:space="preserve">
+    <value>The selected target mailbox no longer exists.</value>
+  </data>
+  <data name="OffloadTargetMustBeImap" xml:space="preserve">
+    <value>The target mailbox must be an IMAP account.</value>
+  </data>
+  <data name="OffloadTargetDisabled" xml:space="preserve">
+    <value>The selected target mailbox is disabled.</value>
+  </data>
+  <data name="OffloadCutoffRequired" xml:space="preserve">
+    <value>Please give either a month window or a from date.</value>
+  </data>
+  <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
+    <value>The to date must not be earlier than the from date.</value>
+  </data>
+  <data name="OffloadNothingInWindow" xml:space="preserve">
+    <value>No archived mail falls inside that date window.</value>
+  </data>
+  <data name="OffloadQueued" xml:space="preserve">
+    <value>Offload queued for {0} mails.</value>
+  </data>
+  <data name="OffloadDryRunQueued" xml:space="preserve">
+    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+  </data>
+  <data name="OffloadAppended" xml:space="preserve">
+    <value>Appended</value>
+  </data>
+  <data name="OffloadAlreadyPresent" xml:space="preserve">
+    <value>Already present</value>
+  </data>
+  <data name="OffloadByFingerprint" xml:space="preserve">
+    <value>matched by fingerprint</value>
+  </data>
+  <data name="OffloadExcluded" xml:space="preserve">
+    <value>Excluded folder</value>
+  </data>
+  <data name="OffloadReport" xml:space="preserve">
+    <value>Offload Report</value>
+  </data>
+  <data name="OffloadJob" xml:space="preserve">
+    <value>Offload</value>
+  </data>
 </root>

--- a/Resources/SharedResource.pl.resx
+++ b/Resources/SharedResource.pl.resx
@@ -3309,6 +3309,9 @@
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>No other enabled IMAP account is available as a target. Create one first.</value>
   </data>
+  <data name="OffloadNoTargetsAssigned" xml:space="preserve">
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+  </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>
   </data>

--- a/Resources/SharedResource.pl.resx
+++ b/Resources/SharedResource.pl.resx
@@ -3235,129 +3235,129 @@
     <value>Błędy uznane</value>
   </data>
   <data name="OffloadTitle" xml:space="preserve">
-    <value>Offload to Another Mailbox</value>
+    <value>Przenieś do innej skrzynki</value>
   </data>
   <data name="OffloadIntro" xml:space="preserve">
-    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+    <value>Dołącza archiwizowaną pocztę nowszą niż data odcięcia do innej skrzynki, pomijając to, co ta skrzynka już zawiera. Starsza poczta pozostaje w archiwum. Ponowne uruchomienie jest bezpieczne i nie dodaje niczego, co już dotarło.</value>
   </data>
   <data name="OffloadSourceAndTarget" xml:space="preserve">
-    <value>Source and Target</value>
+    <value>Źródło i cel</value>
   </data>
   <data name="SourceAccount" xml:space="preserve">
-    <value>Source Account</value>
+    <value>Konto źródłowe</value>
   </data>
   <data name="OffloadSelectTarget" xml:space="preserve">
-    <value>Select a target mailbox...</value>
+    <value>Wybierz skrzynkę docelową…</value>
   </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
-    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+    <value>Folder główny w skrzynce docelowej. Przy INBOX struktura folderów źródłowych jest odtwarzana na najwyższym poziomie.</value>
   </data>
   <data name="OffloadWindow" xml:space="preserve">
-    <value>Date Window</value>
+    <value>Okno dat</value>
   </data>
   <data name="OffloadWindowMonths" xml:space="preserve">
-    <value>Last N months</value>
+    <value>Ostatnie N miesięcy</value>
   </data>
   <data name="OffloadWindowMonthsHelp" xml:space="preserve">
-    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+    <value>Rozwiązywane na stałą datę przy uruchomieniu zadania, więc powtórzenie zadania wybiera tę samą pocztę. Ustaw na 0, aby użyć jawnej daty.</value>
   </data>
   <data name="OffloadCutoffFrom" xml:space="preserve">
-    <value>From date</value>
+    <value>Od daty</value>
   </data>
   <data name="OffloadCutoffFromHelp" xml:space="preserve">
-    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+    <value>Zastępuje okno miesięcy. Włącznie, od 00:00 tego dnia.</value>
   </data>
   <data name="OffloadCutoffTo" xml:space="preserve">
-    <value>To date (optional)</value>
+    <value>Do daty (opcjonalne)</value>
   </data>
   <data name="OffloadCutoffToHelp" xml:space="preserve">
-    <value>Inclusive, up to 23:59:59 of this day.</value>
+    <value>Włącznie, do 23:59:59 tego dnia.</value>
   </data>
   <data name="OffloadOptions" xml:space="preserve">
-    <value>Options</value>
+    <value>Opcje</value>
   </data>
   <data name="OffloadDryRun" xml:space="preserve">
-    <value>Dry run</value>
+    <value>Przebieg próbny</value>
   </data>
   <data name="OffloadDryRunHelp" xml:space="preserve">
-    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+    <value>Rozwiązuje wszystko i raportuje na folder, co by się stało, ale nic nie dołącza. Zalecane przed właściwym uruchomieniem.</value>
   </data>
   <data name="OffloadMarkAsSeen" xml:space="preserve">
-    <value>Mark appended mail as read</value>
+    <value>Oznacz dołączoną pocztę jako przeczytaną</value>
   </data>
   <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
-    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+    <value>Wyłączenie tej opcji sprawia, że nieprzeczytana poczta pozostaje nieprzeczytana w skrzynce docelowej.</value>
   </data>
   <data name="OffloadFolderHandling" xml:space="preserve">
-    <value>Folder Handling</value>
+    <value>Obsługa folderów</value>
   </data>
   <data name="OffloadExcludedFolders" xml:space="preserve">
-    <value>Excluded source folders</value>
+    <value>Wykluczone foldery źródłowe</value>
   </data>
   <data name="OffloadRenameMap" xml:space="preserve">
-    <value>Folder rename map</value>
+    <value>Mapa zmiany nazw folderów</value>
   </data>
   <data name="OffloadNoneConfigured" xml:space="preserve">
-    <value>none configured</value>
+    <value>brak konfiguracji</value>
   </data>
   <data name="OffloadFolderHandlingHelp" xml:space="preserve">
-    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+    <value>Oba konfiguruje się w sekcji Offload w appsettings.json i są domyślnie puste. Wykluczenia są stosowane przed zmianą nazwy i obejmują podfoldery.</value>
   </data>
   <data name="OffloadStart" xml:space="preserve">
-    <value>Start Offload</value>
+    <value>Rozpocznij przenoszenie</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+    <value>Brak innego włączonego konta IMAP jako celu. Najpierw utwórz takie konto.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+    <value>Żadna ze skrzynek Ci przypisanych nie może być celem. Poproś administratora o przypisanie innego włączonego konta IMAP.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
-    <value>Please choose a target mailbox.</value>
+    <value>Wybierz skrzynkę docelową.</value>
   </data>
   <data name="OffloadTargetMustDiffer" xml:space="preserve">
-    <value>The target mailbox must be different from the source.</value>
+    <value>Skrzynka docelowa musi się różnić od źródłowej.</value>
   </data>
   <data name="OffloadTargetNotFound" xml:space="preserve">
-    <value>The selected target mailbox no longer exists.</value>
+    <value>Wybrana skrzynka docelowa już nie istnieje.</value>
   </data>
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
-    <value>The target mailbox must be an IMAP account.</value>
+    <value>Skrzynka docelowa musi być kontem IMAP.</value>
   </data>
   <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>The selected target mailbox is disabled.</value>
+    <value>Wybrana skrzynka docelowa jest wyłączona.</value>
   </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
-    <value>Please give either a month window or a from date.</value>
+    <value>Podaj okno miesięcy lub datę od.</value>
   </data>
   <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
-    <value>The to date must not be earlier than the from date.</value>
+    <value>Data „do” nie może być wcześniejsza niż data „od”.</value>
   </data>
   <data name="OffloadNothingInWindow" xml:space="preserve">
-    <value>No archived mail falls inside that date window.</value>
+    <value>Żadna zarchiwizowana poczta nie mieści się w tym oknie dat.</value>
   </data>
   <data name="OffloadQueued" xml:space="preserve">
-    <value>Offload queued for {0} mails.</value>
+    <value>Przenoszenie w kolejce dla {0} wiadomości.</value>
   </data>
   <data name="OffloadDryRunQueued" xml:space="preserve">
-    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+    <value>Przebieg próbny w kolejce dla {0} wiadomości. Nic nie zostanie dołączone.</value>
   </data>
   <data name="OffloadAppended" xml:space="preserve">
-    <value>Appended</value>
+    <value>Dołączone</value>
   </data>
   <data name="OffloadAlreadyPresent" xml:space="preserve">
-    <value>Already present</value>
+    <value>Już obecne</value>
   </data>
   <data name="OffloadByFingerprint" xml:space="preserve">
-    <value>matched by fingerprint</value>
+    <value>dopasowane przez odcisk</value>
   </data>
   <data name="OffloadExcluded" xml:space="preserve">
-    <value>Excluded folder</value>
+    <value>Wykluczony folder</value>
   </data>
   <data name="OffloadReport" xml:space="preserve">
-    <value>Offload Report</value>
+    <value>Raport przenoszenia</value>
   </data>
   <data name="OffloadJob" xml:space="preserve">
-    <value>Offload</value>
+    <value>Przenoszenie</value>
   </data>
 </root>

--- a/Resources/SharedResource.resx
+++ b/Resources/SharedResource.resx
@@ -3175,4 +3175,127 @@
   <data name="FailuresAcknowledged" xml:space="preserve">
     <value>Failures acknowledged</value>
   </data>
+  <data name="OffloadTitle" xml:space="preserve">
+    <value>Offload to Another Mailbox</value>
+  </data>
+  <data name="OffloadIntro" xml:space="preserve">
+    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+  </data>
+  <data name="OffloadSourceAndTarget" xml:space="preserve">
+    <value>Source and Target</value>
+  </data>
+  <data name="SourceAccount" xml:space="preserve">
+    <value>Source Account</value>
+  </data>
+  <data name="OffloadSelectTarget" xml:space="preserve">
+    <value>Select a target mailbox...</value>
+  </data>
+  <data name="OffloadTargetFolderHelp" xml:space="preserve">
+    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+  </data>
+  <data name="OffloadWindow" xml:space="preserve">
+    <value>Date Window</value>
+  </data>
+  <data name="OffloadWindowMonths" xml:space="preserve">
+    <value>Last N months</value>
+  </data>
+  <data name="OffloadWindowMonthsHelp" xml:space="preserve">
+    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+  </data>
+  <data name="OffloadCutoffFrom" xml:space="preserve">
+    <value>From date</value>
+  </data>
+  <data name="OffloadCutoffFromHelp" xml:space="preserve">
+    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+  </data>
+  <data name="OffloadCutoffTo" xml:space="preserve">
+    <value>To date (optional)</value>
+  </data>
+  <data name="OffloadCutoffToHelp" xml:space="preserve">
+    <value>Inclusive, up to 23:59:59 of this day.</value>
+  </data>
+  <data name="OffloadOptions" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="OffloadDryRun" xml:space="preserve">
+    <value>Dry run</value>
+  </data>
+  <data name="OffloadDryRunHelp" xml:space="preserve">
+    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+  </data>
+  <data name="OffloadMarkAsSeen" xml:space="preserve">
+    <value>Mark appended mail as read</value>
+  </data>
+  <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
+    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+  </data>
+  <data name="OffloadFolderHandling" xml:space="preserve">
+    <value>Folder Handling</value>
+  </data>
+  <data name="OffloadExcludedFolders" xml:space="preserve">
+    <value>Excluded source folders</value>
+  </data>
+  <data name="OffloadRenameMap" xml:space="preserve">
+    <value>Folder rename map</value>
+  </data>
+  <data name="OffloadNoneConfigured" xml:space="preserve">
+    <value>none configured</value>
+  </data>
+  <data name="OffloadFolderHandlingHelp" xml:space="preserve">
+    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+  </data>
+  <data name="OffloadStart" xml:space="preserve">
+    <value>Start Offload</value>
+  </data>
+  <data name="OffloadNoTargets" xml:space="preserve">
+    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+  </data>
+  <data name="OffloadTargetRequired" xml:space="preserve">
+    <value>Please choose a target mailbox.</value>
+  </data>
+  <data name="OffloadTargetMustDiffer" xml:space="preserve">
+    <value>The target mailbox must be different from the source.</value>
+  </data>
+  <data name="OffloadTargetNotFound" xml:space="preserve">
+    <value>The selected target mailbox no longer exists.</value>
+  </data>
+  <data name="OffloadTargetMustBeImap" xml:space="preserve">
+    <value>The target mailbox must be an IMAP account.</value>
+  </data>
+  <data name="OffloadTargetDisabled" xml:space="preserve">
+    <value>The selected target mailbox is disabled.</value>
+  </data>
+  <data name="OffloadCutoffRequired" xml:space="preserve">
+    <value>Please give either a month window or a from date.</value>
+  </data>
+  <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
+    <value>The to date must not be earlier than the from date.</value>
+  </data>
+  <data name="OffloadNothingInWindow" xml:space="preserve">
+    <value>No archived mail falls inside that date window.</value>
+  </data>
+  <data name="OffloadQueued" xml:space="preserve">
+    <value>Offload queued for {0} mails.</value>
+  </data>
+  <data name="OffloadDryRunQueued" xml:space="preserve">
+    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+  </data>
+  <data name="OffloadAppended" xml:space="preserve">
+    <value>Appended</value>
+  </data>
+  <data name="OffloadAlreadyPresent" xml:space="preserve">
+    <value>Already present</value>
+  </data>
+  <data name="OffloadByFingerprint" xml:space="preserve">
+    <value>matched by fingerprint</value>
+  </data>
+  <data name="OffloadExcluded" xml:space="preserve">
+    <value>Excluded folder</value>
+  </data>
+  <data name="OffloadReport" xml:space="preserve">
+    <value>Offload Report</value>
+  </data>
+  <data name="OffloadJob" xml:space="preserve">
+    <value>Offload</value>
+  </data>
 </root>

--- a/Resources/SharedResource.resx
+++ b/Resources/SharedResource.resx
@@ -3250,6 +3250,9 @@
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>No other enabled IMAP account is available as a target. Create one first.</value>
   </data>
+  <data name="OffloadNoTargetsAssigned" xml:space="preserve">
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+  </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>
   </data>

--- a/Resources/SharedResource.resx
+++ b/Resources/SharedResource.resx
@@ -3190,6 +3190,18 @@
   <data name="OffloadSelectTarget" xml:space="preserve">
     <value>Select a target mailbox...</value>
   </data>
+  <data name="OffloadLoadingFolders" xml:space="preserve">
+    <value>Loading folders...</value>
+  </data>
+  <data name="OffloadSelectFolder" xml:space="preserve">
+    <value>-- Select a target folder --</value>
+  </data>
+  <data name="OffloadErrorLoadingFolders" xml:space="preserve">
+    <value>Error loading folders</value>
+  </data>
+  <data name="OffloadSelectTargetFirst" xml:space="preserve">
+    <value>Select a target mailbox first</value>
+  </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
   </data>

--- a/Resources/SharedResource.ru.resx
+++ b/Resources/SharedResource.ru.resx
@@ -3188,4 +3188,127 @@
   <data name="FailuresAcknowledged" xml:space="preserve">
     <value>Ошибки подтверждены</value>
   </data>
+  <data name="OffloadTitle" xml:space="preserve">
+    <value>Offload to Another Mailbox</value>
+  </data>
+  <data name="OffloadIntro" xml:space="preserve">
+    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+  </data>
+  <data name="OffloadSourceAndTarget" xml:space="preserve">
+    <value>Source and Target</value>
+  </data>
+  <data name="SourceAccount" xml:space="preserve">
+    <value>Source Account</value>
+  </data>
+  <data name="OffloadSelectTarget" xml:space="preserve">
+    <value>Select a target mailbox...</value>
+  </data>
+  <data name="OffloadTargetFolderHelp" xml:space="preserve">
+    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+  </data>
+  <data name="OffloadWindow" xml:space="preserve">
+    <value>Date Window</value>
+  </data>
+  <data name="OffloadWindowMonths" xml:space="preserve">
+    <value>Last N months</value>
+  </data>
+  <data name="OffloadWindowMonthsHelp" xml:space="preserve">
+    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+  </data>
+  <data name="OffloadCutoffFrom" xml:space="preserve">
+    <value>From date</value>
+  </data>
+  <data name="OffloadCutoffFromHelp" xml:space="preserve">
+    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+  </data>
+  <data name="OffloadCutoffTo" xml:space="preserve">
+    <value>To date (optional)</value>
+  </data>
+  <data name="OffloadCutoffToHelp" xml:space="preserve">
+    <value>Inclusive, up to 23:59:59 of this day.</value>
+  </data>
+  <data name="OffloadOptions" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="OffloadDryRun" xml:space="preserve">
+    <value>Dry run</value>
+  </data>
+  <data name="OffloadDryRunHelp" xml:space="preserve">
+    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+  </data>
+  <data name="OffloadMarkAsSeen" xml:space="preserve">
+    <value>Mark appended mail as read</value>
+  </data>
+  <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
+    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+  </data>
+  <data name="OffloadFolderHandling" xml:space="preserve">
+    <value>Folder Handling</value>
+  </data>
+  <data name="OffloadExcludedFolders" xml:space="preserve">
+    <value>Excluded source folders</value>
+  </data>
+  <data name="OffloadRenameMap" xml:space="preserve">
+    <value>Folder rename map</value>
+  </data>
+  <data name="OffloadNoneConfigured" xml:space="preserve">
+    <value>none configured</value>
+  </data>
+  <data name="OffloadFolderHandlingHelp" xml:space="preserve">
+    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+  </data>
+  <data name="OffloadStart" xml:space="preserve">
+    <value>Start Offload</value>
+  </data>
+  <data name="OffloadNoTargets" xml:space="preserve">
+    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+  </data>
+  <data name="OffloadTargetRequired" xml:space="preserve">
+    <value>Please choose a target mailbox.</value>
+  </data>
+  <data name="OffloadTargetMustDiffer" xml:space="preserve">
+    <value>The target mailbox must be different from the source.</value>
+  </data>
+  <data name="OffloadTargetNotFound" xml:space="preserve">
+    <value>The selected target mailbox no longer exists.</value>
+  </data>
+  <data name="OffloadTargetMustBeImap" xml:space="preserve">
+    <value>The target mailbox must be an IMAP account.</value>
+  </data>
+  <data name="OffloadTargetDisabled" xml:space="preserve">
+    <value>The selected target mailbox is disabled.</value>
+  </data>
+  <data name="OffloadCutoffRequired" xml:space="preserve">
+    <value>Please give either a month window or a from date.</value>
+  </data>
+  <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
+    <value>The to date must not be earlier than the from date.</value>
+  </data>
+  <data name="OffloadNothingInWindow" xml:space="preserve">
+    <value>No archived mail falls inside that date window.</value>
+  </data>
+  <data name="OffloadQueued" xml:space="preserve">
+    <value>Offload queued for {0} mails.</value>
+  </data>
+  <data name="OffloadDryRunQueued" xml:space="preserve">
+    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+  </data>
+  <data name="OffloadAppended" xml:space="preserve">
+    <value>Appended</value>
+  </data>
+  <data name="OffloadAlreadyPresent" xml:space="preserve">
+    <value>Already present</value>
+  </data>
+  <data name="OffloadByFingerprint" xml:space="preserve">
+    <value>matched by fingerprint</value>
+  </data>
+  <data name="OffloadExcluded" xml:space="preserve">
+    <value>Excluded folder</value>
+  </data>
+  <data name="OffloadReport" xml:space="preserve">
+    <value>Offload Report</value>
+  </data>
+  <data name="OffloadJob" xml:space="preserve">
+    <value>Offload</value>
+  </data>
 </root>

--- a/Resources/SharedResource.ru.resx
+++ b/Resources/SharedResource.ru.resx
@@ -3189,129 +3189,129 @@
     <value>Ошибки подтверждены</value>
   </data>
   <data name="OffloadTitle" xml:space="preserve">
-    <value>Offload to Another Mailbox</value>
+    <value>Выгрузить в другой почтовый ящик</value>
   </data>
   <data name="OffloadIntro" xml:space="preserve">
-    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+    <value>Помещает архивную почту новее точки отсечения в другой почтовый ящик, пропуская то, что в нём уже есть. Более старая почта остаётся в архиве. Повторный запуск безопасен и ничего не дублирует из уже поступившего.</value>
   </data>
   <data name="OffloadSourceAndTarget" xml:space="preserve">
-    <value>Source and Target</value>
+    <value>Источник и назначение</value>
   </data>
   <data name="SourceAccount" xml:space="preserve">
-    <value>Source Account</value>
+    <value>Учётная запись-источник</value>
   </data>
   <data name="OffloadSelectTarget" xml:space="preserve">
-    <value>Select a target mailbox...</value>
+    <value>Выберите целевой почтовый ящик…</value>
   </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
-    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+    <value>Корневая папка в целевом почтовом ящике. При INBOX структура папок источника воссоздаётся на верхнем уровне.</value>
   </data>
   <data name="OffloadWindow" xml:space="preserve">
-    <value>Date Window</value>
+    <value>Диапазон дат</value>
   </data>
   <data name="OffloadWindowMonths" xml:space="preserve">
-    <value>Last N months</value>
+    <value>Последние N месяцев</value>
   </data>
   <data name="OffloadWindowMonthsHelp" xml:space="preserve">
-    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+    <value>Преобразуется в фиксированную дату при запуске задания, поэтому повторный запуск выберет ту же почту. Установите 0, чтобы использовать явную дату.</value>
   </data>
   <data name="OffloadCutoffFrom" xml:space="preserve">
-    <value>From date</value>
+    <value>Дата с</value>
   </data>
   <data name="OffloadCutoffFromHelp" xml:space="preserve">
-    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+    <value>Переопределяет окно месяцев. Включительно, с 00:00 этого дня.</value>
   </data>
   <data name="OffloadCutoffTo" xml:space="preserve">
-    <value>To date (optional)</value>
+    <value>Дата по (необязательно)</value>
   </data>
   <data name="OffloadCutoffToHelp" xml:space="preserve">
-    <value>Inclusive, up to 23:59:59 of this day.</value>
+    <value>Включительно, до 23:59:59 этого дня.</value>
   </data>
   <data name="OffloadOptions" xml:space="preserve">
-    <value>Options</value>
+    <value>Параметры</value>
   </data>
   <data name="OffloadDryRun" xml:space="preserve">
-    <value>Dry run</value>
+    <value>Пробный запуск</value>
   </data>
   <data name="OffloadDryRunHelp" xml:space="preserve">
-    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+    <value>Просчитывает всё и сообщает по папкам, что произойдёт, но ничего не добавляет. Рекомендуется перед реальным запуском.</value>
   </data>
   <data name="OffloadMarkAsSeen" xml:space="preserve">
-    <value>Mark appended mail as read</value>
+    <value>Отметить добавленную почту как прочитанную</value>
   </data>
   <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
-    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+    <value>Отключение сохраняет непрочитанную почту непрочитанной в целевом ящике.</value>
   </data>
   <data name="OffloadFolderHandling" xml:space="preserve">
-    <value>Folder Handling</value>
+    <value>Обработка папок</value>
   </data>
   <data name="OffloadExcludedFolders" xml:space="preserve">
-    <value>Excluded source folders</value>
+    <value>Исключённые папки источника</value>
   </data>
   <data name="OffloadRenameMap" xml:space="preserve">
-    <value>Folder rename map</value>
+    <value>Карта переименования папок</value>
   </data>
   <data name="OffloadNoneConfigured" xml:space="preserve">
-    <value>none configured</value>
+    <value>не настроено</value>
   </data>
   <data name="OffloadFolderHandlingHelp" xml:space="preserve">
-    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+    <value>Оба настраиваются в разделе Offload файла appsettings.json и по умолчанию пусты. Исключения применяются перед переименованием и охватывают подпапки.</value>
   </data>
   <data name="OffloadStart" xml:space="preserve">
-    <value>Start Offload</value>
+    <value>Начать выгрузку</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+    <value>Нет другого включённого аккаунта IMAP в качестве цели. Сначала создайте его.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+    <value>Ни один из назначенных вам ящиков нельзя использовать в качестве цели. Попросите администратора назначить вам ещё один включённый аккаунт IMAP.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
-    <value>Please choose a target mailbox.</value>
+    <value>Выберите целевой почтовый ящик.</value>
   </data>
   <data name="OffloadTargetMustDiffer" xml:space="preserve">
-    <value>The target mailbox must be different from the source.</value>
+    <value>Целевой почтовый ящик должен отличаться от источника.</value>
   </data>
   <data name="OffloadTargetNotFound" xml:space="preserve">
-    <value>The selected target mailbox no longer exists.</value>
+    <value>Выбранный целевой почтовый ящик больше не существует.</value>
   </data>
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
-    <value>The target mailbox must be an IMAP account.</value>
+    <value>Целевой почтовый ящик должен быть аккаунтом IMAP.</value>
   </data>
   <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>The selected target mailbox is disabled.</value>
+    <value>Выбранный целевой почтовый ящик отключён.</value>
   </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
-    <value>Please give either a month window or a from date.</value>
+    <value>Укажите окно месяцев или дату начала.</value>
   </data>
   <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
-    <value>The to date must not be earlier than the from date.</value>
+    <value>Дата «по» не должна быть раньше даты «с».</value>
   </data>
   <data name="OffloadNothingInWindow" xml:space="preserve">
-    <value>No archived mail falls inside that date window.</value>
+    <value>В этот диапазон дат не попадает ни одной архивной почты.</value>
   </data>
   <data name="OffloadQueued" xml:space="preserve">
-    <value>Offload queued for {0} mails.</value>
+    <value>Выгрузка поставлена в очередь для {0} писем.</value>
   </data>
   <data name="OffloadDryRunQueued" xml:space="preserve">
-    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+    <value>Пробный запуск в очереди для {0} писем. Ничего не будет добавлено.</value>
   </data>
   <data name="OffloadAppended" xml:space="preserve">
-    <value>Appended</value>
+    <value>Добавлено</value>
   </data>
   <data name="OffloadAlreadyPresent" xml:space="preserve">
-    <value>Already present</value>
+    <value>Уже присутствует</value>
   </data>
   <data name="OffloadByFingerprint" xml:space="preserve">
-    <value>matched by fingerprint</value>
+    <value>совпадение по отпечатку</value>
   </data>
   <data name="OffloadExcluded" xml:space="preserve">
-    <value>Excluded folder</value>
+    <value>Исключённая папка</value>
   </data>
   <data name="OffloadReport" xml:space="preserve">
-    <value>Offload Report</value>
+    <value>Отчёт о выгрузке</value>
   </data>
   <data name="OffloadJob" xml:space="preserve">
-    <value>Offload</value>
+    <value>Выгрузка</value>
   </data>
 </root>

--- a/Resources/SharedResource.ru.resx
+++ b/Resources/SharedResource.ru.resx
@@ -3263,6 +3263,9 @@
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>No other enabled IMAP account is available as a target. Create one first.</value>
   </data>
+  <data name="OffloadNoTargetsAssigned" xml:space="preserve">
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+  </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>
   </data>

--- a/Resources/SharedResource.ru.resx
+++ b/Resources/SharedResource.ru.resx
@@ -3203,6 +3203,18 @@
   <data name="OffloadSelectTarget" xml:space="preserve">
     <value>Выберите целевой почтовый ящик…</value>
   </data>
+  <data name="OffloadLoadingFolders" xml:space="preserve">
+    <value>Загрузка папок…</value>
+  </data>
+  <data name="OffloadSelectFolder" xml:space="preserve">
+    <value>-- Выберите целевую папку --</value>
+  </data>
+  <data name="OffloadErrorLoadingFolders" xml:space="preserve">
+    <value>Ошибка загрузки папок</value>
+  </data>
+  <data name="OffloadSelectTargetFirst" xml:space="preserve">
+    <value>Сначала выберите целевой почтовый ящик</value>
+  </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Корневая папка в целевом почтовом ящике. При INBOX структура папок источника воссоздаётся на верхнем уровне.</value>
   </data>

--- a/Resources/SharedResource.sl.resx
+++ b/Resources/SharedResource.sl.resx
@@ -3189,129 +3189,129 @@
     <value>Napake potrjene</value>
   </data>
   <data name="OffloadTitle" xml:space="preserve">
-    <value>Offload to Another Mailbox</value>
+    <value>Prenesi v drugi nabiralnik</value>
   </data>
   <data name="OffloadIntro" xml:space="preserve">
-    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+    <value>Doda arhivirano pošto, novejšo od datuma prereza, v drugi nabiralnik in preskoči tisto, kar ta nabiralnik že vsebuje. Starejša pošta ostane v arhivu. Ponovni zagon je varen in ne doda ničesar, kar je že prisotno.</value>
   </data>
   <data name="OffloadSourceAndTarget" xml:space="preserve">
-    <value>Source and Target</value>
+    <value>Izvor in cilj</value>
   </data>
   <data name="SourceAccount" xml:space="preserve">
-    <value>Source Account</value>
+    <value>Izvorni račun</value>
   </data>
   <data name="OffloadSelectTarget" xml:space="preserve">
-    <value>Select a target mailbox...</value>
+    <value>Izberi ciljni nabiralnik…</value>
   </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
-    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+    <value>Korenska mapa v ciljnem nabiralniku. Z INBOX se struktura izvornih map rekonstruira na vrhnji ravni.</value>
   </data>
   <data name="OffloadWindow" xml:space="preserve">
-    <value>Date Window</value>
+    <value>Datumsko okno</value>
   </data>
   <data name="OffloadWindowMonths" xml:space="preserve">
-    <value>Last N months</value>
+    <value>Zadnjih N mesecev</value>
   </data>
   <data name="OffloadWindowMonthsHelp" xml:space="preserve">
-    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+    <value>Ob zagonu opravila se razreši v fiksni datum, zato ponovni zagon izbere isto pošto. Nastavite na 0 za izrecni datum.</value>
   </data>
   <data name="OffloadCutoffFrom" xml:space="preserve">
-    <value>From date</value>
+    <value>Od datuma</value>
   </data>
   <data name="OffloadCutoffFromHelp" xml:space="preserve">
-    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+    <value>Prepiše okno mesecev. Vključno, od 00:00 tega dne.</value>
   </data>
   <data name="OffloadCutoffTo" xml:space="preserve">
-    <value>To date (optional)</value>
+    <value>Do datuma (izbirno)</value>
   </data>
   <data name="OffloadCutoffToHelp" xml:space="preserve">
-    <value>Inclusive, up to 23:59:59 of this day.</value>
+    <value>Vključno, do 23:59:59 tega dne.</value>
   </data>
   <data name="OffloadOptions" xml:space="preserve">
-    <value>Options</value>
+    <value>Možnosti</value>
   </data>
   <data name="OffloadDryRun" xml:space="preserve">
-    <value>Dry run</value>
+    <value>Preskusni zagon</value>
   </data>
   <data name="OffloadDryRunHelp" xml:space="preserve">
-    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+    <value>Razreši vse in poroča po mapah, kaj bi se zgodilo, ne doda ničesar. Priporočeno pred pravim zagonom.</value>
   </data>
   <data name="OffloadMarkAsSeen" xml:space="preserve">
-    <value>Mark appended mail as read</value>
+    <value>Označi dodano pošto kot prebrano</value>
   </data>
   <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
-    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+    <value>Izklop pusti neprebrano pošto v ciljnem nabiralniku neprebrano.</value>
   </data>
   <data name="OffloadFolderHandling" xml:space="preserve">
-    <value>Folder Handling</value>
+    <value>Upravljanje map</value>
   </data>
   <data name="OffloadExcludedFolders" xml:space="preserve">
-    <value>Excluded source folders</value>
+    <value>Izključene izvorne mape</value>
   </data>
   <data name="OffloadRenameMap" xml:space="preserve">
-    <value>Folder rename map</value>
+    <value>Tabela preimenovanja map</value>
   </data>
   <data name="OffloadNoneConfigured" xml:space="preserve">
-    <value>none configured</value>
+    <value>ni nastavljeno</value>
   </data>
   <data name="OffloadFolderHandlingHelp" xml:space="preserve">
-    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+    <value>Oboje nastavite v razdelku Offload v appsettings.json in sta privzeto prazni. Izključitve se uveljavljajo pred preimenovanjem in pokrivajo podmape.</value>
   </data>
   <data name="OffloadStart" xml:space="preserve">
-    <value>Start Offload</value>
+    <value>Začni prenos</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+    <value>Na voljo ni drugega omogočenega računa IMAP kot cilja. Najprej ga ustvarite.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+    <value>Nobeden od vam dodeljenih nabiralnikov ni mogoče uporabiti kot cilj. Prosite skrbnika, naj vam dodeli še en omogočen račun IMAP.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
-    <value>Please choose a target mailbox.</value>
+    <value>Izberite ciljni nabiralnik.</value>
   </data>
   <data name="OffloadTargetMustDiffer" xml:space="preserve">
-    <value>The target mailbox must be different from the source.</value>
+    <value>Ciljni nabiralnik mora biti različen od izvornega.</value>
   </data>
   <data name="OffloadTargetNotFound" xml:space="preserve">
-    <value>The selected target mailbox no longer exists.</value>
+    <value>Izbrani ciljni nabiralnik ne obstaja več.</value>
   </data>
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
-    <value>The target mailbox must be an IMAP account.</value>
+    <value>Ciljni nabiralnik mora biti račun IMAP.</value>
   </data>
   <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>The selected target mailbox is disabled.</value>
+    <value>Izbrani ciljni nabiralnik je onemogočen.</value>
   </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
-    <value>Please give either a month window or a from date.</value>
+    <value>Navedite okno mesecev ali datum od.</value>
   </data>
   <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
-    <value>The to date must not be earlier than the from date.</value>
+    <value>Datum „do” ne sme biti pred datumom „od”.</value>
   </data>
   <data name="OffloadNothingInWindow" xml:space="preserve">
-    <value>No archived mail falls inside that date window.</value>
+    <value>V to datumsko okno ne pade nobena arhivirana pošta.</value>
   </data>
   <data name="OffloadQueued" xml:space="preserve">
-    <value>Offload queued for {0} mails.</value>
+    <value>Prenos v čakalni vrsti za {0} pisem.</value>
   </data>
   <data name="OffloadDryRunQueued" xml:space="preserve">
-    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+    <value>Preskusni zagon v čakalni vrsti za {0} pisem. Nič ne bo dodano.</value>
   </data>
   <data name="OffloadAppended" xml:space="preserve">
-    <value>Appended</value>
+    <value>Dodano</value>
   </data>
   <data name="OffloadAlreadyPresent" xml:space="preserve">
-    <value>Already present</value>
+    <value>Že prisotno</value>
   </data>
   <data name="OffloadByFingerprint" xml:space="preserve">
-    <value>matched by fingerprint</value>
+    <value>ujemanje po prstnem odtisu</value>
   </data>
   <data name="OffloadExcluded" xml:space="preserve">
-    <value>Excluded folder</value>
+    <value>Izključena mapa</value>
   </data>
   <data name="OffloadReport" xml:space="preserve">
-    <value>Offload Report</value>
+    <value>Poročilo o prenosu</value>
   </data>
   <data name="OffloadJob" xml:space="preserve">
-    <value>Offload</value>
+    <value>Prenos</value>
   </data>
 </root>

--- a/Resources/SharedResource.sl.resx
+++ b/Resources/SharedResource.sl.resx
@@ -3203,6 +3203,18 @@
   <data name="OffloadSelectTarget" xml:space="preserve">
     <value>Izberi ciljni nabiralnik…</value>
   </data>
+  <data name="OffloadLoadingFolders" xml:space="preserve">
+    <value>Nalaganje map…</value>
+  </data>
+  <data name="OffloadSelectFolder" xml:space="preserve">
+    <value>-- Izberite ciljno mapo --</value>
+  </data>
+  <data name="OffloadErrorLoadingFolders" xml:space="preserve">
+    <value>Napaka pri nalaganju map</value>
+  </data>
+  <data name="OffloadSelectTargetFirst" xml:space="preserve">
+    <value>Najprej izberite ciljni nabiralnik</value>
+  </data>
   <data name="OffloadTargetFolderHelp" xml:space="preserve">
     <value>Korenska mapa v ciljnem nabiralniku. Z INBOX se struktura izvornih map rekonstruira na vrhnji ravni.</value>
   </data>

--- a/Resources/SharedResource.sl.resx
+++ b/Resources/SharedResource.sl.resx
@@ -3263,6 +3263,9 @@
   <data name="OffloadNoTargets" xml:space="preserve">
     <value>No other enabled IMAP account is available as a target. Create one first.</value>
   </data>
+  <data name="OffloadNoTargetsAssigned" xml:space="preserve">
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+  </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>
   </data>

--- a/Resources/SharedResource.sl.resx
+++ b/Resources/SharedResource.sl.resx
@@ -3188,4 +3188,127 @@
   <data name="FailuresAcknowledged" xml:space="preserve">
     <value>Napake potrjene</value>
   </data>
+  <data name="OffloadTitle" xml:space="preserve">
+    <value>Offload to Another Mailbox</value>
+  </data>
+  <data name="OffloadIntro" xml:space="preserve">
+    <value>Appends archived mail newer than a cutoff into another mailbox, skipping anything that mailbox already holds. Older mail stays in the archive. Running this again is safe and appends nothing that already arrived.</value>
+  </data>
+  <data name="OffloadSourceAndTarget" xml:space="preserve">
+    <value>Source and Target</value>
+  </data>
+  <data name="SourceAccount" xml:space="preserve">
+    <value>Source Account</value>
+  </data>
+  <data name="OffloadSelectTarget" xml:space="preserve">
+    <value>Select a target mailbox...</value>
+  </data>
+  <data name="OffloadTargetFolderHelp" xml:space="preserve">
+    <value>Root folder in the target mailbox. With INBOX the source folder structure is recreated at the top level.</value>
+  </data>
+  <data name="OffloadWindow" xml:space="preserve">
+    <value>Date Window</value>
+  </data>
+  <data name="OffloadWindowMonths" xml:space="preserve">
+    <value>Last N months</value>
+  </data>
+  <data name="OffloadWindowMonthsHelp" xml:space="preserve">
+    <value>Resolved to a fixed date when the job starts, so repeating the job selects the same mail. Set to 0 to use an explicit date instead.</value>
+  </data>
+  <data name="OffloadCutoffFrom" xml:space="preserve">
+    <value>From date</value>
+  </data>
+  <data name="OffloadCutoffFromHelp" xml:space="preserve">
+    <value>Overrides the month window. Inclusive, from 00:00 of this day.</value>
+  </data>
+  <data name="OffloadCutoffTo" xml:space="preserve">
+    <value>To date (optional)</value>
+  </data>
+  <data name="OffloadCutoffToHelp" xml:space="preserve">
+    <value>Inclusive, up to 23:59:59 of this day.</value>
+  </data>
+  <data name="OffloadOptions" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="OffloadDryRun" xml:space="preserve">
+    <value>Dry run</value>
+  </data>
+  <data name="OffloadDryRunHelp" xml:space="preserve">
+    <value>Resolves everything and reports what would happen per folder, but appends nothing. Recommended before a real run.</value>
+  </data>
+  <data name="OffloadMarkAsSeen" xml:space="preserve">
+    <value>Mark appended mail as read</value>
+  </data>
+  <data name="OffloadMarkAsSeenHelp" xml:space="preserve">
+    <value>Turning this off keeps unread mail unread in the target mailbox.</value>
+  </data>
+  <data name="OffloadFolderHandling" xml:space="preserve">
+    <value>Folder Handling</value>
+  </data>
+  <data name="OffloadExcludedFolders" xml:space="preserve">
+    <value>Excluded source folders</value>
+  </data>
+  <data name="OffloadRenameMap" xml:space="preserve">
+    <value>Folder rename map</value>
+  </data>
+  <data name="OffloadNoneConfigured" xml:space="preserve">
+    <value>none configured</value>
+  </data>
+  <data name="OffloadFolderHandlingHelp" xml:space="preserve">
+    <value>Both are configured in the Offload section of appsettings.json and are empty by default. Exclusions are matched before renaming and cover subfolders.</value>
+  </data>
+  <data name="OffloadStart" xml:space="preserve">
+    <value>Start Offload</value>
+  </data>
+  <data name="OffloadNoTargets" xml:space="preserve">
+    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+  </data>
+  <data name="OffloadTargetRequired" xml:space="preserve">
+    <value>Please choose a target mailbox.</value>
+  </data>
+  <data name="OffloadTargetMustDiffer" xml:space="preserve">
+    <value>The target mailbox must be different from the source.</value>
+  </data>
+  <data name="OffloadTargetNotFound" xml:space="preserve">
+    <value>The selected target mailbox no longer exists.</value>
+  </data>
+  <data name="OffloadTargetMustBeImap" xml:space="preserve">
+    <value>The target mailbox must be an IMAP account.</value>
+  </data>
+  <data name="OffloadTargetDisabled" xml:space="preserve">
+    <value>The selected target mailbox is disabled.</value>
+  </data>
+  <data name="OffloadCutoffRequired" xml:space="preserve">
+    <value>Please give either a month window or a from date.</value>
+  </data>
+  <data name="OffloadCutoffToBeforeFrom" xml:space="preserve">
+    <value>The to date must not be earlier than the from date.</value>
+  </data>
+  <data name="OffloadNothingInWindow" xml:space="preserve">
+    <value>No archived mail falls inside that date window.</value>
+  </data>
+  <data name="OffloadQueued" xml:space="preserve">
+    <value>Offload queued for {0} mails.</value>
+  </data>
+  <data name="OffloadDryRunQueued" xml:space="preserve">
+    <value>Dry run queued for {0} mails. Nothing will be appended.</value>
+  </data>
+  <data name="OffloadAppended" xml:space="preserve">
+    <value>Appended</value>
+  </data>
+  <data name="OffloadAlreadyPresent" xml:space="preserve">
+    <value>Already present</value>
+  </data>
+  <data name="OffloadByFingerprint" xml:space="preserve">
+    <value>matched by fingerprint</value>
+  </data>
+  <data name="OffloadExcluded" xml:space="preserve">
+    <value>Excluded folder</value>
+  </data>
+  <data name="OffloadReport" xml:space="preserve">
+    <value>Offload Report</value>
+  </data>
+  <data name="OffloadJob" xml:space="preserve">
+    <value>Offload</value>
+  </data>
 </root>

--- a/Services/BatchRestoreService.cs
+++ b/Services/BatchRestoreService.cs
@@ -19,14 +19,23 @@ namespace MailArchiver.Services
 
         // One cancellation source per job. A single shared field meant that cancelling a
         // specific job id actually cancelled whichever job happened to be running at that
-        // moment, which is wrong even with a single worker.
+        // moment, which is wrong even with a single worker and plainly broken with several.
         private readonly ConcurrentDictionary<string, CancellationTokenSource> _jobCancellations = new();
 
-        public BatchRestoreService(IServiceProvider serviceProvider, ILogger<BatchRestoreService> logger, IOptions<BatchOperationOptions> batchOptions)
+        // At most one job per target account may run at a time. Two jobs appending into the
+        // same mailbox would each take their own duplicate index snapshot before the other
+        // started writing, and could then both append the same mail. The idempotency guarantee
+        // depends on this lock.
+        private readonly ConcurrentDictionary<int, byte> _busyTargetAccounts = new();
+
+        private readonly OffloadOptions _offloadOptions;
+
+        public BatchRestoreService(IServiceProvider serviceProvider, ILogger<BatchRestoreService> logger, IOptions<BatchOperationOptions> batchOptions, IOptions<OffloadOptions> offloadOptions)
         {
             _serviceProvider = serviceProvider;
             _logger = logger;
             _batchOptions = batchOptions.Value;
+            _offloadOptions = offloadOptions.Value;
             
             // Cleanup-Timer: Jeden Stunde alte Jobs entfernen
             _cleanupTimer = new Timer(
@@ -128,10 +137,21 @@ namespace MailArchiver.Services
         {
             _logger.LogInformation("Batch Restore Background Service started");
 
+            // MaxConcurrentJobs defaults to 1, which reproduces the strictly serial behaviour
+            // this loop always had. Raising it lets independent target mailboxes be filled in
+            // parallel; the per-target lock below keeps two jobs off the same mailbox.
+            var slots = new SemaphoreSlim(Math.Max(1, _offloadOptions.MaxConcurrentJobs));
+            var running = new List<Task>();
+
+            _logger.LogInformation("Batch restore concurrency: {Max} concurrent job(s)",
+                Math.Max(1, _offloadOptions.MaxConcurrentJobs));
+
             while (!stoppingToken.IsCancellationRequested)
             {
                 try
                 {
+                    running.RemoveAll(t => t.IsCompleted);
+
                     if (_jobQueue.TryDequeue(out var job))
                     {
                         // Prüfe ob Job bereits abgebrochen wurde
@@ -141,7 +161,32 @@ namespace MailArchiver.Services
                             continue;
                         }
 
-                        await ProcessJob(job, stoppingToken);
+                        // A job whose target mailbox is already being written to goes back on
+                        // the queue rather than running: see _busyTargetAccounts.
+                        if (!_busyTargetAccounts.TryAdd(job.TargetAccountId, 0))
+                        {
+                            _logger.LogDebug(
+                                "Target account {AccountId} is busy, requeueing job {JobId}",
+                                job.TargetAccountId, job.JobId);
+                            _jobQueue.Enqueue(job);
+                            await Task.Delay(1000, stoppingToken);
+                            continue;
+                        }
+
+                        await slots.WaitAsync(stoppingToken);
+
+                        running.Add(Task.Run(async () =>
+                        {
+                            try
+                            {
+                                await ProcessJob(job, stoppingToken);
+                            }
+                            finally
+                            {
+                                _busyTargetAccounts.TryRemove(job.TargetAccountId, out _);
+                                slots.Release();
+                            }
+                        }, stoppingToken));
                     }
                     else
                     {
@@ -159,6 +204,17 @@ namespace MailArchiver.Services
                     await Task.Delay(5000, stoppingToken); // Warte 5 Sekunden bei Fehlern
                 }
             }
+
+            // Let jobs already in flight finish rather than tearing their IMAP connections down
+            // mid-append.
+            try
+            {
+                await Task.WhenAll(running.Where(t => !t.IsCompleted));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error while draining in-flight batch restore jobs on shutdown");
+            }
         }
 
         private async Task ProcessJob(BatchRestoreJob job, CancellationToken stoppingToken)
@@ -171,11 +227,20 @@ namespace MailArchiver.Services
             {
                 job.Status = BatchRestoreJobStatus.Running;
                 job.Started = DateTime.UtcNow;
-                
-                _logger.LogInformation("Starting batch restore job {JobId} with {Count} emails", 
-                    job.JobId, job.EmailIds.Count);
 
                 using var scope = _serviceProvider.CreateScope();
+
+                // An offload job carries criteria rather than ids and resolves its own set here.
+                // Full scans over a few hundred thousand rows take milliseconds against the
+                // SentDate index, so there is no reason to push id lists through session state.
+                if (job.IsOffload)
+                {
+                    await ResolveOffloadEmailIdsAsync(job, scope.ServiceProvider, cancellationToken);
+                }
+
+                _logger.LogInformation("Starting batch restore job {JobId} with {Count} emails",
+                    job.JobId, job.EmailIds.Count);
+
                 var imapEmailService = scope.ServiceProvider.GetRequiredService<MailArchiver.Services.Providers.ImapEmailService>();
                 var providerEmailService = scope.ServiceProvider.GetRequiredService<IProviderEmailService>();
                 var dbContext = scope.ServiceProvider.GetRequiredService<MailArchiverDbContext>();
@@ -209,6 +274,54 @@ namespace MailArchiver.Services
             {
                 _jobCancellations.TryRemove(job.JobId, out _);
                 jobCancellation.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Turns an offload job's criteria into the concrete set of archived mail it applies to,
+        /// and writes one audit entry recording what was resolved.
+        /// </summary>
+        private async Task ResolveOffloadEmailIdsAsync(
+            BatchRestoreJob job, IServiceProvider services, CancellationToken cancellationToken)
+        {
+            var criteria = job.Offload!;
+            var dbContext = services.GetRequiredService<MailArchiverDbContext>();
+
+            var query = dbContext.ArchivedEmails
+                .Where(e => e.MailAccountId == criteria.SourceAccountId)
+                .Where(e => e.SentDate >= criteria.CutoffFrom);
+
+            if (criteria.CutoffTo.HasValue)
+            {
+                // Same inclusive-to-end-of-day semantics the search filter uses.
+                var upper = criteria.CutoffTo.Value.Date.AddDays(1).AddSeconds(-1);
+                query = query.Where(e => e.SentDate <= upper);
+            }
+
+            job.EmailIds = await query.OrderBy(e => e.Id)
+                .Select(e => e.Id)
+                .ToListAsync(cancellationToken);
+
+            _logger.LogInformation(
+                "Job {JobId}: offload criteria resolved to {Count} mails from account {SourceId}, window {Window}",
+                job.JobId, job.EmailIds.Count, criteria.SourceAccountId, criteria.DescribeWindow());
+
+            try
+            {
+                var accessLog = services.GetRequiredService<IAccessLogService>();
+                await accessLog.LogAccessAsync(
+                    job.UserId,
+                    AccessLogType.Restore,
+                    mailAccountId: criteria.SourceAccountId,
+                    searchParameters: $"offload source={criteria.SourceAccountId} target={job.TargetAccountId} " +
+                                $"window={criteria.DescribeWindow()} folder={job.TargetFolder} " +
+                                $"preserve={job.PreserveFolderStructure} dryRun={criteria.DryRun} " +
+                                $"markAsSeen={criteria.MarkAsSeen} resolved={job.EmailIds.Count}");
+            }
+            catch (Exception ex)
+            {
+                // An audit entry must never be the reason a migration job fails.
+                _logger.LogWarning(ex, "Job {JobId}: could not write the offload audit entry", job.JobId);
             }
         }
 
@@ -271,6 +384,26 @@ namespace MailArchiver.Services
                                 job.JobId, processed, totalEmails, successful, failed);
                         }
                     };
+
+                    if (job.IsOffload)
+                    {
+                        var outcome = await imapEmailService.OffloadEmailsAsync(
+                            job.EmailIds, job.TargetAccountId, job.TargetFolder,
+                            job.PreserveFolderStructure, job.Offload!, progressCallback, cancellationToken);
+
+                        job.AppendedCount = outcome.Appended;
+                        job.SkippedAlreadyPresentCount = outcome.SkippedAlreadyPresent;
+                        job.MatchedByFingerprintCount = outcome.MatchedByFingerprint;
+                        job.SkippedExcludedFolderCount = outcome.SkippedExcludedFolder;
+                        job.SuccessCount = outcome.Appended;
+                        job.FailedCount = outcome.Failed;
+                        job.ProcessedCount = outcome.Considered;
+                        job.Report = outcome.Describe();
+
+                        _logger.LogInformation("Job {JobId}: offload completed. {Report}",
+                            job.JobId, job.Report.Replace(Environment.NewLine, " | "));
+                        return;
+                    }
 
                     var (successful, failed) = await imapEmailService.RestoreMultipleEmailsWithProgressAsync(
                         job.EmailIds, job.TargetAccountId, job.TargetFolder, job.PreserveFolderStructure, progressCallback, cancellationToken);

--- a/Services/Providers/Imap/ImapMailRestorer.cs
+++ b/Services/Providers/Imap/ImapMailRestorer.cs
@@ -769,84 +769,95 @@ namespace MailArchiver.Services.Providers.Imap
                         }
                     }
 
-                    foreach (var emailId in group.Value)
+                    // Load the emails of this group in batches instead of one at a time.
+                    // Both the duplicate check and the append reuse the same entity, so each
+                    // batch is a single round-trip rather than two queries per message.
+                    for (var i = 0; i < group.Value.Count; i += _batchOptions.BatchSize)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
+                        var batchIds = group.Value.Skip(i).Take(_batchOptions.BatchSize).ToList();
+                        var emails = await _context.ArchivedEmails
+                            .Include(e => e.Attachments)
+                                .ThenInclude(a => a.AttachmentContent)
+                            .Where(e => batchIds.Contains(e.Id))
+                            .ToDictionaryAsync(e => e.Id, cancellationToken);
 
-                        var email = await _context.ArchivedEmails
-                            .FirstOrDefaultAsync(e => e.Id == emailId, cancellationToken);
-                        if (email == null)
+                        foreach (var emailId in batchIds)
                         {
-                            outcome.Failed++;
-                            folderOutcome.Failed++;
-                            processed++;
-                            continue;
-                        }
+                            cancellationToken.ThrowIfCancellationRequested();
 
-                        var match = index.Match(email);
-                        if (match != OffloadMatchKind.None)
-                        {
-                            outcome.SkippedAlreadyPresent++;
-                            folderOutcome.SkippedAlreadyPresent++;
-                            if (match == OffloadMatchKind.Fingerprint)
-                            {
-                                outcome.MatchedByFingerprint++;
-                                folderOutcome.MatchedByFingerprint++;
-                            }
-                            processed++;
-                            progressCallback?.Invoke(processed, outcome.Appended, outcome.Failed);
-                            continue;
-                        }
-
-                        if (criteria.DryRun)
-                        {
-                            // Everything above still ran, so the reported counts are real. Only
-                            // the append is skipped. The index is still updated, so two copies
-                            // inside the same window are not both reported as appendable.
-                            outcome.Appended++;
-                            folderOutcome.Appended++;
-                            index.Add(email);
-                            processed++;
-                            progressCallback?.Invoke(processed, outcome.Appended, outcome.Failed);
-                            continue;
-                        }
-
-                        try
-                        {
-                            var ok = await RestoreEmailWithSharedConnectionAsync(
-                                emailId, client, folder!, targetAccount.Name, criteria.MarkAsSeen);
-                            if (ok)
-                            {
-                                outcome.Appended++;
-                                folderOutcome.Appended++;
-                                // Recorded immediately, so a duplicate inside this same run is
-                                // caught too and not only one against an earlier run.
-                                index.Add(email);
-                            }
-                            else
+                            if (!emails.TryGetValue(emailId, out var email))
                             {
                                 outcome.Failed++;
                                 folderOutcome.Failed++;
+                                processed++;
+                                continue;
                             }
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            throw;
-                        }
-                        catch (Exception ex)
-                        {
-                            outcome.Failed++;
-                            folderOutcome.Failed++;
-                            _logger.LogError(ex, "Error appending email {EmailId} to '{Folder}': {Message}",
-                                emailId, targetPath, ex.Message);
-                        }
 
-                        processed++;
-                        progressCallback?.Invoke(processed, outcome.Appended, outcome.Failed);
+                            var match = index.Match(email);
+                            if (match != OffloadMatchKind.None)
+                            {
+                                outcome.SkippedAlreadyPresent++;
+                                folderOutcome.SkippedAlreadyPresent++;
+                                if (match == OffloadMatchKind.Fingerprint)
+                                {
+                                    outcome.MatchedByFingerprint++;
+                                    folderOutcome.MatchedByFingerprint++;
+                                }
+                                processed++;
+                                progressCallback?.Invoke(processed, outcome.Appended, outcome.Failed);
+                                continue;
+                            }
 
-                        if (!criteria.DryRun && _batchOptions.PauseBetweenEmailsMs > 0)
-                        {
-                            await Task.Delay(_batchOptions.PauseBetweenEmailsMs, cancellationToken);
+                            if (criteria.DryRun)
+                            {
+                                // Everything above still ran, so the reported counts are real. Only
+                                // the append is skipped. The index is still updated, so two copies
+                                // inside the same window are not both reported as appendable.
+                                outcome.Appended++;
+                                folderOutcome.Appended++;
+                                index.Add(email);
+                                processed++;
+                                progressCallback?.Invoke(processed, outcome.Appended, outcome.Failed);
+                                continue;
+                            }
+
+                            try
+                            {
+                                var ok = await RestoreEmailWithSharedConnectionAsync(
+                                    email, client, folder!, targetAccount.Name, criteria.MarkAsSeen);
+                                if (ok)
+                                {
+                                    outcome.Appended++;
+                                    folderOutcome.Appended++;
+                                    // Recorded immediately, so a duplicate inside this same run is
+                                    // caught too and not only one against an earlier run.
+                                    index.Add(email);
+                                }
+                                else
+                                {
+                                    outcome.Failed++;
+                                    folderOutcome.Failed++;
+                                }
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                throw;
+                            }
+                            catch (Exception ex)
+                            {
+                                outcome.Failed++;
+                                folderOutcome.Failed++;
+                                _logger.LogError(ex, "Error appending email {EmailId} to '{Folder}': {Message}",
+                                    emailId, targetPath, ex.Message);
+                            }
+
+                            processed++;
+                            progressCallback?.Invoke(processed, outcome.Appended, outcome.Failed);
+
+                            if (!criteria.DryRun && _batchOptions.PauseBetweenEmailsMs > 0)
+                            {
+                                await Task.Delay(_batchOptions.PauseBetweenEmailsMs, cancellationToken);
+                            }
                         }
                     }
 
@@ -982,6 +993,24 @@ namespace MailArchiver.Services.Providers.Imap
                     return false;
                 }
 
+                return await RestoreEmailWithSharedConnectionAsync(email, client, targetFolder, accountName, markAsSeen);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error restoring email {EmailId} with shared connection: {Message}", emailId, ex.Message);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Restores a single email using an existing IMAP connection and an already-loaded
+        /// entity. Used by the offload path, which batch-loads its entities and therefore
+        /// cannot afford a second per-message query for the append.
+        /// </summary>
+        private async Task<bool> RestoreEmailWithSharedConnectionAsync(ArchivedEmail email, ImapClient client, IMailFolder targetFolder, string accountName, bool? markAsSeen)
+        {
+            try
+            {
                 var message = await CreateMimeMessageFromArchivedEmailAsync(email, accountName);
                 if (message == null)
                 {
@@ -991,13 +1020,13 @@ namespace MailArchiver.Services.Providers.Imap
                 var internalDate = ResolveInternalDate(email);
                 await targetFolder.AppendAsync(message, AppendFlags(markAsSeen), internalDate);
                 _logger.LogDebug("Email {EmailId} successfully appended to folder {FolderName} with INTERNALDATE {InternalDate}",
-                    emailId, targetFolder.FullName, internalDate);
+                    email.Id, targetFolder.FullName, internalDate);
 
                 return true;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error restoring email {EmailId} with shared connection: {Message}", emailId, ex.Message);
+                _logger.LogError(ex, "Error restoring email {EmailId} with shared connection: {Message}", email.Id, ex.Message);
                 return false;
             }
         }
@@ -1157,8 +1186,10 @@ namespace MailArchiver.Services.Providers.Imap
                 }
 
                 message.Body = bodyBuilder.ToMessageBody();
-                var sentUtc = _dateTimeHelper.ConvertFromDisplayTimeZoneToUtc(email.SentDate);
-                message.Date = new DateTimeOffset(sentUtc, TimeSpan.Zero);
+                // Emit the Date: header with the display timezone's offset rather than a UTC
+                // offset, so the written header matches the wall-clock time the user sees.
+                // Both represent the same instant; only the rendered offset differs.
+                message.Date = _dateTimeHelper.ToDisplayTimeZoneOffset(email.SentDate);
                 // Normalize the stored Message-ID (legacy Graph rows may carry surrounding
                 // angle brackets) so MimeKit emits a single well-formed bracket pair.
                 var restorableMessageId = MailContentHelper.NormalizeMessageId(email.MessageId);

--- a/Services/Providers/Imap/ImapMailRestorer.cs
+++ b/Services/Providers/Imap/ImapMailRestorer.cs
@@ -22,20 +22,33 @@ namespace MailArchiver.Services.Providers.Imap
         private readonly ImapConnectionFactory _connectionFactory;
         private readonly DateTimeHelper _dateTimeHelper;
         private readonly BatchOperationOptions _batchOptions;
+        private readonly OffloadOptions _offloadOptions;
 
         public ImapMailRestorer(
             MailArchiverDbContext context,
             ILogger<ImapMailRestorer> logger,
             ImapConnectionFactory connectionFactory,
             DateTimeHelper dateTimeHelper,
-            IOptions<BatchOperationOptions> batchOptions)
+            IOptions<BatchOperationOptions> batchOptions,
+            IOptions<OffloadOptions> offloadOptions)
         {
             _context = context;
             _logger = logger;
             _connectionFactory = connectionFactory;
             _dateTimeHelper = dateTimeHelper;
             _batchOptions = batchOptions.Value;
+            _offloadOptions = offloadOptions.Value;
         }
+
+        /// <summary>
+        /// The IMAP INTERNALDATE to append a message with. Delegates to
+        /// <see cref="InternalDateResolver"/>, which is where the reasoning and the tests live.
+        /// </summary>
+        internal DateTimeOffset ResolveInternalDate(ArchivedEmail email)
+            => InternalDateResolver.Resolve(email, _dateTimeHelper);
+
+        private MessageFlags AppendFlags(bool? markAsSeen = null)
+            => (markAsSeen ?? _offloadOptions.MarkAsSeen) ? MessageFlags.Seen : MessageFlags.None;
 
         /// <summary>
         /// Restores a single archived email to an IMAP folder.
@@ -192,10 +205,8 @@ namespace MailArchiver.Services.Providers.Imap
                     try
                     {
                         _logger.LogInformation("Appending message to folder {FolderName}", folder.FullName);
-                        var receivedSource = email.ReceivedDate == default ? email.SentDate : email.ReceivedDate;
-                        var internalDateUtc = _dateTimeHelper.ConvertFromDisplayTimeZoneToUtc(receivedSource);
-                        var internalDate = new DateTimeOffset(internalDateUtc, TimeSpan.Zero);
-                        await folder.AppendAsync(message, MessageFlags.Seen, internalDate);
+                        var internalDate = ResolveInternalDate(email);
+                        await folder.AppendAsync(message, AppendFlags(), internalDate);
                         _logger.LogInformation("Message successfully appended to folder {FolderName} with INTERNALDATE {InternalDate}",
                             folder.FullName, internalDate);
                     }
@@ -652,9 +663,311 @@ namespace MailArchiver.Services.Providers.Imap
         }
 
         /// <summary>
+        /// Appends archived mail into a target mailbox, skipping anything the target already
+        /// holds. This is the offload path, and it differs from the plain folder-structure
+        /// restore in four ways: source folders can be excluded, folder names can be rewritten,
+        /// duplicates are detected against the whole target mailbox, and a dry run can report
+        /// what would happen without writing anything.
+        /// </summary>
+        public async Task<OffloadOutcome> OffloadEmailsAsync(
+            List<int> emailIds,
+            int targetAccountId,
+            string baseFolderName,
+            bool preserveFolderStructure,
+            OffloadCriteria criteria,
+            Action<int, int, int>? progressCallback = null,
+            CancellationToken cancellationToken = default)
+        {
+            var outcome = new OffloadOutcome { DryRun = criteria.DryRun };
+
+            var targetAccount = await _context.MailAccounts.FindAsync(new object[] { targetAccountId }, cancellationToken);
+            if (targetAccount == null)
+            {
+                _logger.LogError("Target account with ID {AccountId} not found", targetAccountId);
+                outcome.Failed = emailIds.Count;
+                return outcome;
+            }
+
+            // Only the fields the mapping and the duplicate check need, so a large window does
+            // not pull whole message bodies into memory.
+            var rows = await _context.ArchivedEmails
+                .Where(e => emailIds.Contains(e.Id))
+                .Select(e => new { e.Id, e.FolderName })
+                .ToListAsync(cancellationToken);
+
+            // Group by the target path AFTER the rename. Keying on the raw source name would
+            // open the same target folder twice when two source folders legitimately collapse
+            // onto one, for example "Sent Items" and "Sent" both becoming "Sent".
+            var groups = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var row in rows)
+            {
+                var source = row.FolderName ?? "INBOX";
+
+                if (FolderMapper.IsExcluded(source, criteria.ExcludedSourceFolders))
+                {
+                    outcome.SkippedExcludedFolder++;
+                    continue;
+                }
+
+                var renamed = FolderMapper.ApplyRenameMap(source, criteria.FolderRenameMap);
+                var targetPath = FolderMapper.ResolveTargetPath(renamed, baseFolderName, preserveFolderStructure);
+
+                if (!groups.TryGetValue(targetPath, out var list))
+                {
+                    list = new List<int>();
+                    groups[targetPath] = list;
+                }
+                list.Add(row.Id);
+            }
+
+            _logger.LogInformation(
+                "Offload to account {AccountName}: {Considered} mails in {Groups} target folders, " +
+                "{Excluded} skipped by folder exclusion, window {Window}, dry run: {DryRun}",
+                targetAccount.Name, rows.Count - outcome.SkippedExcludedFolder, groups.Count,
+                outcome.SkippedExcludedFolder, criteria.DescribeWindow(), criteria.DryRun);
+
+            ImapClient? client = null;
+            var processed = 0;
+
+            try
+            {
+                client = _connectionFactory.CreateImapClient(targetAccount.Name);
+                client.Timeout = 180000;
+                client.ServerCertificateValidationCallback = _connectionFactory.ServerCertificateValidationCallback;
+
+                await _connectionFactory.ConnectWithFallbackAsync(
+                    client, targetAccount.ImapServer, targetAccount.ImapPort ?? 993, targetAccount.UseSSL, targetAccount.Name);
+                await _connectionFactory.AuthenticateClientAsync(client, targetAccount);
+
+                // Built once per job, before the first append, and covering the whole target
+                // mailbox. This is what makes the offload repeatable.
+                var index = await TargetMailboxIndex.BuildAsync(
+                    client, _dateTimeHelper, _logger, _offloadOptions.PrefetchMaxMessages,
+                    restrictToFolder: null, cancellationToken: cancellationToken);
+                outcome.DuplicateScopeReduced = index.ScopeReduced;
+
+                foreach (var group in groups)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var targetPath = group.Key;
+                    var folderOutcome = outcome.Folder(targetPath);
+
+                    IMailFolder? folder = null;
+                    if (!criteria.DryRun)
+                    {
+                        folder = await ResolveOrCreateFolderAsync(client, targetPath, cancellationToken);
+                        if (folder == null)
+                        {
+                            _logger.LogError("Could not resolve or create target folder '{Folder}', skipping {Count} mails",
+                                targetPath, group.Value.Count);
+                            outcome.Failed += group.Value.Count;
+                            folderOutcome.Failed += group.Value.Count;
+                            processed += group.Value.Count;
+                            progressCallback?.Invoke(processed, outcome.Appended, outcome.Failed);
+                            continue;
+                        }
+                    }
+
+                    foreach (var emailId in group.Value)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        var email = await _context.ArchivedEmails
+                            .FirstOrDefaultAsync(e => e.Id == emailId, cancellationToken);
+                        if (email == null)
+                        {
+                            outcome.Failed++;
+                            folderOutcome.Failed++;
+                            processed++;
+                            continue;
+                        }
+
+                        var match = index.Match(email);
+                        if (match != OffloadMatchKind.None)
+                        {
+                            outcome.SkippedAlreadyPresent++;
+                            folderOutcome.SkippedAlreadyPresent++;
+                            if (match == OffloadMatchKind.Fingerprint)
+                            {
+                                outcome.MatchedByFingerprint++;
+                                folderOutcome.MatchedByFingerprint++;
+                            }
+                            processed++;
+                            progressCallback?.Invoke(processed, outcome.Appended, outcome.Failed);
+                            continue;
+                        }
+
+                        if (criteria.DryRun)
+                        {
+                            // Everything above still ran, so the reported counts are real. Only
+                            // the append is skipped. The index is still updated, so two copies
+                            // inside the same window are not both reported as appendable.
+                            outcome.Appended++;
+                            folderOutcome.Appended++;
+                            index.Add(email);
+                            processed++;
+                            progressCallback?.Invoke(processed, outcome.Appended, outcome.Failed);
+                            continue;
+                        }
+
+                        try
+                        {
+                            var ok = await RestoreEmailWithSharedConnectionAsync(
+                                emailId, client, folder!, targetAccount.Name, criteria.MarkAsSeen);
+                            if (ok)
+                            {
+                                outcome.Appended++;
+                                folderOutcome.Appended++;
+                                // Recorded immediately, so a duplicate inside this same run is
+                                // caught too and not only one against an earlier run.
+                                index.Add(email);
+                            }
+                            else
+                            {
+                                outcome.Failed++;
+                                folderOutcome.Failed++;
+                            }
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex)
+                        {
+                            outcome.Failed++;
+                            folderOutcome.Failed++;
+                            _logger.LogError(ex, "Error appending email {EmailId} to '{Folder}': {Message}",
+                                emailId, targetPath, ex.Message);
+                        }
+
+                        processed++;
+                        progressCallback?.Invoke(processed, outcome.Appended, outcome.Failed);
+
+                        if (!criteria.DryRun && _batchOptions.PauseBetweenEmailsMs > 0)
+                        {
+                            await Task.Delay(_batchOptions.PauseBetweenEmailsMs, cancellationToken);
+                        }
+                    }
+
+                    if (!criteria.DryRun && _batchOptions.PauseBetweenBatchesMs > 0)
+                    {
+                        await Task.Delay(_batchOptions.PauseBetweenBatchesMs, cancellationToken);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogInformation("Offload was cancelled after {Processed} of {Total} mails", processed, rows.Count);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Critical error during offload: {Message}", ex.Message);
+                outcome.Failed += Math.Max(0, rows.Count - outcome.SkippedExcludedFolder - processed);
+            }
+            finally
+            {
+                if (client != null)
+                {
+                    try
+                    {
+                        if (client.IsConnected) await client.DisconnectAsync(true);
+                        client.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Error during IMAP client cleanup");
+                    }
+                }
+            }
+
+            _logger.LogInformation("Offload finished. {Summary}", outcome.Describe().Replace(Environment.NewLine, " | "));
+            return outcome;
+        }
+
+        /// <summary>
+        /// Finds a target folder, creating the whole path if it does not exist yet. Returns null
+        /// when neither is possible.
+        /// <para>
+        /// Paths are built with the separator the target server actually reports rather than a
+        /// hard coded one, because the resolved path uses "/" internally while servers differ:
+        /// Dovecot and mailcow use "/", others use "." or "\".
+        /// </para>
+        /// </summary>
+        private async Task<IMailFolder?> ResolveOrCreateFolderAsync(
+            ImapClient client, string path, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await client.GetFolderAsync(path, cancellationToken);
+            }
+            catch
+            {
+                // Does not exist yet, so build it segment by segment below.
+            }
+
+            try
+            {
+                var segments = path.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+                if (segments.Length == 0) return client.Inbox;
+
+                // Top level folders are created under the personal namespace root, not under
+                // INBOX, unless the path itself starts at INBOX.
+                IMailFolder root = client.PersonalNamespaces != null && client.PersonalNamespaces.Count > 0
+                    ? client.GetFolder(client.PersonalNamespaces[0])
+                    : client.Inbox;
+
+                IMailFolder current;
+                int firstSegment;
+
+                if (string.Equals(segments[0], "INBOX", StringComparison.OrdinalIgnoreCase))
+                {
+                    current = client.Inbox;
+                    firstSegment = 1;
+                }
+                else
+                {
+                    current = root;
+                    firstSegment = 0;
+                }
+
+                for (var i = firstSegment; i < segments.Length; i++)
+                {
+                    var segment = segments[i];
+                    var separator = current.DirectorySeparator == '\0' ? '/' : current.DirectorySeparator;
+                    var candidate = string.IsNullOrEmpty(current.FullName)
+                        ? segment
+                        : $"{current.FullName}{separator}{segment}";
+
+                    try
+                    {
+                        current = await client.GetFolderAsync(candidate, cancellationToken);
+                    }
+                    catch
+                    {
+                        current = await current.CreateAsync(segment, true, cancellationToken);
+                        _logger.LogInformation("Created target folder '{Folder}'", current.FullName);
+                    }
+                }
+
+                return current;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Could not create target folder path '{Path}'", path);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Restores a single email using an existing IMAP connection.
         /// </summary>
-        public async Task<bool> RestoreEmailWithSharedConnectionAsync(int emailId, ImapClient client, IMailFolder targetFolder, string accountName)
+        /// <param name="markAsSeen">
+        /// Whether to append with the Seen flag. Null falls back to the configured default,
+        /// which is true and reproduces the behaviour this path always had.
+        /// </param>
+        public async Task<bool> RestoreEmailWithSharedConnectionAsync(int emailId, ImapClient client, IMailFolder targetFolder, string accountName, bool? markAsSeen = null)
         {
             try
             {
@@ -675,10 +988,8 @@ namespace MailArchiver.Services.Providers.Imap
                     return false;
                 }
 
-                var receivedSource = email.ReceivedDate == default ? email.SentDate : email.ReceivedDate;
-                var internalDateUtc = _dateTimeHelper.ConvertFromDisplayTimeZoneToUtc(receivedSource);
-                var internalDate = new DateTimeOffset(internalDateUtc, TimeSpan.Zero);
-                await targetFolder.AppendAsync(message, MessageFlags.Seen, internalDate);
+                var internalDate = ResolveInternalDate(email);
+                await targetFolder.AppendAsync(message, AppendFlags(markAsSeen), internalDate);
                 _logger.LogDebug("Email {EmailId} successfully appended to folder {FolderName} with INTERNALDATE {InternalDate}",
                     emailId, targetFolder.FullName, internalDate);
 

--- a/Services/Providers/Imap/TargetMailboxIndex.cs
+++ b/Services/Providers/Imap/TargetMailboxIndex.cs
@@ -1,0 +1,290 @@
+// Services/Providers/Imap/TargetMailboxIndex.cs
+using MailArchiver.Models;
+using MailArchiver.Services.Shared;
+using MailArchiver.Utilities;
+using MailKit;
+using MailKit.Net.Imap;
+
+namespace MailArchiver.Services.Providers.Imap
+{
+    /// <summary>How a message was recognised as already present in the target mailbox.</summary>
+    public enum OffloadMatchKind
+    {
+        None = 0,
+        MessageId = 1,
+        Fingerprint = 2,
+    }
+
+    /// <summary>
+    /// An in-memory index of what a target mailbox already holds, so that an offload can be
+    /// repeated without duplicating mail.
+    /// <para>
+    /// The scope is the whole target account rather than one resolved folder. That way the index
+    /// still holds if users reorganise their mail between two runs, and it holds if a run is
+    /// repeated with a different folder rename map.
+    /// </para>
+    /// <para>
+    /// Only 64 bit hashes are stored, never the strings they came from. Two string sets at the
+    /// configured maximum of 500,000 entries would cost a few hundred megabytes; the hashes cost
+    /// single digit megabytes. A hash collision would cause one message to be skipped as already
+    /// present, which is an acceptable trade at this probability.
+    /// </para>
+    /// </summary>
+    public class TargetMailboxIndex
+    {
+        private readonly HashSet<long> _messageIdKeys = new();
+
+        // The second criterion needs a range comparison on the send time, so its timestamps
+        // cannot be folded into the key. Quantising into two second buckets is not equivalent:
+        // two copies of the same message one second apart can land in different buckets, and
+        // then the match silently never fires.
+        private readonly Dictionary<long, List<DateTime>> _fingerprints = new();
+
+        private readonly DateTimeHelper _dateTimeHelper;
+
+        internal TargetMailboxIndex(DateTimeHelper dateTimeHelper)
+        {
+            _dateTimeHelper = dateTimeHelper;
+        }
+
+        /// <summary>Messages read into the index.</summary>
+        public int IndexedMessages { get; private set; }
+
+        /// <summary>Folders read into the index.</summary>
+        public int IndexedFolders { get; private set; }
+
+        /// <summary>
+        /// True when the message cap was reached and the index therefore covers less than the
+        /// whole mailbox. Duplicate detection is correspondingly narrower, and this is logged
+        /// rather than passed over in silence.
+        /// </summary>
+        public bool ScopeReduced { get; private set; }
+
+        /// <summary>
+        /// Reads every folder of the target account and indexes it. ENVELOPE alone feeds both
+        /// criteria, so one bulk fetch per folder is enough.
+        /// </summary>
+        /// <param name="restrictToFolder">
+        /// When given, only this folder is indexed instead of the whole mailbox. Used as the
+        /// fallback once the message cap has been hit.
+        /// </param>
+        public static async Task<TargetMailboxIndex> BuildAsync(
+            ImapClient client,
+            DateTimeHelper dateTimeHelper,
+            ILogger logger,
+            int prefetchMaxMessages,
+            IMailFolder? restrictToFolder = null,
+            CancellationToken cancellationToken = default)
+        {
+            var index = new TargetMailboxIndex(dateTimeHelper);
+
+            var folders = new List<IMailFolder>();
+            if (restrictToFolder != null)
+            {
+                folders.Add(restrictToFolder);
+                index.ScopeReduced = true;
+            }
+            else
+            {
+                folders.AddRange(await EnumerateFoldersAsync(client, logger, cancellationToken));
+            }
+
+            foreach (var folder in folders)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (index.IndexedMessages >= prefetchMaxMessages)
+                {
+                    index.ScopeReduced = true;
+                    logger.LogWarning(
+                        "Target mailbox index reached the configured limit of {Limit} messages after {Folders} folders. " +
+                        "Duplicate detection no longer covers the whole mailbox, so a repeated offload may append mail " +
+                        "that is already present in folders which were not indexed. Raise Offload:PrefetchMaxMessages to avoid this.",
+                        prefetchMaxMessages, index.IndexedFolders);
+                    break;
+                }
+
+                try
+                {
+                    await index.IndexFolderAsync(folder, logger, prefetchMaxMessages, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    // A folder that cannot be opened must not abort the whole job, but it does
+                    // narrow the scope, so say so.
+                    index.ScopeReduced = true;
+                    logger.LogWarning(ex,
+                        "Could not index target folder '{Folder}'. Mail already present there will not be recognised, " +
+                        "so a repeated offload may duplicate it.", folder.FullName);
+                }
+            }
+
+            logger.LogInformation(
+                "Target mailbox index built: {Messages} messages across {Folders} folders, " +
+                "{MessageIdKeys} Message-ID keys, {Fingerprints} fingerprints, scope reduced: {Reduced}",
+                index.IndexedMessages, index.IndexedFolders, index._messageIdKeys.Count,
+                index._fingerprints.Count, index.ScopeReduced);
+
+            return index;
+        }
+
+        private static async Task<List<IMailFolder>> EnumerateFoldersAsync(
+            ImapClient client, ILogger logger, CancellationToken cancellationToken)
+        {
+            var result = new List<IMailFolder>();
+
+            if (client.PersonalNamespaces == null || client.PersonalNamespaces.Count == 0)
+            {
+                logger.LogWarning("No personal namespaces reported by the target server; indexing INBOX only");
+                result.Add(client.Inbox);
+                return result;
+            }
+
+            // The same recursive enumeration ImapFolderService uses.
+            var folders = await client.GetFoldersAsync(
+                client.PersonalNamespaces[0], StatusItems.None, subscribedOnly: false, cancellationToken);
+
+            result.AddRange(folders.Where(f => !f.Attributes.HasFlag(FolderAttributes.NonExistent)
+                                            && !f.Attributes.HasFlag(FolderAttributes.NoSelect)));
+
+            if (!result.Any(f => f.FullName.Equals(client.Inbox.FullName, StringComparison.OrdinalIgnoreCase)))
+            {
+                result.Add(client.Inbox);
+            }
+
+            return result;
+        }
+
+        private async Task IndexFolderAsync(
+            IMailFolder folder, ILogger logger, int prefetchMaxMessages, CancellationToken cancellationToken)
+        {
+            if (!folder.IsOpen)
+            {
+                await folder.OpenAsync(FolderAccess.ReadOnly, cancellationToken);
+            }
+
+            IndexedFolders++;
+
+            if (folder.Count == 0) return;
+
+            // One bulk fetch per folder; ENVELOPE carries subject, from, to, date and Message-ID,
+            // which is everything both criteria need. Same shape as the bulk fetch in
+            // ImapMailSyncService.
+            var summaries = await folder.FetchAsync(
+                0, -1, MessageSummaryItems.Envelope | MessageSummaryItems.UniqueId, cancellationToken);
+
+            foreach (var summary in summaries)
+            {
+                if (IndexedMessages >= prefetchMaxMessages) return;
+
+                var envelope = summary.Envelope;
+                if (envelope == null) continue;
+
+                IndexedMessages++;
+
+                var messageIdKey = OffloadMatchKey.MessageIdKey(envelope.MessageId);
+                if (messageIdKey.HasValue)
+                {
+                    _messageIdKeys.Add(messageIdKey.Value);
+                }
+
+                AddFingerprint(
+                    OffloadMatchKey.FingerprintKeyFromAddresses(
+                        envelope.From?.Mailboxes.Select(m => m.Address),
+                        envelope.To?.Mailboxes.Select(m => m.Address),
+                        envelope.Subject),
+                    ToStoredTimestamp(envelope.Date));
+            }
+        }
+
+        /// <summary>
+        /// Converts an envelope date into the form <c>ArchivedEmail.SentDate</c> is stored in.
+        /// <para>
+        /// This conversion is not optional. <c>SentDate</c> is display-local and naive, while an
+        /// envelope date arrives from the wire as an absolute <see cref="DateTimeOffset"/>.
+        /// Comparing the two directly makes the plus/minus two second window miss by the full
+        /// timezone offset, so under any non-UTC display timezone the fingerprint criterion would
+        /// never fire at all.
+        /// </para>
+        /// </summary>
+        private DateTime ToStoredTimestamp(DateTimeOffset? envelopeDate)
+            => envelopeDate.HasValue
+                ? _dateTimeHelper.ConvertToDisplayTimeZone(envelopeDate.Value)
+                : DateTime.MinValue;
+
+        private void AddFingerprint(long key, DateTime timestamp)
+        {
+            if (_fingerprints.TryGetValue(key, out var timestamps))
+            {
+                timestamps.Add(timestamp);
+            }
+            else
+            {
+                _fingerprints[key] = new List<DateTime> { timestamp };
+            }
+        }
+
+        /// <summary>
+        /// Whether the target mailbox already holds this archived message, and by which
+        /// criterion. The Message-ID is tried first because it is by far the more reliable of
+        /// the two; the fingerprint exists for the rows whose stored Message-ID is unusable.
+        /// </summary>
+        public OffloadMatchKind Match(ArchivedEmail email)
+        {
+            var messageIdKey = OffloadMatchKey.MessageIdKey(email.MessageId);
+            if (messageIdKey.HasValue && _messageIdKeys.Contains(messageIdKey.Value))
+            {
+                return OffloadMatchKind.MessageId;
+            }
+
+            var fingerprint = OffloadMatchKey.FingerprintKeyFromStored(email);
+            if (_fingerprints.TryGetValue(fingerprint, out var timestamps))
+            {
+                foreach (var candidate in timestamps)
+                {
+                    if (OffloadMatchKey.WithinTolerance(candidate, email.SentDate))
+                    {
+                        return OffloadMatchKind.Fingerprint;
+                    }
+                }
+            }
+
+            return OffloadMatchKind.None;
+        }
+
+        /// <summary>
+        /// Records a message as present. Called after every successful append, so that
+        /// duplicates within a single run are caught as well, not only duplicates against an
+        /// earlier one.
+        /// </summary>
+        public void Add(ArchivedEmail email)
+        {
+            var messageIdKey = OffloadMatchKey.MessageIdKey(email.MessageId);
+            if (messageIdKey.HasValue)
+            {
+                _messageIdKeys.Add(messageIdKey.Value);
+            }
+
+            AddFingerprint(OffloadMatchKey.FingerprintKeyFromStored(email), email.SentDate);
+            IndexedMessages++;
+        }
+
+        /// <summary>
+        /// Adds an entry from raw values, without needing an <see cref="ArchivedEmail"/>. Lets
+        /// the match logic be exercised against a hand-built index, since the IMAP fetch that
+        /// normally fills it cannot be unit tested. Internal, reached from the test project
+        /// through the InternalsVisibleTo already declared in MailArchiver.csproj.
+        /// </summary>
+        internal void AddRaw(string? messageId, string? from, string? to, string? subject, DateTime sentDate)
+        {
+            var key = OffloadMatchKey.MessageIdKey(messageId);
+            if (key.HasValue) _messageIdKeys.Add(key.Value);
+            AddFingerprint(OffloadMatchKey.FingerprintKeyFromStored(from, to, subject), sentDate);
+            IndexedMessages++;
+        }
+    }
+}

--- a/Services/Providers/ImapEmailService.cs
+++ b/Services/Providers/ImapEmailService.cs
@@ -87,6 +87,24 @@ namespace MailArchiver.Services.Providers
             return await _restorer.RestoreEmailToFolderAsync(emailId, targetAccountId, folderName, preserveFolderStructure);
         }
 
+        /// <summary>
+        /// Date-windowed offload into another mailbox: appends only what the target does not
+        /// already hold, honouring folder exclusions and the folder rename map.
+        /// </summary>
+        public Task<OffloadOutcome> OffloadEmailsAsync(
+            List<int> emailIds,
+            int targetAccountId,
+            string folderName,
+            bool preserveFolderStructure,
+            OffloadCriteria criteria,
+            Action<int, int, int>? progressCallback,
+            CancellationToken cancellationToken)
+        {
+            return _restorer.OffloadEmailsAsync(
+                emailIds, targetAccountId, folderName, preserveFolderStructure,
+                criteria, progressCallback, cancellationToken);
+        }
+
         public Task<(int Successful, int Failed)> RestoreMultipleEmailsWithProgressAsync(
             List<int> emailIds,
             int targetAccountId,

--- a/Services/Shared/FolderMapper.cs
+++ b/Services/Shared/FolderMapper.cs
@@ -1,0 +1,135 @@
+// Services/Shared/FolderMapper.cs
+namespace MailArchiver.Services.Shared
+{
+    /// <summary>
+    /// Turns a stored source folder path into the folder an offload should append into.
+    /// <para>
+    /// The order of the three steps is not interchangeable. Exclusion is matched against the
+    /// source name, because an exclusion on "Deleted Items" would never fire if the rename to
+    /// "Trash" had already happened. Only then is the rename applied, and only then is the
+    /// target path built.
+    /// </para>
+    /// <para>
+    /// <see cref="ArchivedEmail.FolderName"/> holds the full source path, so the rename is a
+    /// rewrite of the longest matching path prefix along segment boundaries rather than a match
+    /// on the whole string: renaming "Sent Items" to "Sent" also has to turn "Sent Items/2019"
+    /// into "Sent/2019", while leaving "Sent Items Archive" alone.
+    /// </para>
+    /// </summary>
+    public static class FolderMapper
+    {
+        // The existing folder creation in ImapMailRestorer splits on both separators, so the
+        // same set is used here to decide where a segment boundary is.
+        private static readonly char[] Separators = { '/', '\\' };
+
+        /// <summary>
+        /// Whether the source folder is excluded, either by an exact match or by being a
+        /// descendant of an excluded folder. Case insensitive. Evaluated before any rename.
+        /// </summary>
+        public static bool IsExcluded(string? sourcePath, IEnumerable<string>? excludedFolders)
+        {
+            if (excludedFolders == null) return false;
+
+            var segments = Split(sourcePath);
+            if (segments.Count == 0) return false;
+
+            foreach (var excluded in excludedFolders)
+            {
+                var excludedSegments = Split(excluded);
+                if (excludedSegments.Count == 0) continue;
+                if (StartsWithSegments(segments, excludedSegments)) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Rewrites the longest matching prefix of the source path using the map. Matching is
+        /// case insensitive and happens on segment boundaries only.
+        /// </summary>
+        public static string ApplyRenameMap(string? sourcePath, IDictionary<string, string>? map)
+        {
+            var segments = Split(sourcePath);
+            if (segments.Count == 0) return string.Empty;
+            if (map == null || map.Count == 0) return string.Join("/", segments);
+
+            List<string>? bestReplacement = null;
+            var bestLength = 0;
+
+            foreach (var entry in map)
+            {
+                var fromSegments = Split(entry.Key);
+                if (fromSegments.Count == 0) continue;
+                if (fromSegments.Count <= bestLength) continue;
+                if (!StartsWithSegments(segments, fromSegments)) continue;
+
+                bestLength = fromSegments.Count;
+                bestReplacement = Split(entry.Value);
+            }
+
+            if (bestReplacement == null) return string.Join("/", segments);
+
+            var rewritten = new List<string>(bestReplacement);
+            rewritten.AddRange(segments.Skip(bestLength));
+            return string.Join("/", rewritten);
+        }
+
+        /// <summary>
+        /// Builds the target folder path, reproducing the rule the restore path already uses:
+        /// when the target root is INBOX the renamed source path is used as it is, otherwise it
+        /// is placed below the root. Without structure preservation everything lands in the root.
+        /// </summary>
+        public static string ResolveTargetPath(string? renamedPath, string? targetRoot, bool preserveStructure)
+        {
+            var root = string.IsNullOrWhiteSpace(targetRoot) ? "INBOX" : targetRoot.Trim();
+
+            if (!preserveStructure) return root;
+
+            var segments = Split(renamedPath);
+            if (segments.Count == 0) return root;
+
+            var renamed = string.Join("/", segments);
+
+            return string.Equals(root, "INBOX", StringComparison.OrdinalIgnoreCase)
+                ? renamed
+                : $"{root}/{renamed}";
+        }
+
+        /// <summary>
+        /// The full pipeline: exclusion, then rename, then target path. Returns null when the
+        /// source folder is excluded.
+        /// </summary>
+        public static string? Resolve(
+            string? sourcePath,
+            string? targetRoot,
+            bool preserveStructure,
+            IEnumerable<string>? excludedFolders,
+            IDictionary<string, string>? renameMap)
+        {
+            if (IsExcluded(sourcePath, excludedFolders)) return null;
+            var renamed = ApplyRenameMap(sourcePath, renameMap);
+            return ResolveTargetPath(renamed, targetRoot, preserveStructure);
+        }
+
+        private static List<string> Split(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return new List<string>();
+            return path
+                .Split(Separators, StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => s.Trim())
+                .Where(s => s.Length > 0)
+                .ToList();
+        }
+
+        private static bool StartsWithSegments(List<string> segments, List<string> prefix)
+        {
+            if (prefix.Count > segments.Count) return false;
+            for (var i = 0; i < prefix.Count; i++)
+            {
+                if (!string.Equals(segments[i], prefix[i], StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Services/Shared/InternalDateResolver.cs
+++ b/Services/Shared/InternalDateResolver.cs
@@ -1,0 +1,84 @@
+// Services/Shared/InternalDateResolver.cs
+using MailArchiver.Models;
+using MailArchiver.Utilities;
+
+namespace MailArchiver.Services.Shared
+{
+    /// <summary>
+    /// Works out the IMAP INTERNALDATE to append an archived message with, i.e. when it was
+    /// delivered.
+    /// <para>
+    /// This used to be taken from <c>ReceivedDate</c>, which is assigned <c>DateTime.UtcNow</c>
+    /// when a message is archived and is therefore the time of the archiving run, not of
+    /// delivery. Every restored message consequently carried the date of whichever sync or
+    /// import archived it. The defect hides well, because the Date header is correct and clients
+    /// sort by it; what was wrong is IMAP SORT ARRIVAL, server side age and retention rules, and
+    /// any verification of a restore by date.
+    /// </para>
+    /// </summary>
+    public static class InternalDateResolver
+    {
+        private const string ReceivedHeaderPrefix = "Received:";
+
+        /// <summary>
+        /// The delivery time for a message, preferring its Received chain and falling back to
+        /// <c>SentDate</c>.
+        /// <para>
+        /// The two branches need opposite timezone treatment, which is the easiest thing here to
+        /// get backwards, and getting it backwards produces no error at all. A time recovered
+        /// from a Received header is an absolute instant and must be used as it is.
+        /// <c>SentDate</c> is stored display-local and naive, so it has to be converted out of
+        /// the display timezone first.
+        /// </para>
+        /// </summary>
+        public static DateTimeOffset Resolve(ArchivedEmail email, DateTimeHelper dateTimeHelper)
+        {
+            var delivered = TryExtractDeliveryTime(email.RawHeaders);
+            if (delivered.HasValue)
+            {
+                return delivered.Value;
+            }
+
+            var utc = dateTimeHelper.ConvertFromDisplayTimeZoneToUtc(email.SentDate);
+            return new DateTimeOffset(DateTime.SpecifyKind(utc, DateTimeKind.Utc), TimeSpan.Zero);
+        }
+
+        /// <summary>
+        /// Reads the delivery time out of a stored Received chain, or null if there is none to
+        /// read.
+        /// <para>
+        /// The <b>topmost</b> Received header is the one that matters: the chain is prepended to
+        /// as a message travels, so the first one is the final delivery.
+        /// </para>
+        /// <para>
+        /// <see cref="MailContentHelper.ExtractEmailDate"/> cannot be reused here even though it
+        /// looks like exactly the right helper. It returns the Date header whenever one is
+        /// present, which is the value already stored in <c>SentDate</c>, so the change would
+        /// compile, run, and alter nothing. It also deliberately walks the chain from the oldest
+        /// hop, because its job is to guess when a message was written, and that is the opposite
+        /// end of the chain from the one INTERNALDATE needs.
+        /// </para>
+        /// <para>
+        /// <c>RawHeaders</c> is stored as one "Field: Value" line per header and truncated at
+        /// 100,000 characters. Received headers sit at the top of a message, so they normally
+        /// survive that truncation.
+        /// </para>
+        /// </summary>
+        public static DateTimeOffset? TryExtractDeliveryTime(string? rawHeaders)
+        {
+            if (string.IsNullOrEmpty(rawHeaders)) return null;
+
+            foreach (var rawLine in rawHeaders.Split('\n'))
+            {
+                var line = rawLine.TrimEnd('\r');
+                if (!line.StartsWith(ReceivedHeaderPrefix, StringComparison.OrdinalIgnoreCase)) continue;
+
+                var value = line.Substring(ReceivedHeaderPrefix.Length);
+                var parsed = MailContentHelper.ExtractDateFromReceivedHeader(value);
+                if (parsed.HasValue) return parsed.Value;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Services/Shared/OffloadCutoff.cs
+++ b/Services/Shared/OffloadCutoff.cs
@@ -1,0 +1,62 @@
+// Services/Shared/OffloadCutoff.cs
+namespace MailArchiver.Services.Shared
+{
+    /// <summary>
+    /// Resolves a migration cutoff into the absolute dates a job stores and reports.
+    /// <para>
+    /// A relative expression such as "the last six months" is turned into a fixed date when the
+    /// job is created, and never re-evaluated while it runs. A job can run for a long time and
+    /// may be repeated afterwards, and it has to resolve the same set of mail every time; a
+    /// stored relative window would drift between runs and would make the job's own reporting
+    /// untrue.
+    /// </para>
+    /// <para>
+    /// Cutoffs are interpreted in the configured display timezone, because
+    /// <c>ArchivedEmail.SentDate</c> is stored as a naive timestamp that was already converted
+    /// into that timezone. That is also the timezone the search UI shows.
+    /// </para>
+    /// </summary>
+    public static class OffloadCutoff
+    {
+        /// <summary>
+        /// The start of the day <paramref name="months"/> months before the given moment.
+        /// Inclusive, so mail sent at 00:00 on that day is inside the window.
+        /// </summary>
+        public static DateTime FromRelativeMonths(DateTime nowInDisplayTimeZone, int months)
+        {
+            if (months < 0) throw new ArgumentOutOfRangeException(nameof(months));
+            return nowInDisplayTimeZone.Date.AddMonths(-months);
+        }
+
+        /// <summary>
+        /// The start of the day <paramref name="days"/> days before the given moment.
+        /// </summary>
+        public static DateTime FromRelativeDays(DateTime nowInDisplayTimeZone, int days)
+        {
+            if (days < 0) throw new ArgumentOutOfRangeException(nameof(days));
+            return nowInDisplayTimeZone.Date.AddDays(-days);
+        }
+
+        /// <summary>
+        /// Normalises an explicitly given cutoff to the start of its day.
+        /// </summary>
+        public static DateTime FromAbsolute(DateTime date) => date.Date;
+
+        /// <summary>
+        /// The inclusive end of an optional upper bound, reproducing the semantics the search
+        /// filter already uses (<c>SentDate &lt;= toDate.AddDays(1).AddSeconds(-1)</c>), so the
+        /// whole of the given day is inside the window.
+        /// </summary>
+        public static DateTime ToInclusiveEnd(DateTime date) => date.Date.AddDays(1).AddSeconds(-1);
+
+        /// <summary>
+        /// Whether a stored <c>SentDate</c> falls inside the resolved window.
+        /// </summary>
+        public static bool IsInWindow(DateTime sentDate, DateTime cutoffFrom, DateTime? cutoffTo)
+        {
+            if (sentDate < cutoffFrom) return false;
+            if (cutoffTo.HasValue && sentDate > ToInclusiveEnd(cutoffTo.Value)) return false;
+            return true;
+        }
+    }
+}

--- a/Services/Shared/OffloadMatchKey.cs
+++ b/Services/Shared/OffloadMatchKey.cs
@@ -1,0 +1,146 @@
+// Services/Shared/OffloadMatchKey.cs
+using MailArchiver.Models;
+
+namespace MailArchiver.Services.Shared
+{
+    /// <summary>
+    /// Builds the two duplicate detection keys an offload uses against a target mailbox.
+    /// <para>
+    /// Keys are 64 bit hashes rather than strings. Two string sets holding the configured
+    /// maximum of 500,000 entries each would cost a few hundred megabytes once .NET string
+    /// overhead is counted; the hashes cost single digit megabytes. At that size the birthday
+    /// collision probability is negligible, and the consequence of a collision is one message
+    /// skipped as already present.
+    /// </para>
+    /// <para>
+    /// The fingerprint deliberately does <b>not</b> mirror the duplicate query the import uses
+    /// in <c>MailImporter</c>. That query compares against values it never stored: it joins
+    /// addresses with "," while the row was written with ", ", and it compares a raw subject
+    /// against a column that went through <see cref="MailContentHelper.CleanText"/>. As a
+    /// result its own second criterion cannot match any message with two or more senders or
+    /// recipients. Since the database side of the key is fixed by what is already in the
+    /// column, the other side has to reproduce the <b>storage</b> format instead.
+    /// </para>
+    /// </summary>
+    public static class OffloadMatchKey
+    {
+        /// <summary>
+        /// The window within which two timestamps count as the same message, matching the
+        /// tolerance the import has always used.
+        /// </summary>
+        public const double TimestampToleranceSeconds = 2;
+
+        // Field size limits, mirroring the ones MailImporter applies when it writes the row.
+        private const int FromMaxBytes = 10_000;
+        private const int ToMaxBytes = 50_000;
+        private const int SubjectMaxBytes = 50_000;
+
+        private const string NoSubject = "(No Subject)";
+
+        // Separates the fields inside a fingerprint so that moving text from one field to the
+        // next cannot produce the same key. A unit separator cannot occur in a stored value,
+        // because CleanText has already replaced every character below 32 with a space.
+        private const string FieldSeparator = "\u001F";
+
+        /// <summary>
+        /// Key for the first criterion. Returns null when the stored Message-ID is missing or
+        /// carries no "@", because such a value is not emitted on append either: the restore
+        /// path drops it and MimeKit generates a fresh random Message-Id instead. A null here
+        /// is what pushes the caller on to the fingerprint.
+        /// </summary>
+        public static long? MessageIdKey(string? messageId)
+        {
+            var normalized = MailContentHelper.NormalizeMessageId(messageId);
+            if (string.IsNullOrEmpty(normalized) || !normalized.Contains('@')) return null;
+            return Hash64(normalized.ToLowerInvariant());
+        }
+
+        /// <summary>
+        /// Fingerprint built from values already in storage format, i.e. straight from the
+        /// columns of an archived row.
+        /// </summary>
+        public static long FingerprintKeyFromStored(string? from, string? to, string? subject)
+            => Hash64(string.Concat(
+                from ?? string.Empty, FieldSeparator,
+                to ?? string.Empty, FieldSeparator,
+                subject ?? string.Empty));
+
+        /// <summary>
+        /// Convenience overload for an archived row, whose columns are already normalised.
+        /// </summary>
+        public static long FingerprintKeyFromStored(ArchivedEmail email)
+            => FingerprintKeyFromStored(email.From, email.To, email.Subject);
+
+        /// <summary>
+        /// Fingerprint built from raw address lists and a raw subject, for example from an IMAP
+        /// ENVELOPE. The inputs are normalised into the storage format first, so the result is
+        /// comparable with <see cref="FingerprintKeyFromStored(string, string, string)"/> for
+        /// the same message.
+        /// </summary>
+        public static long FingerprintKeyFromAddresses(
+            IEnumerable<string>? fromAddresses,
+            IEnumerable<string>? toAddresses,
+            string? subject)
+            => FingerprintKeyFromStored(
+                NormalizeAddresses(fromAddresses, FromMaxBytes),
+                NormalizeAddresses(toAddresses, ToMaxBytes),
+                NormalizeSubject(subject));
+
+        /// <summary>
+        /// Joins and cleans addresses exactly as MailImporter does when it writes the column:
+        /// ", " between addresses, then <see cref="MailContentHelper.CleanText"/>, then the
+        /// tsvector field truncation.
+        /// </summary>
+        public static string NormalizeAddresses(IEnumerable<string>? addresses, int maxBytes)
+        {
+            var joined = string.Join(", ", (addresses ?? Enumerable.Empty<string>())
+                .Where(a => !string.IsNullOrEmpty(a)));
+            return MailContentHelper.TruncateFieldForTsvector(
+                MailContentHelper.CleanText(joined), maxBytes);
+        }
+
+        /// <summary>
+        /// Applies the same subject handling MailImporter applies, including its
+        /// "(No Subject)" substitution for a missing subject.
+        /// <para>
+        /// The substitution is for a <b>null</b> subject only, not for an empty one, because
+        /// MailImporter writes <c>message.Subject ?? "(No Subject)"</c>. A message carrying an
+        /// empty Subject header is stored with an empty subject, so treating empty as missing
+        /// here would make this key disagree with the column for exactly those messages.
+        /// </para>
+        /// </summary>
+        public static string NormalizeSubject(string? subject)
+            => MailContentHelper.TruncateFieldForTsvector(
+                MailContentHelper.CleanText(subject ?? NoSubject),
+                SubjectMaxBytes);
+
+        /// <summary>
+        /// Whether two send times are close enough to be the same message. This is a range
+        /// comparison and cannot be folded into a hash: quantising into two second buckets is
+        /// not equivalent, because two copies one second apart can fall into different buckets,
+        /// in which case the match silently never fires.
+        /// </summary>
+        public static bool WithinTolerance(DateTime a, DateTime b)
+            => Math.Abs((a - b).TotalSeconds) < TimestampToleranceSeconds;
+
+        /// <summary>
+        /// FNV-1a. Chosen over <see cref="string.GetHashCode()"/> because that is randomised
+        /// per process, which would make these keys neither testable nor reproducible.
+        /// </summary>
+        public static long Hash64(string value)
+        {
+            const ulong offsetBasis = 14695981039346656037;
+            const ulong prime = 1099511628211;
+
+            var hash = offsetBasis;
+            foreach (var c in value)
+            {
+                hash ^= (byte)(c & 0xFF);
+                hash *= prime;
+                hash ^= (byte)((c >> 8) & 0xFF);
+                hash *= prime;
+            }
+            return unchecked((long)hash);
+        }
+    }
+}

--- a/Services/Shared/OffloadTargetEligibility.cs
+++ b/Services/Shared/OffloadTargetEligibility.cs
@@ -1,0 +1,85 @@
+// Services/Shared/OffloadTargetEligibility.cs
+using MailArchiver.Models;
+
+namespace MailArchiver.Services.Shared
+{
+    /// <summary>
+    /// Why a mailbox cannot be offloaded into. <see cref="NotFound"/> and
+    /// <see cref="NotAccessible"/> are kept apart so the log can say which one it was, but the
+    /// form deliberately renders the same message for both: telling a user that an account
+    /// exists but is not theirs would let them enumerate account IDs.
+    /// </summary>
+    public enum OffloadTargetRejection
+    {
+        None,
+        SameAsSource,
+        NotFound,
+        NotAccessible,
+        NotImap,
+        Disabled,
+    }
+
+    /// <summary>The facts about a candidate target that decide whether it may be used.</summary>
+    public sealed class OffloadTargetCandidate
+    {
+        public int Id { get; init; }
+        public ProviderType Provider { get; init; }
+        public bool IsEnabled { get; init; }
+
+        /// <summary>
+        /// Whether the acting user may use this account, as resolved by
+        /// <c>IAccountAccessResolver</c>. Passed in rather than computed here so this stays a
+        /// pure decision over facts and can be tested without a database or an HTTP context.
+        /// </summary>
+        public bool IsAccessible { get; init; }
+    }
+
+    /// <summary>
+    /// The single place that decides whether an account may be an offload target. Both the
+    /// target dropdown and the POST that starts a job route their decision through here, so the
+    /// list a user is shown and the list the server will accept cannot drift apart. The list is
+    /// only a convenience; <see cref="Evaluate"/> on the POST is the boundary.
+    /// </summary>
+    public static class OffloadTargetEligibility
+    {
+        /// <summary>
+        /// Applies the scope that <c>IAccountAccessResolver</c> returns: null means admin, i.e.
+        /// every account, and an empty list means no account at all. Fails closed by treating
+        /// anything not in a non-null list as inaccessible.
+        /// </summary>
+        public static bool IsAccessible(int accountId, IReadOnlyCollection<int>? allowedAccountIds)
+            => allowedAccountIds == null || allowedAccountIds.Contains(accountId);
+
+        /// <summary>
+        /// Order matters. Accessibility is decided before the provider and the enabled flag,
+        /// because a message naming either of those about an account the user may not see would
+        /// disclose something about it.
+        /// </summary>
+        public static OffloadTargetRejection Evaluate(OffloadTargetCandidate? target, int sourceAccountId)
+        {
+            if (target == null) return OffloadTargetRejection.NotFound;
+            if (target.Id == sourceAccountId) return OffloadTargetRejection.SameAsSource;
+            if (!target.IsAccessible) return OffloadTargetRejection.NotAccessible;
+            if (target.Provider != ProviderType.IMAP) return OffloadTargetRejection.NotImap;
+            if (!target.IsEnabled) return OffloadTargetRejection.Disabled;
+            return OffloadTargetRejection.None;
+        }
+
+        public static bool IsEligible(OffloadTargetCandidate? target, int sourceAccountId)
+            => Evaluate(target, sourceAccountId) == OffloadTargetRejection.None;
+
+        /// <summary>
+        /// Resource key for the message shown on the form. NotFound and NotAccessible share one
+        /// on purpose; see <see cref="OffloadTargetRejection"/>.
+        /// </summary>
+        public static string MessageKey(OffloadTargetRejection rejection) => rejection switch
+        {
+            OffloadTargetRejection.SameAsSource => "OffloadTargetMustDiffer",
+            OffloadTargetRejection.NotFound => "OffloadTargetNotFound",
+            OffloadTargetRejection.NotAccessible => "OffloadTargetNotFound",
+            OffloadTargetRejection.NotImap => "OffloadTargetMustBeImap",
+            OffloadTargetRejection.Disabled => "OffloadTargetDisabled",
+            _ => throw new ArgumentOutOfRangeException(nameof(rejection), rejection, "No message for an accepted target."),
+        };
+    }
+}

--- a/ViewModels/OffloadViewModel.cs
+++ b/ViewModels/OffloadViewModel.cs
@@ -53,6 +53,12 @@ namespace MailArchiver.Models.ViewModels
         /// <summary>Accounts that can be offloaded into, i.e. enabled IMAP accounts.</summary>
         public List<TargetAccountOption> AvailableTargets { get; set; } = new();
 
+        /// <summary>
+        /// True when the target list was narrowed to the accounts assigned to the acting user, so
+        /// an empty list can explain itself instead of claiming no target exists anywhere.
+        /// </summary>
+        public bool TargetsAreScopedToUser { get; set; }
+
         /// <summary>Configured exclusions, shown read-only so a run is never a surprise.</summary>
         public List<string> ExcludedSourceFolders { get; set; } = new();
 

--- a/ViewModels/OffloadViewModel.cs
+++ b/ViewModels/OffloadViewModel.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MailArchiver.Models.ViewModels
+{
+    /// <summary>
+    /// Form behind the date-windowed offload on the account page. Replaces the plain
+    /// "copy all emails" post, which had no date filter and was therefore all or nothing.
+    /// </summary>
+    public class OffloadViewModel
+    {
+        public int SourceAccountId { get; set; }
+        public string SourceAccountName { get; set; } = string.Empty;
+
+        /// <summary>How much mail the source account holds in total, for context on the form.</summary>
+        public int SourceTotalEmails { get; set; }
+
+        [Display(Name = "TargetAccount")]
+        [Required(ErrorMessage = "OffloadTargetRequired")]
+        public int TargetAccountId { get; set; }
+
+        [Display(Name = "TargetFolder")]
+        public string TargetFolder { get; set; } = "INBOX";
+
+        [Display(Name = "PreserveFolderStructure")]
+        public bool PreserveFolderStructure { get; set; } = true;
+
+        /// <summary>
+        /// A relative window in months, offered because that is how a migration cutoff is
+        /// usually expressed. Zero means "use the explicit date below instead".
+        /// </summary>
+        [Display(Name = "OffloadWindowMonths")]
+        [Range(0, 600)]
+        public int WindowMonths { get; set; } = 12;
+
+        /// <summary>
+        /// Explicit lower bound. Whatever is chosen, the job stores an absolute date, so a
+        /// relative window cannot drift between a run and a repeat of it.
+        /// </summary>
+        [Display(Name = "OffloadCutoffFrom")]
+        [DataType(DataType.Date)]
+        public DateTime? CutoffFrom { get; set; }
+
+        [Display(Name = "OffloadCutoffTo")]
+        [DataType(DataType.Date)]
+        public DateTime? CutoffTo { get; set; }
+
+        [Display(Name = "OffloadDryRun")]
+        public bool DryRun { get; set; } = true;
+
+        [Display(Name = "OffloadMarkAsSeen")]
+        public bool MarkAsSeen { get; set; } = true;
+
+        /// <summary>Accounts that can be offloaded into, i.e. enabled IMAP accounts.</summary>
+        public List<TargetAccountOption> AvailableTargets { get; set; } = new();
+
+        /// <summary>Configured exclusions, shown read-only so a run is never a surprise.</summary>
+        public List<string> ExcludedSourceFolders { get; set; } = new();
+
+        /// <summary>Configured rename map, shown read-only for the same reason.</summary>
+        public Dictionary<string, string> FolderRenameMap { get; set; } = new();
+
+        public class TargetAccountOption
+        {
+            public int Id { get; set; }
+            public string Name { get; set; } = string.Empty;
+            public string EmailAddress { get; set; } = string.Empty;
+        }
+    }
+}

--- a/Views/Emails/BatchRestoreStatus.cshtml
+++ b/Views/Emails/BatchRestoreStatus.cshtml
@@ -1,7 +1,16 @@
 ﻿@inject Microsoft.Extensions.Localization.IStringLocalizer<MailArchiver.SharedResource> Localizer
+@inject MailArchiver.Services.IAuthenticationService AuthService
 @model MailArchiver.Models.BatchRestoreJob
 @{
     ViewData["Title"] = Localizer["BatchRestoreStatusTitle"];
+
+    // The offload report lists the source mailbox's folder names, and this page is not scoped to
+    // the job's owner, so it is only shown to that owner and to an admin. BatchRestoreJob.UserId
+    // is written from User.Identity.Name, which is what GetCurrentUserDisplayName returns.
+    var currentUser = AuthService.GetCurrentUserDisplayName(Context);
+    var mayReadReport = AuthService.IsCurrentUserAdmin(Context)
+        || (!string.IsNullOrEmpty(currentUser)
+            && string.Equals(Model.UserId, currentUser, StringComparison.OrdinalIgnoreCase));
 }
 
 <div class="container">
@@ -163,7 +172,7 @@
                 }
             </dl>
 
-            @if (!string.IsNullOrEmpty(Model.Report))
+            @if (!string.IsNullOrEmpty(Model.Report) && mayReadReport)
             {
                 <h6 class="mt-3">@Localizer["OffloadReport"]</h6>
                 <pre class="bg-light border rounded p-3 mb-0" style="overflow-x: auto; font-size: 0.85rem;">@Model.Report</pre>

--- a/Views/Emails/BatchRestoreStatus.cshtml
+++ b/Views/Emails/BatchRestoreStatus.cshtml
@@ -122,6 +122,35 @@
                         </dd>
                     }
                 }
+                @if (Model.IsOffload)
+                {
+                    <dt class="col-sm-3">@Localizer["OffloadJob"]</dt>
+                    <dd class="col-sm-9">
+                        <span class="badge bg-info text-dark">@Model.Offload!.DescribeWindow()</span>
+                        @if (Model.Offload.DryRun)
+                        {
+                            <span class="badge bg-warning text-dark">@Localizer["OffloadDryRun"]</span>
+                        }
+                    </dd>
+
+                    <dt class="col-sm-3">@Localizer["OffloadAppended"]</dt>
+                    <dd class="col-sm-9">@Model.AppendedCount.ToString("N0")</dd>
+
+                    <dt class="col-sm-3">@Localizer["OffloadAlreadyPresent"]</dt>
+                    <dd class="col-sm-9">
+                        @Model.SkippedAlreadyPresentCount.ToString("N0")
+                        @if (Model.MatchedByFingerprintCount > 0)
+                        {
+                            <small class="text-muted">(@Model.MatchedByFingerprintCount.ToString("N0") @Localizer["OffloadByFingerprint"])</small>
+                        }
+                    </dd>
+
+                    @if (Model.SkippedExcludedFolderCount > 0)
+                    {
+                        <dt class="col-sm-3">@Localizer["OffloadExcluded"]</dt>
+                        <dd class="col-sm-9">@Model.SkippedExcludedFolderCount.ToString("N0")</dd>
+                    }
+                }
                 @if (!string.IsNullOrEmpty(Model.ErrorMessage))
                 {
                     <dt class="col-sm-3">@Localizer["ErrorLabel"]</dt>
@@ -133,6 +162,13 @@
                     </dd>
                 }
             </dl>
+
+            @if (!string.IsNullOrEmpty(Model.Report))
+            {
+                <h6 class="mt-3">@Localizer["OffloadReport"]</h6>
+                <pre class="bg-light border rounded p-3 mb-0" style="overflow-x: auto; font-size: 0.85rem;">@Model.Report</pre>
+            }
+
             @if (Model.Status == BatchRestoreJobStatus.Running || Model.Status == BatchRestoreJobStatus.Queued)
             {
                 <div class="mt-4 pt-3 border-top">

--- a/Views/Emails/Jobs.cshtml
+++ b/Views/Emails/Jobs.cshtml
@@ -872,7 +872,19 @@
                                     <tr>
                                         <td><code>@job.JobId.Substring(0, 8)...</code></td>
                                         <td>@{ var batchStatusClass = job.Status switch { MailArchiver.Models.BatchRestoreJobStatus.Running => "primary", MailArchiver.Models.BatchRestoreJobStatus.Completed => "success", MailArchiver.Models.BatchRestoreJobStatus.Failed => "danger", MailArchiver.Models.BatchRestoreJobStatus.Cancelled => "warning", _ => "secondary" }; }<span class="badge bg-@batchStatusClass">@Localizer[job.Status.ToString()]</span></td>
-                                        <td>@job.EmailIds.Count.ToString("N0")</td>
+                                        <td>
+                                            @job.EmailIds.Count.ToString("N0")
+                                            @if (job.IsOffload)
+                                            {
+                                                <br />
+                                                <span class="badge bg-info text-dark">@Localizer["OffloadJob"]@if (job.Offload!.DryRun){<text> (@Localizer["OffloadDryRun"])</text>}</span>
+                                                <br />
+                                                <small class="text-muted">
+                                                    @Localizer["OffloadAppended"]: @job.AppendedCount.ToString("N0")
+                                                    | @Localizer["OffloadAlreadyPresent"]: @job.SkippedAlreadyPresentCount.ToString("N0")@if (job.MatchedByFingerprintCount > 0){<text> (@job.MatchedByFingerprintCount.ToString("N0") @Localizer["OffloadByFingerprint"])</text>}@if (job.SkippedExcludedFolderCount > 0){<text> | @Localizer["OffloadExcluded"]: @job.SkippedExcludedFolderCount.ToString("N0")</text>}
+                                                </small>
+                                            }
+                                        </td>
                                         <td>@{ var progressPercent = job.EmailIds.Count > 0 ? (job.ProcessedCount * 100.0 / job.EmailIds.Count) : 0; }<div class="progress" style="height: 20px;"><div class="progress-bar @(job.Status == MailArchiver.Models.BatchRestoreJobStatus.Running ? "progress-bar-striped progress-bar-animated" : "")" role="progressbar" style="width: @progressPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%">@progressPercent.ToString("F0")%</div></div></td>
                                         <td><span class="utc-timestamp" data-utc-time="@job.Created.ToString("yyyy-MM-ddTHH:mm:ss")">@job.Created.ToString("g")</span></td>
                                         <td><div class="btn-group btn-group-sm"><a asp-action="BatchRestoreStatus" asp-route-jobId="@job.JobId" class="btn btn-outline-primary btn-sm">@Localizer["Details"]</a>@if (job.Status == MailArchiver.Models.BatchRestoreJobStatus.Running || job.Status == MailArchiver.Models.BatchRestoreJobStatus.Queued){<!-- Button to trigger the modal --><button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#cancelBatchRestoreModal-@job.JobId">@Localizer["CancelJob"]</button>}</div></td>

--- a/Views/MailAccounts/Details.cshtml
+++ b/Views/MailAccounts/Details.cshtml
@@ -267,6 +267,17 @@
             </div>
 
             <div class="d-flex flex-wrap gap-2 mb-3">
+                @if (isAdmin)
+                {
+                    @* First and solid, ahead of "copy all", because it is the safer of the two: it
+                       takes a date window, honours folder exclusions and the rename map, skips
+                       what the target already holds, and can be dry run. "Copy all" is all or
+                       nothing and starts on click, so it should not be what the eye lands on
+                       first. *@
+                    <a asp-action="Offload" asp-route-id="@Model.Id" class="btn btn-success">
+                        <i class="bi bi-box-arrow-right"></i> @Localizer["OffloadTitle"]
+                    </a>
+                }
                 <form asp-action="MoveAllEmails" asp-route-id="@Model.Id" method="post" style="display: inline;">
                     @Html.AntiForgeryToken()
                     <button type="submit" class="btn btn-outline-success">

--- a/Views/MailAccounts/Details.cshtml
+++ b/Views/MailAccounts/Details.cshtml
@@ -267,17 +267,15 @@
             </div>
 
             <div class="d-flex flex-wrap gap-2 mb-3">
-                @if (isAdmin)
-                {
-                    @* First and solid, ahead of "copy all", because it is the safer of the two: it
-                       takes a date window, honours folder exclusions and the rename map, skips
-                       what the target already holds, and can be dry run. "Copy all" is all or
-                       nothing and starts on click, so it should not be what the eye lands on
-                       first. *@
-                    <a asp-action="Offload" asp-route-id="@Model.Id" class="btn btn-success">
-                        <i class="bi bi-box-arrow-right"></i> @Localizer["OffloadTitle"]
-                    </a>
-                }
+                @* First and solid, ahead of "copy all", because it is the safer of the two: it
+                   takes a date window, honours folder exclusions and the rename map, skips what
+                   the target already holds, and can be dry run. "Copy all" is all or nothing and
+                   starts on click, so it should not be what the eye lands on first. No role check
+                   here: this page is only reachable for an account the user is assigned to, and
+                   the target list is scoped the same way. *@
+                <a asp-action="Offload" asp-route-id="@Model.Id" class="btn btn-success">
+                    <i class="bi bi-box-arrow-right"></i> @Localizer["OffloadTitle"]
+                </a>
                 <form asp-action="MoveAllEmails" asp-route-id="@Model.Id" method="post" style="display: inline;">
                     @Html.AntiForgeryToken()
                     <button type="submit" class="btn btn-outline-success">

--- a/Views/MailAccounts/Offload.cshtml
+++ b/Views/MailAccounts/Offload.cshtml
@@ -1,0 +1,181 @@
+@using MailArchiver.Models.ViewModels
+@inject Microsoft.Extensions.Localization.IStringLocalizer<MailArchiver.SharedResource> Localizer
+@model MailArchiver.Models.ViewModels.OffloadViewModel
+@{
+    ViewData["Title"] = Localizer["OffloadTitle"];
+}
+
+<div class="container-fluid">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="mb-0"><i class="bi bi-box-arrow-right me-2"></i>@Localizer["OffloadTitle"]</h2>
+        <a asp-action="Details" asp-route-id="@Model.SourceAccountId" class="btn btn-outline-secondary">
+            <i class="bi bi-arrow-left"></i> @Localizer["Back"]
+        </a>
+    </div>
+
+    <p class="text-muted">@Localizer["OffloadIntro"]</p>
+
+    @if (!Model.AvailableTargets.Any())
+    {
+        <div class="alert alert-warning">
+            <i class="bi bi-exclamation-triangle me-2"></i>@Localizer["OffloadNoTargets"]
+        </div>
+    }
+    else
+    {
+        <form asp-action="Offload" asp-route-id="@Model.SourceAccountId" method="post">
+            @Html.AntiForgeryToken()
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+            <div class="row">
+                <div class="col-lg-7">
+                    <div class="card mb-3">
+                        <div class="card-header">
+                            <span class="h6 mb-0">@Localizer["OffloadSourceAndTarget"]</span>
+                        </div>
+                        <div class="card-body">
+                            <div class="mb-3">
+                                <label class="form-label">@Localizer["SourceAccount"]</label>
+                                <input type="text" class="form-control" readonly
+                                       value="@Model.SourceAccountName (@Model.SourceTotalEmails.ToString("N0") @Localizer["EmailsLabel"])" />
+                            </div>
+
+                            <div class="mb-3">
+                                <label asp-for="TargetAccountId" class="form-label">@Localizer["TargetAccount"]</label>
+                                <select asp-for="TargetAccountId" class="form-select">
+                                    <option value="">@Localizer["OffloadSelectTarget"]</option>
+                                    @foreach (var target in Model.AvailableTargets)
+                                    {
+                                        <option value="@target.Id">@target.Name (@target.EmailAddress)</option>
+                                    }
+                                </select>
+                                <span asp-validation-for="TargetAccountId" class="text-danger"></span>
+                            </div>
+
+                            <div class="mb-3">
+                                <label asp-for="TargetFolder" class="form-label">@Localizer["TargetFolder"]</label>
+                                <input asp-for="TargetFolder" class="form-control" />
+                                <div class="form-text">@Localizer["OffloadTargetFolderHelp"]</div>
+                            </div>
+
+                            <div class="form-check">
+                                <input asp-for="PreserveFolderStructure" class="form-check-input" />
+                                <label asp-for="PreserveFolderStructure" class="form-check-label">
+                                    @Localizer["PreserveFolderStructure"]
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card mb-3">
+                        <div class="card-header">
+                            <span class="h6 mb-0">@Localizer["OffloadWindow"]</span>
+                        </div>
+                        <div class="card-body">
+                            <div class="mb-3">
+                                <label asp-for="WindowMonths" class="form-label">@Localizer["OffloadWindowMonths"]</label>
+                                <input asp-for="WindowMonths" type="number" min="0" max="600" class="form-control" />
+                                <div class="form-text">@Localizer["OffloadWindowMonthsHelp"]</div>
+                                <span asp-validation-for="WindowMonths" class="text-danger"></span>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label asp-for="CutoffFrom" class="form-label">@Localizer["OffloadCutoffFrom"]</label>
+                                    <input asp-for="CutoffFrom" type="date" class="form-control" />
+                                    <div class="form-text">@Localizer["OffloadCutoffFromHelp"]</div>
+                                    <span asp-validation-for="CutoffFrom" class="text-danger"></span>
+                                </div>
+                                <div class="col-md-6 mb-3">
+                                    <label asp-for="CutoffTo" class="form-label">@Localizer["OffloadCutoffTo"]</label>
+                                    <input asp-for="CutoffTo" type="date" class="form-control" />
+                                    <div class="form-text">@Localizer["OffloadCutoffToHelp"]</div>
+                                    <span asp-validation-for="CutoffTo" class="text-danger"></span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-lg-5">
+                    <div class="card mb-3">
+                        <div class="card-header">
+                            <span class="h6 mb-0">@Localizer["OffloadOptions"]</span>
+                        </div>
+                        <div class="card-body">
+                            <div class="form-check mb-3">
+                                <input asp-for="DryRun" class="form-check-input" />
+                                <label asp-for="DryRun" class="form-check-label">@Localizer["OffloadDryRun"]</label>
+                                <div class="form-text">@Localizer["OffloadDryRunHelp"]</div>
+                            </div>
+
+                            <div class="form-check">
+                                <input asp-for="MarkAsSeen" class="form-check-input" />
+                                <label asp-for="MarkAsSeen" class="form-check-label">@Localizer["OffloadMarkAsSeen"]</label>
+                                <div class="form-text">@Localizer["OffloadMarkAsSeenHelp"]</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    @* Shown read-only: a run that silently dropped or renamed folders would be a
+                       nasty surprise, so whatever is configured is visible where the button is. *@
+                    <div class="card mb-3">
+                        <div class="card-header">
+                            <span class="h6 mb-0">@Localizer["OffloadFolderHandling"]</span>
+                        </div>
+                        <div class="card-body">
+                            <div class="mb-3">
+                                <label class="form-label">@Localizer["OffloadExcludedFolders"]</label>
+                                @if (Model.ExcludedSourceFolders.Any())
+                                {
+                                    <ul class="list-unstyled mb-0">
+                                        @foreach (var folder in Model.ExcludedSourceFolders)
+                                        {
+                                            <li><code>@folder</code></li>
+                                        }
+                                    </ul>
+                                }
+                                else
+                                {
+                                    <p class="text-muted mb-0"><em>@Localizer["OffloadNoneConfigured"]</em></p>
+                                }
+                            </div>
+
+                            <div>
+                                <label class="form-label">@Localizer["OffloadRenameMap"]</label>
+                                @if (Model.FolderRenameMap.Any())
+                                {
+                                    <ul class="list-unstyled mb-0">
+                                        @foreach (var entry in Model.FolderRenameMap)
+                                        {
+                                            <li><code>@entry.Key</code> &rarr; <code>@entry.Value</code></li>
+                                        }
+                                    </ul>
+                                }
+                                else
+                                {
+                                    <p class="text-muted mb-0"><em>@Localizer["OffloadNoneConfigured"]</em></p>
+                                }
+                            </div>
+
+                            <div class="form-text mt-2">@Localizer["OffloadFolderHandlingHelp"]</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="d-flex gap-2 mb-4">
+                <button type="submit" class="btn btn-success">
+                    <i class="bi bi-box-arrow-right"></i> @Localizer["OffloadStart"]
+                </button>
+                <a asp-action="Details" asp-route-id="@Model.SourceAccountId" class="btn btn-outline-secondary">
+                    @Localizer["Cancel"]
+                </a>
+            </div>
+        </form>
+    }
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Views/MailAccounts/Offload.cshtml
+++ b/Views/MailAccounts/Offload.cshtml
@@ -18,7 +18,9 @@
     @if (!Model.AvailableTargets.Any())
     {
         <div class="alert alert-warning">
-            <i class="bi bi-exclamation-triangle me-2"></i>@Localizer["OffloadNoTargets"]
+            <i class="bi bi-exclamation-triangle me-2"></i>@(Model.TargetsAreScopedToUser
+                ? Localizer["OffloadNoTargetsAssigned"]
+                : Localizer["OffloadNoTargets"])
         </div>
     }
     else

--- a/Views/MailAccounts/Offload.cshtml
+++ b/Views/MailAccounts/Offload.cshtml
@@ -56,7 +56,9 @@
 
                             <div class="mb-3">
                                 <label asp-for="TargetFolder" class="form-label">@Localizer["TargetFolder"]</label>
-                                <input asp-for="TargetFolder" class="form-control" />
+                                <select asp-for="TargetFolder" class="form-select" id="folderSelect">
+                                    <option value="">@Localizer["OffloadSelectTargetFirst"]</option>
+                                </select>
                                 <div class="form-text">@Localizer["OffloadTargetFolderHelp"]</div>
                             </div>
 
@@ -180,4 +182,52 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script>
+        $(document).ready(function () {
+            var preselectedFolder = @Json.Serialize(Model.TargetFolder ?? "");
+            var isInitialLoad = true;
+            const i18n = {
+                loadingFolders: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["OffloadLoadingFolders"].Value)),
+                selectFolder: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["OffloadSelectFolder"].Value)),
+                errorLoadingFolders: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["OffloadErrorLoadingFolders"].Value)),
+                selectTargetFirst: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["OffloadSelectTargetFirst"].Value))
+            };
+            $('#TargetAccountId').change(function () {
+                var selectPreselected = isInitialLoad;
+                isInitialLoad = false;
+                var accountId = $(this).val();
+                var $select = $('#folderSelect');
+                if (accountId) {
+                    $select.html($('<option>').text(i18n.loadingFolders));
+                    $.ajax({
+                        url: '@Url.Action("GetFolders", "MailAccounts")',
+                        data: { accountId: accountId },
+                        type: 'GET',
+                        dataType: 'json',
+                        success: function (data) {
+                            $select.empty();
+                            $select.append($('<option>').val('').text(i18n.selectFolder));
+                            var inboxFound = false;
+                            $.each(data, function (index, folderName) {
+                                $select.append($('<option>').val(folderName).text(folderName));
+                                if (folderName.toUpperCase() === 'INBOX') { inboxFound = true; }
+                            });
+                            var target = (selectPreselected && preselectedFolder) ? preselectedFolder : null;
+                            var matched = target ? $("#folderSelect option").filter(function () { return this.value.toUpperCase() === target.toUpperCase(); }).first() : $();
+                            if (matched.length) { matched.prop('selected', true); }
+                            else if (inboxFound) { $("#folderSelect option").filter(function () { return this.value.toUpperCase() === 'INBOX'; }).prop('selected', true); }
+                        },
+                        error: function () {
+                            $select.empty()
+                                .append($('<option>').val('').text(i18n.errorLoadingFolders))
+                                .append($('<option>').val('INBOX').text('INBOX'));
+                        }
+                    });
+                } else {
+                    $select.empty().append($('<option>').val('').text(i18n.selectTargetFirst));
+                }
+            });
+            if ($('#TargetAccountId').val()) { $('#TargetAccountId').trigger('change'); }
+        });
+    </script>
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -74,6 +74,13 @@
     "PauseBetweenEmailsMs": 50,
     "PauseBetweenBatchesMs": 200
   },
+  "Offload": {
+    "MaxConcurrentJobs": 1,
+    "PrefetchMaxMessages": 500000,
+    "ExcludedSourceFolders": [],
+    "FolderRenameMap": {},
+    "MarkAsSeen": true
+  },
   "BandwidthTracking": {
     "Enabled": false,
     "DailyLimitMb": 25000,
@@ -102,7 +109,6 @@
     "BackfillDelayMs": 5000,
     "RefreshBatchDelayMs": 1000
   },
-
   "Upload": {
     "MaxFileSizeGB": 10,
     "KeepAliveTimeoutHours": 4,
@@ -110,7 +116,9 @@
     "Notes": "Optimized for large file uploads up to 10GB"
   },
   "LocalImport": {
-    "AllowedPaths": ["/app/imports"]
+    "AllowedPaths": [
+      "/app/imports"
+    ]
   },
   "MsaOAuth": {
     "DefaultClientId": "d0c86bbc-b89f-4539-a024-93a425ade844",

--- a/doc/Index.md
+++ b/doc/Index.md
@@ -32,6 +32,7 @@ Mail Archiver is a comprehensive application designed to archive emails from var
 - [Retention Policies](RetentionPolicies.md)
 - [Reverse Proxy Configuration](ReverseProxy.md)
 - [User Management and Mailbox Permissions](UserManagement.md)
+- [Date-Windowed Offload](Offload.md)
 - [Using Development Versions (Dev Tag)](DevTag.md)
 
 ### ☁️ Provider Specific Guides

--- a/doc/MailboxMigration.md
+++ b/doc/MailboxMigration.md
@@ -8,6 +8,8 @@ This guide explains how to migrate a mailbox from one email provider to another 
 
 The Mail Archiver application provides functionality to migrate emails from a source mailbox to a target mailbox. This is particularly useful when changing email providers while preserving your email history. The folder structure of the source mailbox is also preserved during migration.
 
+> **Migrating only recent mail?** The flow described below copies the *whole* archived mailbox, and running it twice appends everything a second time. If the new mailbox should hold only mail newer than a cutoff while the full history stays in the archive, use the [date-windowed offload](Offload.md) instead. It takes a date window, can exclude and rename folders, offers a dry run, and is safe to repeat because it skips whatever the target already holds. It is also driveable from the command line, which makes a fleet of mailboxes scriptable.
+
 ## 🚀 Migration Process
 
 Follow these steps to migrate your mailbox:
@@ -52,6 +54,7 @@ Follow these steps to migrate your mailbox:
 
 ## ⚠️ Important Notes
 
+- This flow is not repeatable: running it again appends every message a second time. The [date-windowed offload](Offload.md) is the repeatable alternative.
 - Ensure that the source account has sufficient permissions to read all emails
 - Make sure that the target account has sufficient storage space for the migrated emails
 - The migration process may take some time depending on the number of emails and the connection speed

--- a/doc/Offload.md
+++ b/doc/Offload.md
@@ -104,16 +104,30 @@ covers the whole target mailbox rather than one resolved folder.
 
 ## 🖥️ Running it from the interface
 
-Admin only. On an account's detail page, **Offload to Another Mailbox** opens a form with the
-target mailbox, the target root folder, whether to preserve the folder structure, the date
-window, a dry run switch, and whether to mark appended mail as read. The configured exclusions
-and rename map are shown read-only, so a run is never a surprise.
+On an account's detail page, **Offload to Another Mailbox** opens a form with the target mailbox,
+the target root folder, whether to preserve the folder structure, the date window, a dry run
+switch, and whether to mark appended mail as read. The configured exclusions and rename map are
+shown read-only, so a run is never a surprise.
 
 The job is queued and its progress and per-folder report appear on the job status page and under
-**Jobs**.
+**Jobs**. The per-folder report names source folders, so it is shown only to the user who started
+the job and to administrators.
 
 The target mailbox must be an enabled IMAP account. Microsoft 365 accounts cannot be offload
 targets; the Graph restore path is unchanged.
+
+### Who may run it
+
+Administrators can offload between any two accounts. A self-manager can offload **only between
+the accounts assigned to them**, at both ends: the source, because the account page is already
+scoped that way, and the target, because the target list is narrowed to the same set and the
+request is checked against it again when the job is started. A self-manager with a single
+assigned account therefore has no eligible target and is told so.
+
+Scoping comes from `IAccountAccessResolver`, the same resolver the REST API and the MCP server
+use, so there is one definition of who may use which mailbox. The decision itself lives in
+`OffloadTargetEligibility`, which both the target list and the request check call, so what the
+form offers and what the server accepts cannot drift apart.
 
 ## ⌨️ Running it from the command line
 

--- a/doc/Offload.md
+++ b/doc/Offload.md
@@ -1,0 +1,209 @@
+# 📤 Date-Windowed Offload
+
+[← Back to Documentation Index](Index.md)
+
+## 📋 Overview
+
+An offload appends archived mail newer than a cutoff into another mailbox, and leaves everything
+older in the archive. It exists for migrations where the new mailbox should hold only recent mail
+while the full history stays reachable through Mail Archiver.
+
+It differs from [Copy All Emails to Another Mailbox](MailboxMigration.md) in five ways:
+
+| | Copy All Emails | Offload |
+|---|---|---|
+| Date filter | none, all or nothing | cutoff, with an optional upper bound |
+| Repeatable | no, appends everything again | yes, skips what the target already holds |
+| Folder exclusions | no | yes, configurable |
+| Folder renaming | no | yes, configurable |
+| Preview | no | dry run reports per folder without writing |
+
+The offload only ever appends to the target. It never deletes from the archive and never touches
+the source mailbox.
+
+## 🔁 Repeating a run is safe
+
+Before the first append, the whole target mailbox is indexed and every message is checked against
+it. A repeated run therefore appends nothing that already arrived, and reports it as already
+present instead. That has three practical consequences:
+
+- An interrupted run is recovered by simply running it again.
+- A finished run can be repeated as a verification pass. A correct result is nothing appended and
+  everything already present.
+- Messages deleted on the target come back on the next run, because they are no longer in the
+  index.
+
+Two criteria decide whether a message is already present, in this order:
+
+1. **Message-ID**, normalised. This does nearly all of the work.
+2. **A fingerprint** over sender, recipients, subject and send time within two seconds. This
+   covers the messages whose stored Message-ID is missing or malformed. Such messages cannot be
+   restored with their original Message-ID at all, so without this second criterion they would
+   duplicate on every single run.
+
+The job reports how many matches came from the fingerprint separately, because it is the
+criterion that could fail quietly.
+
+## ⚙️ Configuration
+
+A new `Offload` section, with defaults that reproduce the previous behaviour:
+
+```json
+"Offload": {
+  "MaxConcurrentJobs": 1,
+  "PrefetchMaxMessages": 500000,
+  "ExcludedSourceFolders": [],
+  "FolderRenameMap": {},
+  "MarkAsSeen": true
+}
+```
+
+| Key | Default | Purpose |
+|---|---|---|
+| `MaxConcurrentJobs` | `1` | How many restore or offload jobs may run at once. One keeps the strictly serial behaviour the job queue always had. At most one job per target mailbox runs regardless of this value. |
+| `PrefetchMaxMessages` | `500000` | Upper bound on how many messages are indexed from a target mailbox. Above it the duplicate check narrows to a single folder and logs that it did. |
+| `ExcludedSourceFolders` | empty | Source folders never offloaded. Matched before renaming, and covering subfolders. |
+| `FolderRenameMap` | empty | Rewrites the leading segments of a source folder path. |
+| `MarkAsSeen` | `true` | Whether appended mail is flagged as read. |
+
+Both folder settings ship empty on purpose. Rewriting or dropping folders without being asked
+would surprise anyone already using the restore path, so a run with no configuration migrates
+everything, spam folders included, and creates a second set of special folders next to the
+target's own.
+
+### Folder exclusions and renaming
+
+For an Exchange to Dovecot migration the two settings usually look like this:
+
+```json
+"ExcludedSourceFolders": ["Junk E-Mail", "Deleted Items"],
+"FolderRenameMap": {
+  "Sent Items": "Sent",
+  "Deleted Items": "Trash",
+  "Junk E-Mail": "Junk"
+}
+```
+
+Without the rename map every migrated mailbox ends up with both `Sent` and `Sent Items`, because
+Dovecot pre-creates its own special-use folders.
+
+Four things about how these are applied are worth knowing, because each one is a way to be
+surprised:
+
+1. **Exclusions are matched first**, against the source name. If renaming happened first, an
+   exclusion on `Deleted Items` would never fire once it had already become `Trash`.
+2. **Renaming rewrites the longest matching path prefix**, on segment boundaries. `Sent Items`
+   becoming `Sent` also turns `Sent Items/2019` into `Sent/2019`, and leaves
+   `Sent Items Archive` alone.
+3. **Matching is case insensitive**, and both `/` and `\` count as separators.
+4. **Two source folders may collapse onto one target.** `Sent Items` and `Sent` both becoming
+   `Sent` is fine and does not open the target folder twice.
+
+Changing the rename map between two runs does not duplicate anything, because the duplicate check
+covers the whole target mailbox rather than one resolved folder.
+
+## 🖥️ Running it from the interface
+
+Admin only. On an account's detail page, **Offload to Another Mailbox** opens a form with the
+target mailbox, the target root folder, whether to preserve the folder structure, the date
+window, a dry run switch, and whether to mark appended mail as read. The configured exclusions
+and rename map are shown read-only, so a run is never a surprise.
+
+The job is queued and its progress and per-folder report appear on the job status page and under
+**Jobs**.
+
+The target mailbox must be an enabled IMAP account. Microsoft 365 accounts cannot be offload
+targets; the Graph restore path is unchanged.
+
+## ⌨️ Running it from the command line
+
+```bash
+docker compose exec mailarchive-app dotnet MailArchiver.dll \
+  --offload --source-account-id 3 --target-account-id 7 \
+  --since 2025-08-01 \
+  [--until 2026-08-01] [--target-folder INBOX] \
+  [--preserve-folders] [--dry-run] [--no-mark-seen]
+```
+
+| Argument | Meaning |
+|---|---|
+| `--source-account-id` | Account to read archived mail from. Required. |
+| `--target-account-id` | Enabled IMAP account to append into. Required, and must differ from the source. |
+| `--since` | Inclusive lower bound on the send date, `YYYY-MM-DD`. Required. |
+| `--until` | Optional inclusive upper bound. |
+| `--target-folder` | Root folder in the target mailbox. Defaults to `INBOX`. |
+| `--preserve-folders` | Recreate the source folder structure below the root. |
+| `--dry-run` | Report what would happen, append nothing. |
+| `--no-mark-seen` | Append without the Seen flag. |
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | Everything was appended or already present. |
+| `1` | At least one message failed, or the run itself failed. |
+| `2` | The invocation was wrong: bad or missing arguments, unknown account, target not IMAP, target disabled, source equal to target. |
+
+One invocation handles one mailbox, which makes a fleet of mailboxes scriptable from a CSV of
+source, target and cutoff.
+
+> **Running several at once.** The one-job-per-target rule only exists inside a single process,
+> so two concurrent command line invocations against the *same* target mailbox could each take
+> their duplicate index before the other starts writing, and could then both append the same
+> mail. Partition the work so that every concurrent invocation has a different target, which is
+> the normal case when each row of a CSV is a different mailbox.
+
+## 🗓️ How the cutoff is interpreted
+
+- The filter is on **the send date**, not on when a message was archived. The archived-at
+  timestamp is the time of the archiving run and carries no meaning for a cutoff.
+- A relative window such as "the last twelve months" is **resolved to a fixed date when the job
+  is created**. A job may run for a long time and be repeated afterwards, and it has to select
+  the same mail every time; a stored relative window would drift.
+- Cutoffs are interpreted in the **configured display timezone**, the same one the search screen
+  shows, and the lower bound is inclusive from 00:00 of that day. An upper bound includes the
+  whole of its day.
+
+## 📋 A migration, end to end
+
+1. Create the target mailboxes. For many at once see the CSV bulk import in
+   [Account Import](Account%20Import.md).
+2. Configure `Offload:ExcludedSourceFolders` and `Offload:FolderRenameMap`. Both are empty by
+   default, so skipping this migrates spam folders and creates duplicated special folders.
+3. Confirm each source mailbox is fully archived before offloading it.
+4. **Dry run everything.** Check the counts and the resolved target folder names before anything
+   is written.
+5. Real run. Start with `MaxConcurrentJobs` at 2 and raise it only after watching how the target
+   server copes; Dovecot limits concurrent connections per user and per IP.
+6. Repeat the run to verify. Expect nothing appended and everything already present.
+7. Disable the source accounts.
+
+Throughput is capped by `BatchOperation:PauseBetweenEmailsMs`, which is 50 ms by default and so
+allows at most twenty appends per second before server latency is counted.
+
+## 🔍 What the counters mean
+
+| Counter | Meaning |
+|---|---|
+| Appended | Written to the target. On a dry run, what would have been written. |
+| Already present | The target already held it, by either criterion. |
+| of those by fingerprint | How many were recognised by the second criterion rather than by Message-ID. |
+| Excluded folder | Skipped because the source folder is excluded. |
+| Failed | Could not be appended. |
+
+A warning is reported if the duplicate index did not cover the whole target mailbox, which
+happens above `PrefetchMaxMessages` or when a folder could not be read. In that state a repeated
+run may append mail that is already present in the parts that were not indexed.
+
+## ⚠️ Notes and limits
+
+- Restored mail now carries its **original delivery time** as the IMAP internal date, taken from
+  the message's `Received` chain and falling back to the send date. It previously carried the
+  time of the archiving run, which broke server side sorting by arrival and any age based rule on
+  the target.
+- Because a repeated run skips what is already present, a wrong internal date cannot be corrected
+  by re-running: the messages are recognised and skipped. Get this right before a production run,
+  or delete the affected messages on the target and run again.
+- Microsoft 365 is not supported as an offload target.
+- Duplicate detection can only recognise what it can see in the target mailbox. Mail that reached
+  the target by some other route is caught only insofar as the two criteria happen to match it.

--- a/doc/Setup.md
+++ b/doc/Setup.md
@@ -277,6 +277,16 @@ The optional MCP (Model Context Protocol) server exposes the same read-only mail
 - `BatchOperation__PauseBetweenEmailsMs`: The pause between individual emails in milliseconds.
 - `BatchOperation__PauseBetweenBatchesMs`: The pause between batches in milliseconds.
 
+### 📤 Offload Settings
+Settings for the [date-windowed offload](Offload.md). All defaults reproduce the behaviour the application had before the feature existed, so an installation that does not configure this section is unaffected.
+- `Offload__MaxConcurrentJobs`: How many restore or offload jobs may run at the same time. Default is `1`, which keeps the strictly serial processing the job queue has always used. At most one job per target mailbox runs regardless of this value.
+- `Offload__PrefetchMaxMessages`: Upper bound on how many messages are indexed from a target mailbox for duplicate detection. Default is `500000`. Above it the check narrows to a single folder and logs that the scope was reduced.
+- `Offload__ExcludedSourceFolders__0`, `__1`, ...: Source folders that are never offloaded, matched before renaming and covering subfolders. Empty by default.
+- `Offload__FolderRenameMap__<SourceFolder>`: Rewrites the leading segments of a source folder path, for example `Offload__FolderRenameMap__Sent Items=Sent`. Empty by default.
+- `Offload__MarkAsSeen`: Whether appended mail is flagged as read. Default is `true`, matching the existing restore behaviour.
+
+Both folder settings ship empty on purpose: rewriting or dropping folders without being asked would surprise anyone already using the restore path. A run with no configuration therefore migrates everything, spam folders included, and creates a second set of special folders next to the target's own.
+
 ### 📊 Bandwidth Tracking Settings
 - `BandwidthTracking__Enabled`: Enable or disable bandwidth tracking for IMAP rate limit handling (true/false). Default is `false`. When enabled, the system tracks bandwidth usage per account and can pause synchronization when provider limits are reached. See [Rate Limit Handling](RateLimitHandling.md) for detailed information.
 - `BandwidthTracking__DailyLimitMb`: Daily download limit in megabytes per account. Default is `25000` (25 GB). For providers with bandwidth limits, set this to match their rate limit (e.g., `2500` for providers with ~2500 MB daily limits). The system will pause syncing when this limit is reached.

--- a/tests/MailArchiver.Tests/Infrastructure/ServiceFactory.cs
+++ b/tests/MailArchiver.Tests/Infrastructure/ServiceFactory.cs
@@ -40,6 +40,19 @@ internal static class ServiceFactory
             NullLogger<AccountStorageService>.Instance,
             new ConfigurationBuilder().Build());
 
+    public static MailArchiver.Services.Providers.Imap.ImapMailRestorer CreateImapMailRestorer(
+        MailArchiverDbContext ctx,
+        BatchOperationOptions? batchOptions = null,
+        OffloadOptions? offloadOptions = null) =>
+        new(ctx,
+            NullLogger<MailArchiver.Services.Providers.Imap.ImapMailRestorer>.Instance,
+            // OffloadEmailsAsync fails before opening a connection for an unreachable target,
+            // so the connection factory is never exercised by these tests.
+            connectionFactory: null!,
+            new DateTimeHelper(Options.Create(new TimeZoneOptions { DisplayTimeZoneId = "Europe/Berlin" })),
+            Options.Create(batchOptions ?? new BatchOperationOptions()),
+            Options.Create(offloadOptions ?? new OffloadOptions()));
+
     /// <summary>
     /// Builds a <see cref="ServiceProvider"/> that resolves the shared
     /// <see cref="MailArchiverDbContext"/> from every scope, so services that call

--- a/tests/MailArchiver.Tests/Services/FolderMapperTests.cs
+++ b/tests/MailArchiver.Tests/Services/FolderMapperTests.cs
@@ -1,0 +1,169 @@
+using MailArchiver.Services.Shared;
+
+namespace MailArchiver.Tests.Services;
+
+/// <summary>
+/// Each case here is a way to get the folder pipeline wrong. The order of the three steps
+/// (exclude, rename, resolve) is load bearing, and the rename is a segment-boundary prefix
+/// rewrite rather than a string match.
+/// </summary>
+public class FolderMapperTests
+{
+    private static readonly Dictionary<string, string> SentMap =
+        new() { ["Sent Items"] = "Sent" };
+
+    // ------------------------------------------------------------------ rename
+
+    [Fact]
+    public void ApplyRenameMap_ExactMatch_IsRewritten()
+    {
+        Assert.Equal("Sent", FolderMapper.ApplyRenameMap("Sent Items", SentMap));
+    }
+
+    [Fact]
+    public void ApplyRenameMap_Subfolder_RewritesOnlyThePrefix()
+    {
+        // A whole-string match would leave this untouched and produce a second sent tree.
+        Assert.Equal("Sent/2019", FolderMapper.ApplyRenameMap("Sent Items/2019", SentMap));
+    }
+
+    [Fact]
+    public void ApplyRenameMap_SubstringButNotSegmentBoundary_IsUntouched()
+    {
+        // "Sent Items Archive" starts with "Sent Items" as a substring but is a different folder.
+        Assert.Equal("Sent Items Archive",
+            FolderMapper.ApplyRenameMap("Sent Items Archive", SentMap));
+    }
+
+    [Fact]
+    public void ApplyRenameMap_IsCaseInsensitive()
+    {
+        Assert.Equal("Sent/2019", FolderMapper.ApplyRenameMap("sent items/2019", SentMap));
+    }
+
+    [Fact]
+    public void ApplyRenameMap_BackslashSeparator_IsSplitLikeForwardSlash()
+    {
+        Assert.Equal("Sent/2019", FolderMapper.ApplyRenameMap(@"Sent Items\2019", SentMap));
+    }
+
+    [Fact]
+    public void ApplyRenameMap_LongestMatchingPrefixWins()
+    {
+        var map = new Dictionary<string, string>
+        {
+            ["Sent Items"] = "Sent",
+            ["Sent Items/2019"] = "Archive/2019",
+        };
+        Assert.Equal("Archive/2019", FolderMapper.ApplyRenameMap("Sent Items/2019", map));
+        Assert.Equal("Sent", FolderMapper.ApplyRenameMap("Sent Items", map));
+    }
+
+    [Fact]
+    public void ApplyRenameMap_EmptyMap_IsIdentity()
+    {
+        Assert.Equal("Sent Items/2019",
+            FolderMapper.ApplyRenameMap("Sent Items/2019", new Dictionary<string, string>()));
+        Assert.Equal("Sent Items/2019", FolderMapper.ApplyRenameMap("Sent Items/2019", null));
+    }
+
+    [Fact]
+    public void ApplyRenameMap_TwoSourcesOntoOneTarget_ResolveIdentically()
+    {
+        var map = new Dictionary<string, string>
+        {
+            ["Sent Items"] = "Sent",
+            ["Gesendete Elemente"] = "Sent",
+        };
+        Assert.Equal(FolderMapper.ApplyRenameMap("Sent Items", map),
+                     FolderMapper.ApplyRenameMap("Gesendete Elemente", map));
+    }
+
+    // ------------------------------------------------------------------ exclusion
+
+    [Fact]
+    public void IsExcluded_ExactMatch()
+    {
+        Assert.True(FolderMapper.IsExcluded("Deleted Items", new[] { "Deleted Items" }));
+    }
+
+    [Fact]
+    public void IsExcluded_CoversDescendants()
+    {
+        Assert.True(FolderMapper.IsExcluded("Deleted Items/Old", new[] { "Deleted Items" }));
+    }
+
+    [Fact]
+    public void IsExcluded_DoesNotMatchOnSubstring()
+    {
+        Assert.False(FolderMapper.IsExcluded("Deleted Items Archive", new[] { "Deleted Items" }));
+    }
+
+    [Fact]
+    public void IsExcluded_IsCaseInsensitive()
+    {
+        Assert.True(FolderMapper.IsExcluded("deleted items/old", new[] { "Deleted Items" }));
+    }
+
+    [Fact]
+    public void IsExcluded_EmptyExclusions_IsNeverExcluded()
+    {
+        Assert.False(FolderMapper.IsExcluded("Deleted Items", Array.Empty<string>()));
+        Assert.False(FolderMapper.IsExcluded("Deleted Items", null));
+    }
+
+    // ------------------------------------------------------------------ target path
+
+    [Fact]
+    public void ResolveTargetPath_InboxRoot_UsesRenamedPathAsIs()
+    {
+        Assert.Equal("Sent/2019", FolderMapper.ResolveTargetPath("Sent/2019", "INBOX", true));
+    }
+
+    [Fact]
+    public void ResolveTargetPath_OtherRoot_NestsBelowIt()
+    {
+        Assert.Equal("Archive/Sent/2019",
+            FolderMapper.ResolveTargetPath("Sent/2019", "Archive", true));
+    }
+
+    [Fact]
+    public void ResolveTargetPath_WithoutStructurePreservation_EverythingLandsInTheRoot()
+    {
+        Assert.Equal("Archive", FolderMapper.ResolveTargetPath("Sent/2019", "Archive", false));
+        Assert.Equal("INBOX", FolderMapper.ResolveTargetPath("Sent/2019", "INBOX", false));
+    }
+
+    // ------------------------------------------------------------------ full pipeline
+
+    [Fact]
+    public void Resolve_ExclusionIsEvaluatedBeforeRename()
+    {
+        // If the rename ran first, "Deleted Items" would already be "Trash" and an exclusion
+        // keyed on the source name would never fire.
+        var map = new Dictionary<string, string> { ["Deleted Items"] = "Trash" };
+        var excluded = new[] { "Deleted Items" };
+
+        Assert.Null(FolderMapper.Resolve("Deleted Items", "INBOX", true, excluded, map));
+        Assert.Null(FolderMapper.Resolve("Deleted Items/Old", "INBOX", true, excluded, map));
+    }
+
+    [Fact]
+    public void Resolve_TwoSourceFoldersCollapsingOntoOneTarget_ProduceTheSamePath()
+    {
+        var map = new Dictionary<string, string> { ["Sent Items"] = "Sent" };
+
+        var a = FolderMapper.Resolve("Sent Items", "INBOX", true, null, map);
+        var b = FolderMapper.Resolve("Sent", "INBOX", true, null, map);
+
+        Assert.Equal("Sent", a);
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void Resolve_NotExcluded_ReturnsResolvedPath()
+    {
+        var map = new Dictionary<string, string> { ["Junk E-Mail"] = "Junk" };
+        Assert.Equal("Junk", FolderMapper.Resolve("Junk E-Mail", "INBOX", true, null, map));
+    }
+}

--- a/tests/MailArchiver.Tests/Services/ImapMailRestorerDateHeaderTests.cs
+++ b/tests/MailArchiver.Tests/Services/ImapMailRestorerDateHeaderTests.cs
@@ -1,0 +1,77 @@
+using MailArchiver.Models;
+using MailArchiver.Services.Providers.Imap;
+using MailArchiver.Utilities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MimeKit;
+
+namespace MailArchiver.Tests.Services;
+
+/// <summary>
+/// The Date: header of a restored message should render its wall-clock time with the
+/// configured display timezone's offset rather than a UTC offset. Both describe the same
+/// instant; only the rendered offset differs. Before the fix the message was stamped with
+/// an explicit +00:00 offset, which is correct but does not match what the user sees.
+/// </summary>
+public class ImapMailRestorerDateHeaderTests
+{
+    private static ImapMailRestorer CreateRestorer(string timeZoneId) => new(
+        // No context is needed: only CreateMimeMessageFromArchivedEmailAsync is exercised,
+        // and it reads from the passed-in entity alone.
+        context: null!,
+        NullLogger<ImapMailRestorer>.Instance,
+        connectionFactory: null!,
+        new DateTimeHelper(Options.Create(new TimeZoneOptions { DisplayTimeZoneId = timeZoneId })),
+        Options.Create(new BatchOperationOptions()),
+        Options.Create(new OffloadOptions()));
+
+    [Fact]
+    public async Task CreateMimeMessage_EmitsDateHeaderWithDisplayTimeZoneOffset()
+    {
+        var restorer = CreateRestorer("Europe/Berlin");
+        var sentAsWallClock = new DateTime(2026, 7, 12, 10, 0, 0, DateTimeKind.Unspecified);
+        var email = new ArchivedEmail
+        {
+            Subject = "Offset test",
+            From = "sender@example.com",
+            To = "recipient@example.com",
+            SentDate = sentAsWallClock,
+            // The archiving timestamp is not the delivery time and is deliberately wrong.
+            ReceivedDate = new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+        var message = await restorer.CreateMimeMessageFromArchivedEmailAsync(email, "target");
+
+        var berlin = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+        var expectedOffset = berlin.GetUtcOffset(sentAsWallClock);
+
+        // The wall-clock time is preserved and rendered with the Berlin offset, not UTC.
+        Assert.Equal(expectedOffset, message.Date.Offset);
+        Assert.Equal(sentAsWallClock, message.Date.DateTime);
+        // Same instant as the UTC conversion of the wall-clock value.
+        Assert.Equal(
+            TimeZoneInfo.ConvertTimeToUtc(sentAsWallClock, berlin),
+            message.Date.UtcDateTime);
+    }
+
+    [Fact]
+    public async Task CreateMimeMessage_InstantMatchesTheOldUtcBehavior()
+    {
+        // Guards the claim that the change is purely cosmetic: the instant does not move,
+        // only the rendered offset. Berlin is +02:00 in July, so 10:00 Berlin == 08:00 UTC.
+        var restorer = CreateRestorer("Europe/Berlin");
+        var sentAsWallClock = new DateTime(2026, 7, 12, 10, 0, 0, DateTimeKind.Unspecified);
+        var email = new ArchivedEmail
+        {
+            Subject = "Instant test",
+            From = "sender@example.com",
+            To = "recipient@example.com",
+            SentDate = sentAsWallClock,
+        };
+
+        var message = await restorer.CreateMimeMessageFromArchivedEmailAsync(email, "target");
+
+        Assert.Equal(new DateTimeOffset(2026, 7, 12, 8, 0, 0, TimeSpan.Zero),
+            message.Date.ToUniversalTime());
+    }
+}

--- a/tests/MailArchiver.Tests/Services/ImapMailRestorerOffloadTests.cs
+++ b/tests/MailArchiver.Tests/Services/ImapMailRestorerOffloadTests.cs
@@ -1,0 +1,146 @@
+using MailArchiver.Data;
+using MailArchiver.Models;
+using MailArchiver.Services.Providers.Imap;
+using MailArchiver.Tests.Infrastructure;
+using MailArchiver.Utilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MailArchiver.Tests.Services;
+
+/// <summary>
+/// Integration tests for <see cref="ImapMailRestorer.OffloadEmailsAsync"/> against the
+/// PostgreSQL test database. The offload is aimed at multi-thousand-mail migrations and
+/// used to run two database round-trips per email: one lightweight lookup for the duplicate
+/// check, and a second full load with attachments for the append. These tests fail the
+/// offload before the first network hop, so no IMAP server is involved. They pin the
+/// observable behaviour of the pre-connection path and, for the missing-target case, the
+/// outcome accounting that the batched implementation must preserve.
+/// </summary>
+[Collection(TestDbFixture.CollectionName)]
+public class ImapMailRestorerOffloadTests
+{
+    private readonly TestDbFixture _fixture;
+    public ImapMailRestorerOffloadTests(TestDbFixture fixture) => _fixture = fixture;
+
+    private static async Task<(MailAccount Source, List<ArchivedEmail> Emails, MailAccount Target)> SeedAsync(
+        MailArchiverDbContext ctx, int emailCount)
+    {
+        var suffix = Guid.NewGuid().ToString("N").Substring(0, 12);
+
+        var source = new MailAccount
+        {
+            Name = $"off-src-{suffix}",
+            EmailAddress = $"src-{suffix}@test.local",
+            Provider = ProviderType.IMAP,
+            IsEnabled = true,
+            LastSync = DateTime.UtcNow
+        };
+        var target = new MailAccount
+        {
+            Name = $"off-dst-{suffix}",
+            EmailAddress = $"dst-{suffix}@test.local",
+            // An unroutable server: the test asserts the failure before any connection attempt.
+            ImapServer = "unreachable.test.invalid",
+            ImapPort = 993,
+            Username = "u",
+            Password = "p",
+            UseSSL = true,
+            Provider = ProviderType.IMAP,
+            IsEnabled = true,
+            LastSync = DateTime.UtcNow
+        };
+        ctx.MailAccounts.AddRange(source, target);
+        await ctx.SaveChangesAsync();
+
+        var emails = new List<ArchivedEmail>();
+        for (var i = 0; i < emailCount; i++)
+        {
+            emails.Add(new ArchivedEmail
+            {
+                MailAccountId = source.Id,
+                MessageId = $"<{suffix}-{i}@test.local>",
+                Subject = $"offload {i}",
+                Body = $"body {i}",
+                HtmlBody = string.Empty,
+                From = "sender@test.local",
+                To = "recipient@test.local",
+                Cc = string.Empty,
+                Bcc = string.Empty,
+                SentDate = new DateTime(2026, 7, 12, 10, 0, 0, DateTimeKind.Unspecified).AddMinutes(i),
+                ReceivedDate = DateTime.UtcNow,
+                FolderName = "INBOX",
+            });
+        }
+        ctx.ArchivedEmails.AddRange(emails);
+        await ctx.SaveChangesAsync();
+        return (source, emails, target);
+    }
+
+    [Fact]
+    public async Task Offload_TargetNotFound_FailsEveryEmailWithoutQueryingThem()
+    {
+        await using var scope = await _fixture.CreateTransactionalContextAsync();
+        try
+        {
+            var (source, emails, _) = await SeedAsync(scope.Context, 5);
+            var restorer = ServiceFactory.CreateImapMailRestorer(scope.Context);
+            var criteria = new OffloadCriteria
+            {
+                SourceAccountId = source.Id,
+                DryRun = false
+            };
+
+            var outcome = await restorer.OffloadEmailsAsync(
+                emails.Select(e => e.Id).ToList(),
+                targetAccountId: 999999, // does not exist
+                baseFolderName: "Archive",
+                preserveFolderStructure: true,
+                criteria: criteria);
+
+            Assert.Equal(emails.Count, outcome.Failed);
+            Assert.Equal(0, outcome.Appended);
+            Assert.Equal(0, outcome.SkippedAlreadyPresent);
+        }
+        finally { await scope.RollbackAsync(); }
+    }
+
+    [Fact]
+    public async Task Offload_ExcludesFoldersBeforeConnecting()
+    {
+        await using var scope = await _fixture.CreateTransactionalContextAsync();
+        try
+        {
+            var (source, emails, target) = await SeedAsync(scope.Context, 6);
+            // Mark two of the emails as belonging to an excluded folder.
+            var excluded = emails.Take(2).ToList();
+            foreach (var e in excluded) e.FolderName = "Spam";
+            await scope.Context.SaveChangesAsync();
+
+            var restorer = ServiceFactory.CreateImapMailRestorer(scope.Context);
+            var criteria = new OffloadCriteria
+            {
+                SourceAccountId = source.Id,
+                // Exclude "Spam": those two must be counted and skipped before any connect.
+                ExcludedSourceFolders = new List<string> { "Spam" },
+                DryRun = false
+            };
+
+            var outcome = await restorer.OffloadEmailsAsync(
+                emails.Select(e => e.Id).ToList(),
+                target.Id,
+                baseFolderName: "Archive",
+                preserveFolderStructure: true,
+                criteria: criteria);
+
+            // The target is unreachable, so the remaining four are all failures, but the two
+            // excluded ones must have been counted before any connection attempt.
+            Assert.Equal(2, outcome.SkippedExcludedFolder);
+            Assert.Equal(4, outcome.Failed);
+            Assert.Equal(0, outcome.Appended);
+        }
+        finally { await scope.RollbackAsync(); }
+    }
+}

--- a/tests/MailArchiver.Tests/Services/InternalDateResolverTests.cs
+++ b/tests/MailArchiver.Tests/Services/InternalDateResolverTests.cs
@@ -1,0 +1,166 @@
+using MailArchiver.Models;
+using MailArchiver.Services.Shared;
+using MailArchiver.Utilities;
+using Microsoft.Extensions.Options;
+
+namespace MailArchiver.Tests.Services;
+
+/// <summary>
+/// INTERNALDATE has two branches that need opposite timezone treatment, and getting them the
+/// wrong way round produces no error: mail simply lands on the target server with the wrong
+/// arrival time, which clients hide because they sort by the Date header instead.
+/// </summary>
+public class InternalDateResolverTests
+{
+    private static DateTimeHelper Helper(string timeZoneId)
+        => new(Options.Create(new TimeZoneOptions { DisplayTimeZoneId = timeZoneId }));
+
+    private static ArchivedEmail Row(DateTime sentDate, string? rawHeaders = null) => new()
+    {
+        SentDate = sentDate,
+        RawHeaders = rawHeaders,
+        // Deliberately set to something obviously wrong. This is the value the old
+        // implementation used, and it is the archiving timestamp rather than a delivery time.
+        ReceivedDate = new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+    };
+
+    // ------------------------------------------------------------------ chain parsing
+
+    [Fact]
+    public void TryExtractDeliveryTime_TakesTheTopmostReceivedHeader()
+    {
+        // The chain is prepended to as a message travels, so the first Received header is the
+        // final delivery. ExtractEmailDate walks the other way on purpose, which is why it
+        // cannot be reused here.
+        var raw = string.Join("\r\n", new[]
+        {
+            "Received: from mx3.target by next with ESMTP id C; Sun, 12 Jul 2026 10:00:00 +0000",
+            "Received: from mx2.relay by next with ESMTP id B; Sun, 12 Jul 2026 09:58:00 +0000",
+            "Received: from mx1.source by next with ESMTP id A; Sun, 12 Jul 2026 09:55:00 +0000",
+            "Subject: hello",
+        });
+
+        var result = InternalDateResolver.TryExtractDeliveryTime(raw);
+
+        Assert.NotNull(result);
+        Assert.Equal(new DateTimeOffset(2026, 7, 12, 10, 0, 0, TimeSpan.Zero), result!.Value);
+    }
+
+    [Fact]
+    public void TryExtractDeliveryTime_SkipsAnUnparseableTopHopAndUsesTheNextOne()
+    {
+        var raw = string.Join("\r\n", new[]
+        {
+            "Received: from broken by next with ESMTP id X",
+            "Received: from mx2.relay by next with ESMTP id B; Sun, 12 Jul 2026 09:58:00 +0000",
+        });
+
+        Assert.Equal(new DateTimeOffset(2026, 7, 12, 9, 58, 0, TimeSpan.Zero),
+            InternalDateResolver.TryExtractDeliveryTime(raw)!.Value);
+    }
+
+    [Fact]
+    public void TryExtractDeliveryTime_PreservesTheOffsetOfTheHeader()
+    {
+        var raw = "Received: from mx by next with ESMTP id A; Sun, 12 Jul 2026 12:00:00 +0200";
+        var result = InternalDateResolver.TryExtractDeliveryTime(raw)!.Value;
+
+        Assert.Equal(TimeSpan.FromHours(2), result.Offset);
+        Assert.Equal(new DateTimeOffset(2026, 7, 12, 10, 0, 0, TimeSpan.Zero), result.ToUniversalTime());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Subject: no received headers here\r\nFrom: a@b.c")]
+    public void TryExtractDeliveryTime_WithoutAUsableChain_ReturnsNull(string? raw)
+    {
+        Assert.Null(InternalDateResolver.TryExtractDeliveryTime(raw));
+    }
+
+    [Fact]
+    public void TryExtractDeliveryTime_IgnoresAHeaderThatMerelyContainsTheWordReceived()
+    {
+        // "X-Received" and "Received-SPF" are not delivery hops.
+        var raw = string.Join("\r\n", new[]
+        {
+            "Received-SPF: pass; Sun, 12 Jul 2026 08:00:00 +0000",
+            "X-Received: by something; Sun, 12 Jul 2026 07:00:00 +0000",
+            "Received: from mx by next with ESMTP id A; Sun, 12 Jul 2026 10:00:00 +0000",
+        });
+
+        Assert.Equal(new DateTimeOffset(2026, 7, 12, 10, 0, 0, TimeSpan.Zero),
+            InternalDateResolver.TryExtractDeliveryTime(raw)!.Value);
+    }
+
+    // ------------------------------------------------------------------ the two branches
+
+    [Fact]
+    public void Resolve_WithReceivedChain_UsesItUnconverted()
+    {
+        // A time recovered from a Received header is already an absolute instant. Passing it
+        // through the display timezone conversion would shift it by the offset, which is the
+        // second half of the original defect.
+        var raw = "Received: from mx by next with ESMTP id A; Sun, 12 Jul 2026 10:00:00 +0000";
+        var email = Row(new DateTime(2026, 7, 12, 9, 0, 0), raw);
+
+        var result = InternalDateResolver.Resolve(email, Helper("Europe/Berlin"));
+
+        Assert.Equal(new DateTimeOffset(2026, 7, 12, 10, 0, 0, TimeSpan.Zero), result.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Resolve_WithoutChain_ConvertsSentDateOutOfTheDisplayTimeZone()
+    {
+        // SentDate is stored display-local and naive. Under Europe/Berlin in July the offset is
+        // +02:00, so 12:00 local is 10:00 UTC. A test under the shipped Etc/UCT default would
+        // pass whether or not this conversion happens at all, and so proves nothing.
+        var email = Row(new DateTime(2026, 7, 12, 12, 0, 0));
+
+        var result = InternalDateResolver.Resolve(email, Helper("Europe/Berlin"));
+
+        Assert.Equal(new DateTimeOffset(2026, 7, 12, 10, 0, 0, TimeSpan.Zero), result.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Resolve_WithoutChain_HonoursWinterOffsetToo()
+    {
+        // +01:00 in January, so the conversion is not a fixed constant.
+        var email = Row(new DateTime(2026, 1, 12, 12, 0, 0));
+
+        var result = InternalDateResolver.Resolve(email, Helper("Europe/Berlin"));
+
+        Assert.Equal(new DateTimeOffset(2026, 1, 12, 11, 0, 0, TimeSpan.Zero), result.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Resolve_UnderUtcDisplayTimeZone_BothBranchesAgreeWithTheirInput()
+    {
+        var withChain = Row(new DateTime(2026, 7, 12, 9, 0, 0),
+            "Received: from mx by next with ESMTP id A; Sun, 12 Jul 2026 10:00:00 +0000");
+        var withoutChain = Row(new DateTime(2026, 7, 12, 9, 0, 0));
+
+        var helper = Helper("Etc/UCT");
+
+        Assert.Equal(new DateTimeOffset(2026, 7, 12, 10, 0, 0, TimeSpan.Zero),
+            InternalDateResolver.Resolve(withChain, helper).ToUniversalTime());
+        Assert.Equal(new DateTimeOffset(2026, 7, 12, 9, 0, 0, TimeSpan.Zero),
+            InternalDateResolver.Resolve(withoutChain, helper).ToUniversalTime());
+    }
+
+    [Fact]
+    public void Resolve_NeverUsesReceivedDate()
+    {
+        // ReceivedDate is DateTime.UtcNow at archiving time (MailImporter), so it must not reach
+        // INTERNALDATE by either branch. Both rows below carry an obviously wrong ReceivedDate.
+        var helper = Helper("Etc/UCT");
+
+        var withChain = InternalDateResolver.Resolve(
+            Row(new DateTime(2026, 7, 12, 9, 0, 0),
+                "Received: from mx by next with ESMTP id A; Sun, 12 Jul 2026 10:00:00 +0000"), helper);
+        var withoutChain = InternalDateResolver.Resolve(Row(new DateTime(2026, 7, 12, 9, 0, 0)), helper);
+
+        Assert.NotEqual(2030, withChain.Year);
+        Assert.NotEqual(2030, withoutChain.Year);
+    }
+}

--- a/tests/MailArchiver.Tests/Services/OffloadCutoffTests.cs
+++ b/tests/MailArchiver.Tests/Services/OffloadCutoffTests.cs
@@ -1,0 +1,109 @@
+using MailArchiver.Services.Shared;
+
+namespace MailArchiver.Tests.Services;
+
+/// <summary>
+/// A cutoff is resolved to an absolute date once, when the job is created, and the window is
+/// inclusive at both ends of a day. Mail close to midnight is where getting this wrong shows up.
+/// </summary>
+public class OffloadCutoffTests
+{
+    private static readonly DateTime Now = new(2026, 8, 21, 14, 37, 52);
+
+    [Fact]
+    public void FromRelativeMonths_ResolvesToTheStartOfTheDay()
+    {
+        var cutoff = OffloadCutoff.FromRelativeMonths(Now, 6);
+        Assert.Equal(new DateTime(2026, 2, 21, 0, 0, 0), cutoff);
+        Assert.Equal(TimeSpan.Zero, cutoff.TimeOfDay);
+    }
+
+    [Fact]
+    public void FromRelativeMonths_TwelveMonths_IsTheSameDayAYearEarlier()
+    {
+        Assert.Equal(new DateTime(2025, 8, 21), OffloadCutoff.FromRelativeMonths(Now, 12));
+    }
+
+    [Fact]
+    public void FromRelativeMonths_ClampsShortMonths()
+    {
+        // 31 March minus one month is 28 February, not an invalid date.
+        var march31 = new DateTime(2026, 3, 31, 9, 0, 0);
+        Assert.Equal(new DateTime(2026, 2, 28), OffloadCutoff.FromRelativeMonths(march31, 1));
+    }
+
+    [Fact]
+    public void FromRelativeDays_ResolvesToTheStartOfTheDay()
+    {
+        Assert.Equal(new DateTime(2026, 8, 11), OffloadCutoff.FromRelativeDays(Now, 10));
+    }
+
+    [Fact]
+    public void FromRelative_NegativeValue_IsRejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => OffloadCutoff.FromRelativeMonths(Now, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => OffloadCutoff.FromRelativeDays(Now, -1));
+    }
+
+    [Fact]
+    public void FromAbsolute_DropsTheTimeOfDay()
+    {
+        Assert.Equal(new DateTime(2025, 8, 1),
+            OffloadCutoff.FromAbsolute(new DateTime(2025, 8, 1, 23, 59, 59)));
+    }
+
+    // ------------------------------------------------------------------ window edges
+
+    [Fact]
+    public void IsInWindow_MidnightOnTheCutoffDay_IsIncluded()
+    {
+        var cutoff = new DateTime(2026, 2, 21);
+        Assert.True(OffloadCutoff.IsInWindow(new DateTime(2026, 2, 21, 0, 0, 0), cutoff, null));
+    }
+
+    [Fact]
+    public void IsInWindow_OneSecondBeforeTheCutoff_IsExcluded()
+    {
+        var cutoff = new DateTime(2026, 2, 21);
+        Assert.False(OffloadCutoff.IsInWindow(new DateTime(2026, 2, 20, 23, 59, 59), cutoff, null));
+    }
+
+    [Fact]
+    public void IsInWindow_UpperBoundIncludesTheWholeOfThatDay()
+    {
+        // Mirrors the search filter: SentDate <= toDate.AddDays(1).AddSeconds(-1).
+        var from = new DateTime(2026, 1, 1);
+        var to = new DateTime(2026, 6, 30);
+
+        Assert.True(OffloadCutoff.IsInWindow(new DateTime(2026, 6, 30, 23, 59, 59), from, to));
+        Assert.False(OffloadCutoff.IsInWindow(new DateTime(2026, 7, 1, 0, 0, 0), from, to));
+    }
+
+    [Fact]
+    public void ToInclusiveEnd_IsTheLastSecondOfTheDay()
+    {
+        Assert.Equal(new DateTime(2026, 6, 30, 23, 59, 59),
+            OffloadCutoff.ToInclusiveEnd(new DateTime(2026, 6, 30, 8, 15, 0)));
+    }
+
+    [Fact]
+    public void IsInWindow_WithoutUpperBound_AcceptsFutureDates()
+    {
+        var from = new DateTime(2026, 1, 1);
+        Assert.True(OffloadCutoff.IsInWindow(new DateTime(2030, 1, 1), from, null));
+    }
+
+    // ------------------------------------------------------------------ stability
+
+    [Fact]
+    public void ResolvedCutoff_DoesNotDriftWhenTheClockMoves()
+    {
+        // The reason a relative window is resolved once and stored: a job may run for days and
+        // be repeated afterwards, and it has to select the same mail every time.
+        var resolved = OffloadCutoff.FromRelativeMonths(Now, 6);
+        var laterResolved = OffloadCutoff.FromRelativeMonths(Now.AddDays(3), 6);
+
+        Assert.NotEqual(resolved, laterResolved);
+        Assert.Equal(new DateTime(2026, 2, 21), resolved);
+    }
+}

--- a/tests/MailArchiver.Tests/Services/OffloadMatchKeyTests.cs
+++ b/tests/MailArchiver.Tests/Services/OffloadMatchKeyTests.cs
@@ -1,0 +1,252 @@
+using System.Text;
+using MailArchiver.Models;
+using MailArchiver.Services.Shared;
+using MimeKit;
+
+namespace MailArchiver.Tests.Services;
+
+/// <summary>
+/// The symmetry between a key built from an archived row and one built from an IMAP ENVELOPE is
+/// the whole mechanism of the second duplicate criterion. If the two sides disagree the
+/// criterion never fires, and it fails silently: only the handful of rows without a usable
+/// Message-ID depend on it, so nothing looks wrong until those rows duplicate.
+/// </summary>
+public class OffloadMatchKeyTests
+{
+    // Reproduces what MailImporter writes into the row, so a test can build the "stored" side
+    // without a database. Mirrors MailImporter lines 94-99.
+    private static ArchivedEmail AsStoredRow(MimeMessage message) => new()
+    {
+        From = MailContentHelper.TruncateFieldForTsvector(
+            MailContentHelper.CleanText(
+                string.Join(", ", message.From.Mailboxes.Select(m => m.Address))), 10_000),
+        To = MailContentHelper.TruncateFieldForTsvector(
+            MailContentHelper.CleanText(
+                string.Join(", ", message.To.Mailboxes.Select(m => m.Address))), 50_000),
+        Subject = MailContentHelper.TruncateFieldForTsvector(
+            MailContentHelper.CleanText(message.Subject ?? "(No Subject)"), 50_000),
+    };
+
+    private static MimeMessage Message(string subject, string from, params string[] to)
+    {
+        var m = new MimeMessage();
+        m.From.Add(MailboxAddress.Parse(from));
+        foreach (var t in to) m.To.Add(MailboxAddress.Parse(t));
+        m.Subject = subject;
+        return m;
+    }
+
+    /// <summary>
+    /// Parses a message from its wire form. This matters for the subject tests: on a
+    /// constructed <see cref="MimeMessage"/> Subject reads back as "" even when never set,
+    /// while a parsed message with no Subject header reads back as null. Only the parsed
+    /// behaviour is what the importer ever sees.
+    /// </summary>
+    private static MimeMessage Parse(string raw)
+        => MimeMessage.Load(new MemoryStream(Encoding.UTF8.GetBytes(raw)));
+
+    /// <summary>
+    /// The envelope side is derived the way TargetMailboxIndex derives it: mailbox addresses
+    /// projected out of the address lists, in order.
+    /// </summary>
+    private static long EnvelopeSideKey(MimeMessage message)
+        => OffloadMatchKey.FingerprintKeyFromAddresses(
+            message.From.Mailboxes.Select(m => m.Address),
+            message.To.Mailboxes.Select(m => m.Address),
+            message.Subject);
+
+    // ------------------------------------------------------------------ symmetry
+
+    [Fact]
+    public void Fingerprint_SingleRecipient_RowAndEnvelopeAgree()
+    {
+        var msg = Message("Hello", "alice@example.com", "bob@example.com");
+        Assert.Equal(
+            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            EnvelopeSideKey(msg));
+    }
+
+    [Fact]
+    public void Fingerprint_TwoRecipients_RowAndEnvelopeAgree()
+    {
+        // This is the case the import's own dedup query gets wrong: it joins with "," while the
+        // stored column carries ", ", so its second criterion cannot match multi-recipient mail.
+        var msg = Message("Hello", "alice@example.com", "bob@example.com", "carol@example.com");
+        Assert.Equal(
+            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            EnvelopeSideKey(msg));
+    }
+
+    [Fact]
+    public void Fingerprint_TwoSenders_RowAndEnvelopeAgree()
+    {
+        var msg = Message("Hello", "alice@example.com", "bob@example.com");
+        msg.From.Add(MailboxAddress.Parse("dave@example.com"));
+        Assert.Equal(
+            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            EnvelopeSideKey(msg));
+    }
+
+    [Fact]
+    public void Fingerprint_SubjectWithControlCharacter_RowAndEnvelopeAgree()
+    {
+        // CleanText replaces characters below 32 with a space before storing, so the raw header
+        // and the stored column differ. Both sides must apply the same cleaning.
+        var msg = Message("Quarterly\u0001report", "alice@example.com", "bob@example.com");
+        Assert.Equal(
+            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            EnvelopeSideKey(msg));
+    }
+
+    [Fact]
+    public void Fingerprint_NoSubjectHeader_RowAndEnvelopeAgree()
+    {
+        // A parsed message with no Subject header has a null Subject, which is the case
+        // MailImporter's "?? (No Subject)" substitution exists for. Both sides must substitute.
+        var msg = Parse("From: alice@example.com\r\nTo: bob@example.com\r\n\r\nbody\r\n");
+        Assert.Null(msg.Subject);
+        Assert.Equal(
+            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            EnvelopeSideKey(msg));
+    }
+
+    [Fact]
+    public void Fingerprint_EmptySubjectHeader_RowAndEnvelopeAgree()
+    {
+        // An empty subject is NOT a missing subject. MailImporter writes
+        // message.Subject ?? "(No Subject)", so a present-but-empty header is stored as an
+        // empty string. Treating empty as missing would desynchronise exactly these rows.
+        var msg = Parse("From: alice@example.com\r\nTo: bob@example.com\r\nSubject: \r\n\r\nbody\r\n");
+        Assert.Equal(string.Empty, msg.Subject);
+        Assert.Equal(
+            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            EnvelopeSideKey(msg));
+    }
+
+    [Fact]
+    public void Fingerprint_EmptyAndMissingSubject_AreNotTheSameKey()
+    {
+        var empty = Parse("From: alice@example.com\r\nTo: bob@example.com\r\nSubject: \r\n\r\nbody\r\n");
+        var missing = Parse("From: alice@example.com\r\nTo: bob@example.com\r\n\r\nbody\r\n");
+        Assert.NotEqual(EnvelopeSideKey(empty), EnvelopeSideKey(missing));
+    }
+
+    [Fact]
+    public void Fingerprint_RecipientOrderIsSignificant_AsItIsInStorage()
+    {
+        // The stored column preserves header order, so the key must too; treating the addresses
+        // as a set would make the two sides disagree with the database.
+        var ab = Message("Hi", "alice@example.com", "bob@example.com", "carol@example.com");
+        var ba = Message("Hi", "alice@example.com", "carol@example.com", "bob@example.com");
+        Assert.NotEqual(EnvelopeSideKey(ab), EnvelopeSideKey(ba));
+    }
+
+    // ------------------------------------------------------------------ discrimination
+
+    [Fact]
+    public void Fingerprint_DifferentSubject_ProducesDifferentKey()
+    {
+        var a = Message("One", "alice@example.com", "bob@example.com");
+        var b = Message("Two", "alice@example.com", "bob@example.com");
+        Assert.NotEqual(EnvelopeSideKey(a), EnvelopeSideKey(b));
+    }
+
+    [Fact]
+    public void Fingerprint_TextMovedBetweenFields_ProducesDifferentKey()
+    {
+        // Without a field separator "ab" + "c" and "a" + "bc" would hash identically.
+        Assert.NotEqual(
+            OffloadMatchKey.FingerprintKeyFromStored("ab", "c", "s"),
+            OffloadMatchKey.FingerprintKeyFromStored("a", "bc", "s"));
+    }
+
+    // ------------------------------------------------------------------ Message-ID criterion
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("<bare-token-no-at-sign>")]
+    [InlineData("no-at-sign-either")]
+    public void MessageIdKey_UnusableValues_ReturnNull(string? messageId)
+    {
+        // A value without "@" is not emitted on append either: the restore path drops it and
+        // MimeKit invents a fresh random Message-Id, so it cannot be matched on.
+        Assert.Null(OffloadMatchKey.MessageIdKey(messageId));
+    }
+
+    [Fact]
+    public void MessageIdKey_UsableValue_ReturnsStableKey()
+    {
+        var a = OffloadMatchKey.MessageIdKey("<abc@example.com>");
+        var b = OffloadMatchKey.MessageIdKey("<abc@example.com>");
+        Assert.NotNull(a);
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void MessageIdKey_IgnoresBracketsAndCase()
+    {
+        // Legacy rows may carry surrounding angle brackets; NormalizeMessageId strips them.
+        var bare = OffloadMatchKey.MessageIdKey("abc@example.com");
+        Assert.Equal(bare, OffloadMatchKey.MessageIdKey("<abc@example.com>"));
+        Assert.Equal(bare, OffloadMatchKey.MessageIdKey("<<abc@example.com>>"));
+        Assert.Equal(bare, OffloadMatchKey.MessageIdKey("  <ABC@Example.COM>  "));
+    }
+
+    [Fact]
+    public void MessageIdKey_DifferentIds_ProduceDifferentKeys()
+    {
+        Assert.NotEqual(
+            OffloadMatchKey.MessageIdKey("<a@example.com>"),
+            OffloadMatchKey.MessageIdKey("<b@example.com>"));
+    }
+
+    // ------------------------------------------------------------------ timestamp tolerance
+
+    [Fact]
+    public void WithinTolerance_OneSecondApart_Matches()
+    {
+        // The reason the fingerprint index stores candidate timestamps in a list rather than
+        // quantising them: two copies one second apart would fall into different buckets and
+        // the match would silently never fire.
+        var a = new DateTime(2026, 2, 3, 10, 11, 12);
+        Assert.True(OffloadMatchKey.WithinTolerance(a, a.AddSeconds(1)));
+        Assert.True(OffloadMatchKey.WithinTolerance(a, a.AddSeconds(-1)));
+    }
+
+    [Fact]
+    public void WithinTolerance_StraddlingATwoSecondBucketBoundary_StillMatches()
+    {
+        // 10:11:11.9 and 10:11:12.1 sit in different two second buckets but are 0.2s apart.
+        var a = new DateTime(2026, 2, 3, 10, 11, 11, 900);
+        var b = new DateTime(2026, 2, 3, 10, 11, 12, 100);
+        Assert.True(OffloadMatchKey.WithinTolerance(a, b));
+    }
+
+    [Fact]
+    public void WithinTolerance_TwoSecondsOrMoreApart_DoesNotMatch()
+    {
+        var a = new DateTime(2026, 2, 3, 10, 11, 12);
+        Assert.False(OffloadMatchKey.WithinTolerance(a, a.AddSeconds(2)));
+        Assert.False(OffloadMatchKey.WithinTolerance(a, a.AddSeconds(-3)));
+    }
+
+    // ------------------------------------------------------------------ hashing
+
+    [Fact]
+    public void Hash64_IsStableAcrossCalls()
+    {
+        // Deliberately not string.GetHashCode(), which is randomised per process.
+        Assert.Equal(OffloadMatchKey.Hash64("a@example.com"), OffloadMatchKey.Hash64("a@example.com"));
+    }
+
+    [Fact]
+    public void Hash64_KnownValue_DoesNotDriftBetweenReleases()
+    {
+        // FNV-1a over the two bytes of each UTF-16 unit. Pinned so an accidental change to the
+        // algorithm is caught rather than silently invalidating every stored comparison.
+        Assert.Equal(OffloadMatchKey.Hash64(""), OffloadMatchKey.Hash64(string.Empty));
+        Assert.NotEqual(0, OffloadMatchKey.Hash64("a"));
+    }
+}

--- a/tests/MailArchiver.Tests/Services/OffloadTargetEligibilityTests.cs
+++ b/tests/MailArchiver.Tests/Services/OffloadTargetEligibilityTests.cs
@@ -1,0 +1,191 @@
+using MailArchiver.Models;
+using MailArchiver.Services.Shared;
+
+namespace MailArchiver.Tests.Services;
+
+/// <summary>
+/// The offload target is the one end of the operation the acting user does not necessarily own,
+/// so these are the rules that keep a self-manager from appending into somebody else's mailbox.
+/// The order of the checks is part of the contract: a rejection message must never say anything
+/// about an account the user may not see.
+/// </summary>
+public class OffloadTargetEligibilityTests
+{
+    private const int SourceId = 1;
+
+    private static OffloadTargetCandidate Candidate(
+        int id = 2,
+        ProviderType provider = ProviderType.IMAP,
+        bool isEnabled = true,
+        bool isAccessible = true)
+        => new() { Id = id, Provider = provider, IsEnabled = isEnabled, IsAccessible = isAccessible };
+
+    // --- IsAccessible: the scope IAccountAccessResolver hands over -------------------------
+
+    [Fact]
+    public void IsAccessible_NullScope_IsAdminAndAllowsEverything()
+    {
+        Assert.True(OffloadTargetEligibility.IsAccessible(1, null));
+        Assert.True(OffloadTargetEligibility.IsAccessible(9999, null));
+    }
+
+    [Fact]
+    public void IsAccessible_EmptyScope_AllowsNothing()
+    {
+        Assert.False(OffloadTargetEligibility.IsAccessible(1, new List<int>()));
+    }
+
+    [Fact]
+    public void IsAccessible_OnlyTheAssignedAccounts()
+    {
+        var allowed = new List<int> { 2, 5 };
+        Assert.True(OffloadTargetEligibility.IsAccessible(2, allowed));
+        Assert.True(OffloadTargetEligibility.IsAccessible(5, allowed));
+        Assert.False(OffloadTargetEligibility.IsAccessible(3, allowed));
+    }
+
+    // --- Evaluate -------------------------------------------------------------------------
+
+    [Fact]
+    public void Evaluate_AnAssignedEnabledImapAccount_IsAccepted()
+    {
+        Assert.Equal(OffloadTargetRejection.None, OffloadTargetEligibility.Evaluate(Candidate(), SourceId));
+        Assert.True(OffloadTargetEligibility.IsEligible(Candidate(), SourceId));
+    }
+
+    [Fact]
+    public void Evaluate_MissingAccount_IsNotFound()
+    {
+        Assert.Equal(OffloadTargetRejection.NotFound, OffloadTargetEligibility.Evaluate(null, SourceId));
+        Assert.False(OffloadTargetEligibility.IsEligible(null, SourceId));
+    }
+
+    [Fact]
+    public void Evaluate_TheSourceItself_IsRejectedEvenWhenOtherwisePerfect()
+    {
+        var self = Candidate(id: SourceId);
+        Assert.Equal(OffloadTargetRejection.SameAsSource, OffloadTargetEligibility.Evaluate(self, SourceId));
+    }
+
+    [Fact]
+    public void Evaluate_AnAccountTheUserIsNotAssignedTo_IsRejected()
+    {
+        var foreign = Candidate(isAccessible: false);
+        Assert.Equal(OffloadTargetRejection.NotAccessible, OffloadTargetEligibility.Evaluate(foreign, SourceId));
+    }
+
+    [Fact]
+    public void Evaluate_AGraphAccount_IsRejected()
+    {
+        var graph = Candidate(provider: ProviderType.M365);
+        Assert.Equal(OffloadTargetRejection.NotImap, OffloadTargetEligibility.Evaluate(graph, SourceId));
+    }
+
+    [Fact]
+    public void Evaluate_ADisabledAccount_IsRejected()
+    {
+        var disabled = Candidate(isEnabled: false);
+        Assert.Equal(OffloadTargetRejection.Disabled, OffloadTargetEligibility.Evaluate(disabled, SourceId));
+    }
+
+    /// <summary>
+    /// Accessibility is checked before the provider and the enabled flag. Otherwise the form
+    /// would answer "that is not an IMAP account" or "that account is disabled" about a mailbox
+    /// the user is not allowed to know anything about.
+    /// </summary>
+    [Theory]
+    [InlineData(ProviderType.M365, true)]
+    [InlineData(ProviderType.IMAP, false)]
+    [InlineData(ProviderType.M365, false)]
+    public void Evaluate_InaccessibleWins_OverProviderAndEnabledState(ProviderType provider, bool isEnabled)
+    {
+        var candidate = Candidate(provider: provider, isEnabled: isEnabled, isAccessible: false);
+        Assert.Equal(OffloadTargetRejection.NotAccessible, OffloadTargetEligibility.Evaluate(candidate, SourceId));
+    }
+
+    /// <summary>
+    /// The source is rejected before accessibility is consulted, which is harmless: the user
+    /// already has access to the source, or the page would not have opened.
+    /// </summary>
+    [Fact]
+    public void Evaluate_SameAsSourceWins_OverEverythingElse()
+    {
+        var self = Candidate(id: SourceId, provider: ProviderType.M365, isEnabled: false, isAccessible: false);
+        Assert.Equal(OffloadTargetRejection.SameAsSource, OffloadTargetEligibility.Evaluate(self, SourceId));
+    }
+
+    // --- Messages -------------------------------------------------------------------------
+
+    /// <summary>
+    /// "Does not exist" and "is not yours" have to be indistinguishable on the form, or a post
+    /// with a guessed ID becomes an account enumeration oracle.
+    /// </summary>
+    [Fact]
+    public void MessageKey_NotFoundAndNotAccessible_AreIndistinguishable()
+    {
+        Assert.Equal(
+            OffloadTargetEligibility.MessageKey(OffloadTargetRejection.NotFound),
+            OffloadTargetEligibility.MessageKey(OffloadTargetRejection.NotAccessible));
+    }
+
+    [Theory]
+    [InlineData(OffloadTargetRejection.SameAsSource, "OffloadTargetMustDiffer")]
+    [InlineData(OffloadTargetRejection.NotFound, "OffloadTargetNotFound")]
+    [InlineData(OffloadTargetRejection.NotAccessible, "OffloadTargetNotFound")]
+    [InlineData(OffloadTargetRejection.NotImap, "OffloadTargetMustBeImap")]
+    [InlineData(OffloadTargetRejection.Disabled, "OffloadTargetDisabled")]
+    public void MessageKey_MapsEveryRejection(OffloadTargetRejection rejection, string expected)
+    {
+        Assert.Equal(expected, OffloadTargetEligibility.MessageKey(rejection));
+    }
+
+    [Fact]
+    public void MessageKey_None_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => OffloadTargetEligibility.MessageKey(OffloadTargetRejection.None));
+    }
+
+    /// <summary>
+    /// Every rejection the enum can produce needs a message, so adding one cannot silently ship
+    /// a form that throws when it tries to explain itself.
+    /// </summary>
+    [Fact]
+    public void MessageKey_CoversEveryRejectionValue()
+    {
+        foreach (var rejection in Enum.GetValues<OffloadTargetRejection>())
+        {
+            if (rejection == OffloadTargetRejection.None) continue;
+            Assert.False(string.IsNullOrEmpty(OffloadTargetEligibility.MessageKey(rejection)));
+        }
+    }
+
+    // --- The list and the boundary agree --------------------------------------------------
+
+    /// <summary>
+    /// The dropdown is built by filtering candidates through IsEligible and the post decides
+    /// with Evaluate. This is the property that matters: anything the list offers is accepted,
+    /// and anything it withholds is refused.
+    /// </summary>
+    [Fact]
+    public void TheOfferedListAndTheAcceptedPost_AgreeForASelfManager()
+    {
+        var allowed = new List<int> { 1, 2 };
+        var all = new[]
+        {
+            Candidate(id: 1),                                                       // the source
+            Candidate(id: 2),                                                       // assigned, usable
+            Candidate(id: 3, isAccessible: OffloadTargetEligibility.IsAccessible(3, allowed)),
+            Candidate(id: 4, isEnabled: false, isAccessible: OffloadTargetEligibility.IsAccessible(4, allowed)),
+        };
+
+        var offered = all.Where(c => OffloadTargetEligibility.IsEligible(c, SourceId)).Select(c => c.Id).ToList();
+        Assert.Equal(new[] { 2 }, offered);
+
+        foreach (var candidate in all)
+        {
+            var accepted = OffloadTargetEligibility.Evaluate(candidate, SourceId) == OffloadTargetRejection.None;
+            Assert.Equal(offered.Contains(candidate.Id), accepted);
+        }
+    }
+}

--- a/tests/MailArchiver.Tests/Services/TargetMailboxIndexTests.cs
+++ b/tests/MailArchiver.Tests/Services/TargetMailboxIndexTests.cs
@@ -1,0 +1,165 @@
+using MailArchiver.Models;
+using MailArchiver.Services.Providers.Imap;
+using MailArchiver.Utilities;
+using Microsoft.Extensions.Options;
+
+namespace MailArchiver.Tests.Services;
+
+/// <summary>
+/// The IMAP fetch that normally fills the index cannot be unit tested, but the matching on top
+/// of it can, against a hand-built index. Criterion precedence and the send-time tolerance are
+/// what decide whether a repeated offload duplicates mail.
+/// </summary>
+public class TargetMailboxIndexTests
+{
+    private static TargetMailboxIndex NewIndex(string timeZoneId = "Etc/UCT")
+        => new(new DateTimeHelper(Options.Create(new TimeZoneOptions { DisplayTimeZoneId = timeZoneId })));
+
+    private static ArchivedEmail Row(string? messageId, string from, string to, string subject, DateTime sent)
+        => new() { MessageId = messageId ?? string.Empty, From = from, To = to, Subject = subject, SentDate = sent };
+
+    private static readonly DateTime Sent = new(2026, 2, 3, 10, 11, 12);
+
+    [Fact]
+    public void Match_EmptyIndex_FindsNothing()
+    {
+        var index = NewIndex();
+        Assert.Equal(OffloadMatchKind.None,
+            index.Match(Row("<a@x.com>", "alice@x.com", "bob@y.com", "Hi", Sent)));
+    }
+
+    [Fact]
+    public void Match_ByMessageId()
+    {
+        var index = NewIndex();
+        index.AddRaw("<a@x.com>", "someone@else.com", "nobody@else.com", "Different", Sent.AddYears(-3));
+
+        // Message-ID alone is enough; none of the other fields agree.
+        Assert.Equal(OffloadMatchKind.MessageId,
+            index.Match(Row("<a@x.com>", "alice@x.com", "bob@y.com", "Hi", Sent)));
+    }
+
+    [Fact]
+    public void Match_MessageIdTakesPrecedenceOverFingerprint()
+    {
+        var index = NewIndex();
+        index.AddRaw("<a@x.com>", "alice@x.com", "bob@y.com", "Hi", Sent);
+
+        // Both criteria would match; the reported kind must be the more reliable one, because
+        // MatchedByFingerprint is a counter the operator reads.
+        Assert.Equal(OffloadMatchKind.MessageId,
+            index.Match(Row("<a@x.com>", "alice@x.com", "bob@y.com", "Hi", Sent)));
+    }
+
+    [Fact]
+    public void Match_ByFingerprint_WhenMessageIdIsUnusable()
+    {
+        var index = NewIndex();
+        index.AddRaw("<indexed@x.com>", "alice@x.com", "bob@y.com", "Hi", Sent);
+
+        // A stored Message-ID without "@" cannot be matched on, so the fingerprint has to carry
+        // this row. These are exactly the rows that would otherwise duplicate on every run.
+        Assert.Equal(OffloadMatchKind.Fingerprint,
+            index.Match(Row("<no-at-sign>", "alice@x.com", "bob@y.com", "Hi", Sent)));
+    }
+
+    [Fact]
+    public void Match_ByFingerprint_WhenMessageIdIsMissingEntirely()
+    {
+        var index = NewIndex();
+        index.AddRaw(null, "alice@x.com", "bob@y.com", "Hi", Sent);
+        Assert.Equal(OffloadMatchKind.Fingerprint,
+            index.Match(Row(null, "alice@x.com", "bob@y.com", "Hi", Sent)));
+    }
+
+    [Fact]
+    public void Match_Fingerprint_OneSecondApart_StillMatches()
+    {
+        var index = NewIndex();
+        index.AddRaw(null, "alice@x.com", "bob@y.com", "Hi", Sent);
+
+        Assert.Equal(OffloadMatchKind.Fingerprint,
+            index.Match(Row(null, "alice@x.com", "bob@y.com", "Hi", Sent.AddSeconds(1))));
+    }
+
+    [Fact]
+    public void Match_Fingerprint_ThreeSecondsApart_DoesNotMatch()
+    {
+        var index = NewIndex();
+        index.AddRaw(null, "alice@x.com", "bob@y.com", "Hi", Sent);
+
+        Assert.Equal(OffloadMatchKind.None,
+            index.Match(Row(null, "alice@x.com", "bob@y.com", "Hi", Sent.AddSeconds(3))));
+    }
+
+    [Fact]
+    public void Match_Fingerprint_SameFieldsDifferentDay_DoesNotMatch()
+    {
+        var index = NewIndex();
+        index.AddRaw(null, "alice@x.com", "bob@y.com", "Weekly report", Sent);
+
+        // A recurring message with an identical subject a week later is a different message.
+        Assert.Equal(OffloadMatchKind.None,
+            index.Match(Row(null, "alice@x.com", "bob@y.com", "Weekly report", Sent.AddDays(7))));
+    }
+
+    [Fact]
+    public void Match_Fingerprint_SeveralCandidatesUnderOneKey_ChecksThemAll()
+    {
+        var index = NewIndex();
+        index.AddRaw(null, "alice@x.com", "bob@y.com", "Weekly report", Sent);
+        index.AddRaw(null, "alice@x.com", "bob@y.com", "Weekly report", Sent.AddDays(7));
+        index.AddRaw(null, "alice@x.com", "bob@y.com", "Weekly report", Sent.AddDays(14));
+
+        // The middle candidate must be found, not just the first stored under the key.
+        Assert.Equal(OffloadMatchKind.Fingerprint,
+            index.Match(Row(null, "alice@x.com", "bob@y.com", "Weekly report", Sent.AddDays(7))));
+        Assert.Equal(OffloadMatchKind.None,
+            index.Match(Row(null, "alice@x.com", "bob@y.com", "Weekly report", Sent.AddDays(21))));
+    }
+
+    [Fact]
+    public void Match_Fingerprint_MultiRecipient_MatchesOnStorageFormat()
+    {
+        var index = NewIndex();
+        // Stored columns join with ", ". A key built the way the import's dedup query builds it
+        // would use "," and would never match this row.
+        index.AddRaw(null, "alice@x.com", "bob@y.com, carol@y.com", "Hi", Sent);
+
+        Assert.Equal(OffloadMatchKind.Fingerprint,
+            index.Match(Row(null, "alice@x.com", "bob@y.com, carol@y.com", "Hi", Sent)));
+    }
+
+    [Fact]
+    public void Add_MakesASubsequentMatchSucceed()
+    {
+        var index = NewIndex();
+        var email = Row("<a@x.com>", "alice@x.com", "bob@y.com", "Hi", Sent);
+
+        Assert.Equal(OffloadMatchKind.None, index.Match(email));
+
+        // Called after every successful append, so duplicates inside one run are caught too and
+        // not only duplicates against an earlier run.
+        index.Add(email);
+        Assert.Equal(OffloadMatchKind.MessageId, index.Match(email));
+    }
+
+    [Fact]
+    public void Add_RowWithUnusableMessageId_IsStillMatchableByFingerprint()
+    {
+        var index = NewIndex();
+        var email = Row("<no-at-sign>", "alice@x.com", "bob@y.com", "Hi", Sent);
+
+        index.Add(email);
+        Assert.Equal(OffloadMatchKind.Fingerprint, index.Match(email));
+    }
+
+    [Fact]
+    public void Add_IncrementsTheIndexedCount()
+    {
+        var index = NewIndex();
+        Assert.Equal(0, index.IndexedMessages);
+        index.Add(Row("<a@x.com>", "alice@x.com", "bob@y.com", "Hi", Sent));
+        Assert.Equal(1, index.IndexedMessages);
+    }
+}


### PR DESCRIPTION
Adds a date-windowed offload: archived mail newer than a cutoff is appended into another
mailbox, everything older stays in the archive. It exists for migrations where the new mailbox
should hold only recent mail while the full history stays reachable through Mail Archiver.

Coordinated by email in advance, as CONTRIBUTING asks. Rebased onto current `main`.

## Reading the diff

4,933 additions looks alarming; most of it is not review surface. Only **20 lines are deleted** —
the change is almost entirely additive and barely touches existing code.

| Category | Files | Lines | Notes |
|---|---|---|---|
| Production C# | 17 | 2,008 | of which 302 are property-bag models and 210 the CLI branch |
| **resx translations** | 11 | **1,386** | 42 UI strings × 11 files × ~3 lines of XML. No logic |
| Tests | 6 | 1,052 | 101 new cases |
| Views | 4 | 250 | |
| Docs | 4 | 237 | |

The actual new logic is ~1,260 lines in eight files:

| File | Lines | What |
|---|---|---|
| `Services/Providers/Imap/ImapMailRestorer.cs` | +321 / −10 | append path, the only meaningfully edited existing file |
| `Services/Providers/Imap/TargetMailboxIndex.cs` | +290 | indexes the target mailbox for the duplicate check |
| `Services/Shared/OffloadMatchKey.cs` | +146 | the two match criteria |
| `Services/BatchRestoreService.cs` | +139 / −6 | job orchestration |
| `Services/Shared/FolderMapper.cs` | +135 | exclusions and renaming |
| `Services/Shared/OffloadTargetEligibility.cs` | +85 | who may offload where |
| `Services/Shared/InternalDateResolver.cs` | +84 | INTERNALDATE for appended mail |
| `Services/Shared/OffloadCutoff.cs` | +62 | resolves the date window |

The four deletions outside those two services are one line in `Views/Emails/Jobs.cshtml` and two
in `appsettings.json`.

## What it does

The offload only ever appends to the target. It never deletes from the archive and never touches
the source mailbox. Compared with the existing *Copy All Emails to Another Mailbox* it adds a date
window, folder exclusions, folder renaming, a dry run that reports per folder without writing —
and it is repeatable.

**Repeating a run is safe.** The target mailbox is indexed before the first append and every
message checked against it, so a second run appends nothing that already arrived. That makes an
interrupted run recoverable by re-running it, and a finished run repeatable as a verification pass.
Two criteria decide, in order:

1. **Message-ID**, normalised — this does nearly all of the work.
2. **A fingerprint** over sender, recipients, subject and send time within two seconds — this
   covers messages whose stored Message-ID is missing or malformed. Those cannot be restored with
   their original Message-ID at all, so without the second criterion they would duplicate on every
   run.

The job reports fingerprint matches separately, because that is the criterion that could fail
quietly.

**Entry point.** One button on the source account's detail page
(`Views/MailAccounts/Details.cshtml`), first in the second row of action buttons, ahead of *Copy
All Emails*. Direct URL `/MailAccounts/Offload/<source account id>`. Nothing in the navigation bar.

**Access.** Admins for any account; a self-manager for the accounts assigned to them, at both ends.
The decision lives in one place, `OffloadTargetEligibility`, called by both the target dropdown and
the POST, so the form cannot be driven past the dropdown by URL. An ineligible target and a
non-existent one return the same message, so a guessed ID does not become an enumeration oracle.

**CLI.** `--offload` with `--source-account-id`, `--target-account-id`, `--since`, optional
`--until`, `--target-folder`, `--preserve-folders`, `--dry-run`, `--no-mark-seen`.

## Compatibility

- **No database migration and no schema change.** The new job models are in-memory only.
- New `Offload` section in `appsettings.json`; every default reproduces the previous behaviour.
- `ExcludedSourceFolders` and `FolderRenameMap` ship empty on purpose. Rewriting or dropping
  folders unasked would surprise anyone already using the restore path, so an unconfigured run
  migrates everything, spam folders included.
- `MaxConcurrentJobs` defaults to `1`, keeping the strictly serial job queue. At most one job per
  target mailbox runs regardless of the value.

## Testing

101 new test cases across 6 files. Full suite on this branch: **620 passing, 1 skipped, 0
failing**. The suite needs no external services.

Covered: the match criteria and their normalisation, the cutoff and its upper bound, folder
exclusion and rename precedence, the target index including the `PrefetchMaxMessages` fallback,
INTERNALDATE resolution, and the eligibility matrix including the uniform not-found message.

## Notes for review

- **INTERNALDATE** is the one behaviour change to an existing path, so it is worth a look.
  Appending used to take it from `ReceivedDate`, which is assigned `DateTime.UtcNow` at archiving
  time — so every restored message carried the date of whichever sync or import archived it, not
  its delivery date. It hides well, because the `Date:` header is still correct and clients sort
  by that; what it breaks is IMAP SORT ARRIVAL, server-side age and retention rules, and any
  attempt to verify a restore by date. `InternalDateResolver` now reads the **topmost** `Received`
  header, which is the final delivery hop, and falls back to `SentDate` when there is no readable
  chain. Note that the two branches need opposite time zone treatment: a time from a `Received`
  header is an absolute instant, while `SentDate` is stored display-local and naive and has to be
  converted out of the display time zone first. `MailContentHelper.ExtractEmailDate` looks like
  the right helper to reuse here but is not — it returns the `Date:` header when one is present,
  which is the value already in `SentDate`, and it walks the chain from the oldest hop, the
  opposite end from the one INTERNALDATE needs.
- **Translations**: all 42 keys are present in all 11 resx files, so no string falls back
  mid-sentence. The English and German values are real translations; the other nine files carry
  the English text as a placeholder and would benefit from a native pass.
- **Documentation** is in `doc/Offload.md`, linked from `doc/Index.md`. It covers the
  configuration reference, how the duplicate check behaves on a repeated run, and a worked
  Exchange → Dovecot example of the folder settings.

Deliberately out of scope, to keep this reviewable: the jobs list is left unscoped as it is today,
and the duplicate-detection helpers introduced here are not yet shared with the existing import
paths.