### PR TITLE
Add a local test environment with a Dovecot IMAP target

### DIFF
--- a/doc/Index.md
+++ b/doc/Index.md
@@ -33,6 +33,7 @@ Mail Archiver is a comprehensive application designed to archive emails from var
 - [Reverse Proxy Configuration](ReverseProxy.md)
 - [User Management and Mailbox Permissions](UserManagement.md)
 - [Date-Windowed Offload](Offload.md)
+- [Local Test Environment](LocalTestEnvironment.md)
 - [Using Development Versions (Dev Tag)](DevTag.md)
 
 ### ☁️ Provider Specific Guides

--- a/doc/LocalTestEnvironment.md
+++ b/doc/LocalTestEnvironment.md
@@ -104,9 +104,10 @@ ASPNETCORE_ENVIRONMENT=Development ASPNETCORE_URLS=http://127.0.0.1:5000 \
   dotnet run --project MailArchiver.csproj
 ```
 
-The port is worth setting explicitly. There is no `Properties/launchSettings.json` in the
-repository, and `ASPNETCORE_URLS` is set only inside the `Dockerfile`, so a local `dotnet run`
-otherwise falls back to whatever the ASP.NET Core default happens to be.
+`Properties/launchSettings.json` already sets `ASPNETCORE_ENVIRONMENT=Development` for
+`dotnet run`, so a plain `dotnet run --project MailArchiver.csproj` works too and serves
+http://localhost:5179 (the `http` profile). `ASPNETCORE_URLS` above only picks the container
+port 5000 instead.
 
 Pending migrations are applied to `MailArchiverDev` at startup. Sign in with the credentials from `appsettings.json`
 (`Authentication:Username` and `Authentication:Password`).
@@ -152,9 +153,13 @@ tests/seed/seed.sh            # seed
 tests/seed/seed.sh --reset    # discard what was seeded before, then seed again
 ```
 
-It creates two accounts, imports the fixtures, and prints what landed. Both accounts are created
-with sync disabled, so the background sync service ignores them: the source server does not
-exist, and the Dovecot target only ever needs to be appended to. Running it twice is harmless;
+It creates two accounts, imports the fixtures, and prints what landed. Both accounts are
+created with a per-account sync interval of a year, and the source is additionally disabled,
+so the background sync service ignores it: its server does not exist, and the Dovecot target
+only ever needs to be appended to. One caveat: the scheduling state lives in memory, so every
+application restart schedules the target once, immediately. The target therefore also
+excludes the Dovecot special-use folders (`INBOX`, `Drafts`, `Junk`, `Sent`, `Trash`), so that
+one restart sync has nothing to archive back. Running the script twice is harmless;
 the second run reports every message as already present.
 
 The fixtures are checked in under `tests/seed/fixtures`, one mbox per source folder, with
@@ -170,7 +175,7 @@ Every fixture message carries an `X-Fixture-Purpose` header saying why it exists
 document themselves:
 
 ```
-X-Fixture-Purpose: ImapMailRestorer.cs:854 refuses to emit this, so MimeKit invents a
+X-Fixture-Purpose: ImapMailRestorer.cs:1196 refuses to emit this, so MimeKit invents a
   fresh random Message-Id on every append and the row duplicates each repetition
 Subject: Message-ID without an at sign
 Message-ID: <bare-token-no-at-sign>

--- a/doc/LocalTestEnvironment.md
+++ b/doc/LocalTestEnvironment.md
@@ -1,0 +1,231 @@
+# 🧪 Local Test Environment
+
+[← Back to Documentation Index](Index.md)
+
+## 📋 Overview
+
+This guide describes how to run the test suite, the application, and an IMAP target on a
+development machine. It is aimed at contributors: the stack it brings up is deliberately
+insecure and is not a deployment guide. For deployment see the
+[Setup Guide](Setup.md).
+
+Three pieces are involved:
+
+| Piece | Provided by | Purpose |
+|---|---|---|
+| PostgreSQL | `docker-compose.test.yml` | Two databases, one for `dotnet test` and one for the application |
+| Dovecot | `docker-compose.test.yml` | An IMAP target standing in for a mailcow mailbox |
+| The application | `dotnet run` on the host | Faster to iterate than rebuilding the container image |
+
+## 🚀 Starting the stack
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+```
+
+This publishes everything on loopback only:
+
+| Service | Host address | Notes |
+|---|---|---|
+| PostgreSQL | `127.0.0.1:5433` | 5433, not 5432, so it does not clash with a local server |
+| Dovecot, plain | `127.0.0.1:1143` | Plaintext authentication is enabled |
+| Dovecot, TLS | `127.0.0.1:1993` | The image's self-signed certificate |
+
+To stop it, and to discard all databases and stored mail:
+
+```bash
+docker compose -f docker-compose.test.yml down -v
+```
+
+## 🗄️ The two databases
+
+The test suite leaves fixture rows behind: after a full run the test database holds several
+dozen mail accounts and users. If the application shared that database, its background sync
+would pick those fixtures up and repeatedly try to reach servers that do not exist. So the
+postgres container creates two databases on first initialisation
+(`tests/postgres/10-create-dev-db.sql`):
+
+| Database | Used by | Configured in |
+|---|---|---|
+| `MailArchiver` | `dotnet test` | `tests/MailArchiver.Tests/appsettings.Test.json` |
+| `MailArchiverDev` | `dotnet run` | `appsettings.Development.json` |
+
+Both configuration files are gitignored and have to be created locally.
+
+`tests/MailArchiver.Tests/appsettings.Test.json`:
+
+```json
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=127.0.0.1;Port=5433;Database=MailArchiver;Username=mailuser;Password=masterkey"
+  }
+}
+```
+
+`appsettings.Development.json` in the repository root:
+
+```json
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=127.0.0.1;Port=5433;Database=MailArchiverDev;Username=mailuser;Password=masterkey"
+  },
+  "DataProtection": { "KeyPath": "DataProtection-Keys" },
+  "MailSync": { "IgnoreSelfSignedCert": true }
+}
+```
+
+`DataProtection:KeyPath` matters outside the container: it defaults to the absolute path
+`/app/DataProtection-Keys`, which does not exist on a development machine, and without it every
+request fails while reading the key ring. `IgnoreSelfSignedCert` is what lets the application
+accept the Dovecot certificate on port 1993.
+
+## ✅ Running the tests
+
+```bash
+dotnet test tests/MailArchiver.Tests/MailArchiver.Tests.csproj
+```
+
+Migrations are applied automatically by `TestDbFixture` on the first run. Of the 519 tests,
+about 330 need no database at all; the rest use PostgreSQL, so they fail with
+`Name or service not known` if the stack is not running.
+
+A connection string can also be supplied through the environment, which overrides every
+configuration file:
+
+```bash
+MailArchiverTest__ConnectionStrings__DefaultConnection="Host=...;Port=...;Database=...;Username=...;Password=..." \
+  dotnet test tests/MailArchiver.Tests/MailArchiver.Tests.csproj
+```
+
+## 🖥️ Running the application
+
+```bash
+ASPNETCORE_ENVIRONMENT=Development ASPNETCORE_URLS=http://127.0.0.1:5000 \
+  dotnet run --project MailArchiver.csproj
+```
+
+The port is worth setting explicitly. There is no `Properties/launchSettings.json` in the
+repository, and `ASPNETCORE_URLS` is set only inside the `Dockerfile`, so a local `dotnet run`
+otherwise falls back to whatever the ASP.NET Core default happens to be.
+
+Pending migrations are applied to `MailArchiverDev` at startup. Sign in with the credentials from `appsettings.json`
+(`Authentication:Username` and `Authentication:Password`).
+
+## 📬 Using the Dovecot target
+
+Dovecot accepts **any username** with the password `pass`, so a new target mailbox needs no
+provisioning: pick a name and log in. Add it under Mail Accounts with:
+
+| Field | Plain | TLS |
+|---|---|---|
+| IMAP Server | `localhost` | `localhost` |
+| IMAP Port | `1143` | `1993` |
+| Use SSL | off | on |
+| Username | anything, e.g. `offload-target@example.com` | same |
+| Password | `pass` | same |
+
+The configuration in `tests/dovecot/dovecot.conf` is modelled on the image's own default, with
+three deliberate differences that make it behave like a mailcow target:
+
+- **Maildir storage** instead of the image's sdbox, which is what mailcow uses.
+- **`separator = /`**, matching mailcow. Folder paths are split on `/` and `\` when a restore
+  recreates a folder hierarchy, so a server using `.` would behave differently.
+- **The special-use folders `Drafts`, `Junk`, `Sent` and `Trash` are pre-created**, as mailcow
+  pre-creates them. This matters when testing a migration from Exchange: a source folder named
+  `Sent Items` lands next to the existing `Sent` rather than merging with it, which is the
+  situation folder renaming has to deal with.
+
+Plaintext authentication is enabled on port 1143 because the application connects without any
+transport security when an account has SSL disabled.
+
+## 🌱 Seeding an archive to test against
+
+An empty archive is not much use for testing a restore or a migration, so
+`tests/seed/seed.sh` builds one:
+
+```bash
+# once, so the schema exists
+ASPNETCORE_ENVIRONMENT=Development ASPNETCORE_URLS=http://127.0.0.1:5000 \
+  dotnet run --project MailArchiver.csproj
+
+tests/seed/seed.sh            # seed
+tests/seed/seed.sh --reset    # discard what was seeded before, then seed again
+```
+
+It creates two accounts, imports the fixtures, and prints what landed. Both accounts are created
+with sync disabled, so the background sync service ignores them: the source server does not
+exist, and the Dovecot target only ever needs to be appended to. Running it twice is harmless;
+the second run reports every message as already present.
+
+The fixtures are checked in under `tests/seed/fixtures`, one mbox per source folder, with
+`manifest.tsv` mapping each file to its target folder. They are imported through the
+application's own `--import-mbox` CLI, and that detail is deliberate: the CLI routes through
+`MailImporter.ImportEmailToDatabase`, the same importer the IMAP sync uses, so the rows land in
+exactly the format a real archive holds -- addresses joined with `", "`, subjects passed through
+`CleanText`, `SentDate` converted to the display timezone, `RawHeaders` extracted and truncated.
+Inserting rows straight into the database would skip all of that and produce fixtures that
+quietly differ from production data.
+
+Every fixture message carries an `X-Fixture-Purpose` header saying why it exists, so the files
+document themselves:
+
+```
+X-Fixture-Purpose: ImapMailRestorer.cs:854 refuses to emit this, so MimeKit invents a
+  fresh random Message-Id on every append and the row duplicates each repetition
+Subject: Message-ID without an at sign
+Message-ID: <bare-token-no-at-sign>
+```
+
+Dates are fixed rather than relative to the current day. A migration cutoff is resolved to an
+absolute date before a job runs, so a fixed fixture set and a fixed cutoff test the same thing
+more predictably than a sliding one. The messages span 2012 to 2026.
+
+The folder layout mirrors an Exchange mailbox, and each folder exists to exercise something:
+
+| Source folder | Why it is there |
+|---|---|
+| `INBOX` | dates spanning fifteen years, plus the edge-case messages below |
+| `Sent Items` | collides with the Dovecot target's existing special-use `Sent` |
+| `Sent Items/2019` | a rename has to rewrite the leading path segment only |
+| `Sent Items Archive` | shares a prefix as a substring but not on a segment boundary, so it must not be rewritten |
+| `Deleted Items` | folder exclusion |
+| `Deleted Items/Old` | an exclusion on a parent has to cover descendants |
+| `Junk E-Mail` | Exchange's name for a folder Dovecot calls `Junk` |
+| `Archive/Projects/2020` | three levels of nesting |
+
+The individual messages cover a message with no `Message-ID` header (which gets the deterministic
+fallback), one whose `Message-ID` has no `@` (which does not survive a restore intact), a subject
+containing a control character, a message with a three-hop `Received` chain and one with none,
+several with two `To` recipients, and two near-duplicate pairs one second apart.
+
+### A note on the exit code
+
+`tests/seed/seed.sh` checks the failed and malformed counts from the import output rather than
+the process exit code. `MBoxImportService` reports `CompletedWithErrors` when it skipped
+duplicates, and the CLI maps every status other than `Completed` to exit 1, so re-running an
+import exits non-zero even when nothing went wrong. Re-running the seed script is therefore safe
+and reports every message as already present.
+
+## ⚠️ Not for production
+
+- Any username authenticates against Dovecot with a single fixed password.
+- Plaintext authentication is enabled.
+- Database credentials are the documented defaults.
+- Mail and database state live in Docker volumes that `down -v` deletes.
+
+## 🔧 Troubleshooting
+
+**Tests fail with `Name or service not known`** — the stack is not running, or
+`appsettings.Test.json` is missing so the connection string falls back to the container default
+`Host=postgres`.
+
+**`NETSDK1226` on build** — incomplete workload data in the local .NET SDK, unrelated to this
+repository. Either run `dotnet workload repair`, or build with
+`-p:AllowMissingPrunePackageData=true`.
+
+**Dovecot restarts in a loop** — a configuration error. `docker compose -f
+docker-compose.test.yml logs dovecot` reports the offending line. Note that Dovecot does not
+accept several settings on one line inside a block.
+
+**The application returns HTTP 500 on every request** — usually the data protection key ring.
+Check that `DataProtection:KeyPath` points at a writable directory.

--- a/doc/LocalTestEnvironment.md
+++ b/doc/LocalTestEnvironment.md
@@ -85,8 +85,8 @@ accept the Dovecot certificate on port 1993.
 dotnet test tests/MailArchiver.Tests/MailArchiver.Tests.csproj
 ```
 
-Migrations are applied automatically by `TestDbFixture` on the first run. Of the 519 tests,
-about 330 need no database at all; the rest use PostgreSQL, so they fail with
+Migrations are applied automatically by `TestDbFixture` on the first run. Most tests need
+no database at all; the rest use PostgreSQL, so they fail with
 `Name or service not known` if the stack is not running.
 
 A connection string can also be supplied through the environment, which overrides every

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,66 @@
+# Local test environment for mail-archiver.
+#
+# Brings up the two backing services that the test suite and any IMAP work need,
+# both published on loopback so tools running on the host (dotnet test, dotnet run
+# --offload, an IMAP client) can reach them:
+#
+#   postgres  the archive database, on 5433 to avoid clashing with a local server
+#   dovecot   an IMAP target standing in for mailcow, on 1143 (plain) and 1993 (TLS)
+#
+# The application itself is deliberately not included. Running it from the host with
+# `dotnet run` iterates far faster than rebuilding the image, and the deployable
+# stack already lives in docker-compose.yml.
+#
+#   docker compose -f docker-compose.test.yml up -d      start
+#   docker compose -f docker-compose.test.yml down -v     stop and wipe all state
+#
+# NOT for production. Credentials are fixed and dovecot accepts any username.
+
+networks:
+  mailarchiver-test:
+
+volumes:
+  test-postgres-data:
+  test-dovecot-mail:
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: MailArchiver
+      POSTGRES_USER: mailuser
+      POSTGRES_PASSWORD: masterkey
+    ports:
+      - "127.0.0.1:5433:5432"
+    volumes:
+      - test-postgres-data:/var/lib/postgresql/data
+      # Creates the second (application) database on first initialisation.
+      - ./tests/postgres:/docker-entrypoint-initdb.d:ro
+    networks:
+      - mailarchiver-test
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mailuser -d MailArchiver"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  dovecot:
+    image: dovecot/dovecot:2.3-latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:1143:143"
+      - "127.0.0.1:1993:993"
+    volumes:
+      # Mounted as a single file so the image's self-signed cert.pem / key.pem remain.
+      - ./tests/dovecot/dovecot.conf:/etc/dovecot/dovecot.conf:ro
+      - test-dovecot-mail:/srv/mail
+    networks:
+      - mailarchiver-test
+    healthcheck:
+      test: ["CMD-SHELL", "doveadm who >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 # Local test environment for mail-archiver.
 #
 # Brings up the two backing services that the test suite and any IMAP work need,
-# both published on loopback so tools running on the host (dotnet test, dotnet run
+# both published on loopback so tools running on the host (dotnet test, dotnet run --
 # --offload, an IMAP client) can reach them:
 #
 #   postgres  the archive database, on 5433 to avoid clashing with a local server

--- a/tests/dovecot/dovecot.conf
+++ b/tests/dovecot/dovecot.conf
@@ -1,0 +1,82 @@
+## Local IMAP target for mail-archiver integration testing.
+##
+## Modelled on the dovecot/dovecot:2.3-latest default /etc/dovecot/dovecot.conf,
+## with only the differences needed to make this stand in for a mailcow target.
+## Mounted as a single file, so the image's own cert.pem / key.pem stay in place.
+##
+## NOT for production: the passdb below accepts any username.
+
+## mailcow stores mail as Maildir; the image default is sdbox.
+mail_home = /srv/mail/%Lu
+mail_location = maildir:~/Maildir
+mail_uid = 1000
+mail_gid = 1000
+
+first_valid_uid = 1000
+last_valid_uid = 1000
+
+## Only IMAP is needed here. The image default also starts pop3, submission,
+## sieve and lmtp, which would just add noise to the logs.
+protocols = imap
+
+## Test-only: every username authenticates with this one password, so extra
+## target mailboxes need no provisioning. Log in as anything you like, e.g.
+## offload-target@example.com / pass
+passdb {
+  driver = static
+  args = password=pass
+}
+
+ssl = yes
+ssl_cert = <cert.pem
+ssl_key = <key.pem
+
+## ImapConnectionFactory connects with SecureSocketOptions.None when the account
+## has UseSSL = false (Services/Providers/Imap/ImapConnectionFactory.cs:72).
+## Dovecot refuses plaintext auth on port 143 by default, so allow it here.
+disable_plaintext_auth = no
+auth_mechanisms = plain login
+
+namespace inbox {
+  inbox = yes
+  ## mailcow uses '/' as the hierarchy separator, and so does the image default.
+  ## ImapMailRestorer splits folder paths on '/' and '\', so this has to match.
+  separator = /
+
+  ## mailcow pre-creates the special-use folders. Having them here means an
+  ## Exchange source folder called "Sent Items" collides with an existing "Sent"
+  ## exactly as it will in production, which is what the FolderRenameMap exists
+  ## for. Without these the collision cannot be reproduced locally.
+  mailbox Drafts {
+    special_use = \Drafts
+    auto = subscribe
+  }
+  mailbox Junk {
+    special_use = \Junk
+    auto = subscribe
+  }
+  mailbox Sent {
+    special_use = \Sent
+    auto = subscribe
+  }
+  mailbox Trash {
+    special_use = \Trash
+    auto = subscribe
+  }
+}
+
+service imap-login {
+  process_min_avail = 1
+  client_limit = 1000
+  service_count = 0
+}
+
+listen = *
+
+log_path = /dev/stdout
+info_log_path = /dev/stdout
+debug_log_path = /dev/stdout
+
+verbose_proctitle = yes
+
+!include_try /etc/dovecot/conf.d/*.conf

--- a/tests/postgres/10-create-dev-db.sql
+++ b/tests/postgres/10-create-dev-db.sql
@@ -1,0 +1,11 @@
+-- Runs once, on first initialisation of the postgres volume.
+--
+-- Two databases so `dotnet test` and a manually run application do not share state:
+-- the test suite leaves fixture rows behind (mail accounts, users, log entries), which
+-- the application's background sync would otherwise pick up and try to sync.
+--
+--   MailArchiver     used by dotnet test        (tests/MailArchiver.Tests/appsettings.Test.json)
+--   MailArchiverDev  used by dotnet run         (appsettings.Development.json)
+--
+-- MailArchiver itself is created by the image from POSTGRES_DB.
+CREATE DATABASE "MailArchiverDev" OWNER mailuser;

--- a/tests/seed/fixtures/Archive__Projects__2020.mbox
+++ b/tests/seed/fixtures/Archive__Projects__2020.mbox
@@ -1,0 +1,24 @@
+From alice@source.example Fri Nov 20 00:00:00 2020
+X-Fixture-Purpose: three levels, recreated below the target root
+From: alice@source.example
+To: bob@target.example
+Subject: Deeply nested
+Date: Fri, 20 Nov 2020 00:00:00 +0000
+Message-ID: <deeply-nested-2100-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Sun Nov 15 00:00:00 2020
+X-Fixture-Purpose: second row in the deepest folder
+From: alice@source.example
+To: bob@target.example
+Subject: Deeply nested again
+Date: Sun, 15 Nov 2020 00:00:00 +0000
+Message-ID: <deeply-nested-again-2105-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+

--- a/tests/seed/fixtures/Deleted_Items.mbox
+++ b/tests/seed/fixtures/Deleted_Items.mbox
@@ -1,0 +1,12 @@
+From alice@source.example Thu Aug 06 00:00:00 2026
+X-Fixture-Purpose: should be excluded, and excluded before any rename
+From: alice@source.example
+To: bob@target.example
+Subject: Deleted mail
+Date: Thu, 06 Aug 2026 00:00:00 +0000
+Message-ID: <deleted-mail-15-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+

--- a/tests/seed/fixtures/Deleted_Items__Old.mbox
+++ b/tests/seed/fixtures/Deleted_Items__Old.mbox
@@ -1,0 +1,12 @@
+From alice@source.example Sun Dec 29 00:00:00 2024
+X-Fixture-Purpose: an exclusion on the parent has to cover descendants
+From: alice@source.example
+To: bob@target.example
+Subject: Old deleted mail
+Date: Sun, 29 Dec 2024 00:00:00 +0000
+Message-ID: <old-deleted-mail-600-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+

--- a/tests/seed/fixtures/INBOX.mbox
+++ b/tests/seed/fixtures/INBOX.mbox
@@ -58,7 +58,7 @@ Content-Type: text/plain; charset="utf-8"
 Fixture message.
 
 From alice@source.example Tue Jul 21 00:00:00 2026
-X-Fixture-Purpose: ImapMailRestorer.cs:854 refuses to emit this, so MimeKit invents a fresh random Message-Id on every append and the row duplicates each repetition
+X-Fixture-Purpose: ImapMailRestorer.cs:1196 refuses to emit this, so MimeKit invents a fresh random Message-Id on every append and the row duplicates each repetition
 From: alice@source.example
 To: bob@target.example
 Subject: Message-ID without an at sign

--- a/tests/seed/fixtures/INBOX.mbox
+++ b/tests/seed/fixtures/INBOX.mbox
@@ -1,0 +1,158 @@
+From alice@source.example Sat May 26 00:00:00 2012
+X-Fixture-Purpose: well before any plausible cutoff
+From: alice@source.example
+To: bob@target.example
+Subject: Ancient thread
+Date: Sat, 26 May 2012 00:00:00 +0000
+Message-ID: <ancient-thread-5200-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Thu Aug 17 00:00:00 2023
+X-Fixture-Purpose: inside a two year window, outside a six month one
+From: alice@source.example
+To: bob@target.example
+Subject: Mid-history note
+Date: Thu, 17 Aug 2023 00:00:00 +0000
+Message-ID: <mid-history-note-1100-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Wed Aug 12 00:00:00 2026
+X-Fixture-Purpose: inside every window a migration would use
+From: alice@source.example
+To: bob@target.example
+Subject: Recent note
+Date: Wed, 12 Aug 2026 00:00:00 +0000
+Message-ID: <recent-note-9-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Sat Aug 01 00:00:00 2026
+X-Fixture-Purpose: stored To carries ', ' but the import's dedup query builds ',' -- the separator mismatch in MailImporter.cs:35-37 vs :94-99
+From: alice@source.example
+To: bob@target.example, carol@target.example
+Subject: Two recipients
+Date: Sat, 01 Aug 2026 00:00:00 +0000
+Message-ID: <two-recipients-20-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Wed Jul 22 00:00:00 2026
+X-Fixture-Purpose: MessageId falls back to the deterministic GenerateFallbackMessageId, which does contain '@', so this row restores safely
+From: alice@source.example
+To: bob@target.example
+Subject: No Message-ID header
+Date: Wed, 22 Jul 2026 00:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Tue Jul 21 00:00:00 2026
+X-Fixture-Purpose: ImapMailRestorer.cs:854 refuses to emit this, so MimeKit invents a fresh random Message-Id on every append and the row duplicates each repetition
+From: alice@source.example
+To: bob@target.example
+Subject: Message-ID without an at sign
+Date: Tue, 21 Jul 2026 00:00:00 +0000
+Message-ID: <bare-token-no-at-sign>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Mon Jul 20 00:00:00 2026
+X-Fixture-Purpose: CleanText replaces chars below 32 with a space before storing, so a fingerprint built from the raw header will not match the stored column
+From: alice@source.example
+To: bob@target.example
+Subject: Subject with a control char  inside
+Date: Mon, 20 Jul 2026 00:00:00 +0000
+Message-ID: <subject-with-a-control-char---inside-32-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Sun Jul 12 00:00:00 2026
+Received: from mx3.target.example by next.hop.example with ESMTP id ABC0; Sun, 12 Jul 2026 00:00:00 +0000
+Received: from mx2.relay.example by next.hop.example with ESMTP id ABC1; Sat, 11 Jul 2026 23:58:00 +0000
+Received: from mx1.source.example by next.hop.example with ESMTP id ABC2; Sat, 11 Jul 2026 23:55:00 +0000
+X-Fixture-Purpose: has a full Received chain, so the INTERNALDATE fix has something to parse
+From: alice@source.example
+To: bob@target.example
+Subject: Delivered through three hops
+Date: Sun, 12 Jul 2026 00:00:00 +0000
+Message-ID: <delivered-through-three-hops-40-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Sat Jul 11 00:00:00 2026
+X-Fixture-Purpose: forces the INTERNALDATE fallback path; rows archived before RawHeaders existed look like this
+From: alice@source.example
+To: bob@target.example
+Subject: No Received headers at all
+Date: Sat, 11 Jul 2026 00:00:00 +0000
+Message-ID: <no-received-headers-at-all-41-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Thu Jul 02 00:00:00 2026
+X-Fixture-Purpose: import dedup SHOULD collapse this pair
+From: alice@source.example
+To: bob@target.example
+Subject: Near duplicate single recipient
+Date: Thu, 02 Jul 2026 00:00:00 +0000
+Message-ID: <near-duplicate-single-recipient-50-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Thu Jul 02 00:00:01 2026
+X-Fixture-Purpose: second half of the pair, 1s later
+From: alice@source.example
+To: bob@target.example
+Subject: Near duplicate single recipient
+Date: Thu, 02 Jul 2026 00:00:01 +0000
+Message-ID: <near-duplicate-single-recipient-50-1@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Wed Jul 01 00:00:00 2026
+X-Fixture-Purpose: import dedup should collapse this pair but cannot -- this is defect 4 made visible in the seeded data
+From: alice@source.example
+To: bob@target.example, carol@target.example
+Subject: Near duplicate two recipients
+Date: Wed, 01 Jul 2026 00:00:00 +0000
+Message-ID: <near-duplicate-two-recipients-51-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Wed Jul 01 00:00:01 2026
+X-Fixture-Purpose: second half of the pair, 1s later
+From: alice@source.example
+To: bob@target.example, carol@target.example
+Subject: Near duplicate two recipients
+Date: Wed, 01 Jul 2026 00:00:01 +0000
+Message-ID: <near-duplicate-two-recipients-51-1@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+

--- a/tests/seed/fixtures/Junk_E-Mail.mbox
+++ b/tests/seed/fixtures/Junk_E-Mail.mbox
@@ -1,0 +1,12 @@
+From alice@source.example Sat Aug 15 00:00:00 2026
+X-Fixture-Purpose: Exchange's name for it; either renamed to Junk or excluded
+From: alice@source.example
+To: bob@target.example
+Subject: Spam
+Date: Sat, 15 Aug 2026 00:00:00 +0000
+Message-ID: <spam-6-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+

--- a/tests/seed/fixtures/Sent_Items.mbox
+++ b/tests/seed/fixtures/Sent_Items.mbox
@@ -1,0 +1,24 @@
+From alice@source.example Sun Aug 09 00:00:00 2026
+X-Fixture-Purpose: collides with the target's existing special-use Sent
+From: alice@source.example
+To: bob@target.example
+Subject: Sent recently
+Date: Sun, 09 Aug 2026 00:00:00 +0000
+Message-ID: <sent-recently-12-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Sun Feb 28 00:00:00 2021
+X-Fixture-Purpose: same folder, outside a short cutoff
+From: alice@source.example
+To: bob@target.example
+Subject: Sent long ago
+Date: Sun, 28 Feb 2021 00:00:00 +0000
+Message-ID: <sent-long-ago-2000-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+

--- a/tests/seed/fixtures/Sent_Items_Archive.mbox
+++ b/tests/seed/fixtures/Sent_Items_Archive.mbox
@@ -1,0 +1,12 @@
+From alice@source.example Wed Jun 12 00:00:00 2024
+X-Fixture-Purpose: shares a prefix as a substring but not along a segment boundary, so a rename keyed on 'Sent Items' must leave this folder untouched
+From: alice@source.example
+To: bob@target.example
+Subject: Not a Sent Items subfolder
+Date: Wed, 12 Jun 2024 00:00:00 +0000
+Message-ID: <not-a-sent-items-subfolder-800-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+

--- a/tests/seed/fixtures/Sent_Items__2019.mbox
+++ b/tests/seed/fixtures/Sent_Items__2019.mbox
@@ -1,0 +1,24 @@
+From alice@source.example Sat Jan 25 00:00:00 2020
+X-Fixture-Purpose: the rename must rewrite the leading path segment only, giving Sent/2019
+From: alice@source.example
+To: bob@target.example
+Subject: Sent in a subfolder
+Date: Sat, 25 Jan 2020 00:00:00 +0000
+Message-ID: <sent-in-a-subfolder-2400-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+
+From alice@source.example Fri Dec 06 00:00:00 2019
+X-Fixture-Purpose: second row so the folder count is not 1
+From: alice@source.example
+To: bob@target.example
+Subject: Another subfolder message
+Date: Fri, 06 Dec 2019 00:00:00 +0000
+Message-ID: <another-subfolder-message-2450-0@source.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Fixture message.
+

--- a/tests/seed/fixtures/manifest.tsv
+++ b/tests/seed/fixtures/manifest.tsv
@@ -1,0 +1,8 @@
+INBOX.mbox	INBOX	13
+Sent_Items.mbox	Sent Items	2
+Sent_Items__2019.mbox	Sent Items/2019	2
+Sent_Items_Archive.mbox	Sent Items Archive	1
+Deleted_Items.mbox	Deleted Items	1
+Deleted_Items__Old.mbox	Deleted Items/Old	1
+Junk_E-Mail.mbox	Junk E-Mail	1
+Archive__Projects__2020.mbox	Archive/Projects/2020	2

--- a/tests/seed/seed.sh
+++ b/tests/seed/seed.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+#
+# Seed the local development archive with an Exchange-shaped source mailbox, and
+# register the local Dovecot instance as a restore/offload target.
+#
+# The fixtures in tests/seed/fixtures are imported with the application's own
+# --import-mbox CLI, so the rows land in exactly the format the IMAP sync would have
+# produced. Seeding the database directly would bypass MailImporter and could store,
+# for example, addresses joined differently from how the importer joins them.
+#
+# Each fixture message carries an X-Fixture-Purpose header explaining why it is there.
+#
+# Requires the local test stack:  docker compose -f docker-compose.test.yml up -d
+# And the schema to exist, which the application creates on first start:
+#   ASPNETCORE_ENVIRONMENT=Development ASPNETCORE_URLS=http://127.0.0.1:5000 \
+#     dotnet run --project MailArchiver.csproj
+#
+# Usage:
+#   tests/seed/seed.sh [--reset] [--db NAME]
+#
+#   --reset    delete previously seeded accounts and their mail first
+#   --db       database to seed (default: MailArchiverDev)
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+COMPOSE_FILE="docker-compose.test.yml"
+DB="MailArchiverDev"
+DB_USER="mailuser"
+RESET=0
+FIXTURE_DIR="$REPO_ROOT/tests/seed/fixtures"
+
+SOURCE_NAME="seed-source-exchange"
+SOURCE_EMAIL="alice@source.example"
+TARGET_NAME="seed-target-dovecot"
+TARGET_EMAIL="offload-target@example.com"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --db)     DB="$2"; shift 2 ;;
+    --reset)  RESET=1; shift ;;
+    -h|--help) sed -n '2,25p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+psql_q() { docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U "$DB_USER" -d "$DB" -tAc "$1"; }
+
+step() { printf '\n=== %s ===\n' "$1"; }
+
+# --------------------------------------------------------------- preconditions
+step "checking preconditions"
+if ! docker compose -f "$COMPOSE_FILE" ps --status running --services 2>/dev/null | grep -q postgres; then
+  echo "ERROR: the test stack is not running." >&2
+  echo "  docker compose -f $COMPOSE_FILE up -d" >&2
+  exit 1
+fi
+echo "test stack: running"
+
+if [[ "$(psql_q "select count(*) from information_schema.tables where table_schema='mail_archiver' and table_name='MailAccounts';")" != "1" ]]; then
+  echo "ERROR: database '$DB' has no schema yet. Start the application once so it applies migrations:" >&2
+  echo "  ASPNETCORE_ENVIRONMENT=Development ASPNETCORE_URLS=http://127.0.0.1:5000 dotnet run --project MailArchiver.csproj" >&2
+  exit 1
+fi
+echo "schema in $DB: present"
+
+DLL="bin/Debug/net10.0/MailArchiver.dll"
+if [[ ! -f "$DLL" ]]; then
+  echo "building (dll not found)..."
+  dotnet build MailArchiver.csproj -v q --nologo -p:AllowMissingPrunePackageData=true >/dev/null
+fi
+echo "binary: $DLL"
+
+# --------------------------------------------------------------- optional reset
+if [[ $RESET -eq 1 ]]; then
+  step "resetting previously seeded data"
+  for n in "$SOURCE_NAME" "$TARGET_NAME"; do
+    id="$(psql_q "select \"Id\" from mail_archiver.\"MailAccounts\" where \"Name\"='$n';" || true)"
+    if [[ -n "$id" ]]; then
+      # ArchivedEmails cascade from the account, but delete explicitly so the counts print.
+      removed="$(psql_q "with d as (delete from mail_archiver.\"ArchivedEmails\" where \"MailAccountId\"=$id returning 1) select count(*) from d;")"
+      psql_q "delete from mail_archiver.\"MailAccounts\" where \"Id\"=$id;" >/dev/null
+      echo "removed account '$n' (id $id) and $removed archived mails"
+    else
+      echo "no existing account '$n'"
+    fi
+  done
+fi
+
+# --------------------------------------------------------------- accounts
+# The source is created disabled and import-only: its server does not exist, so the
+# background sync service must leave it alone. The target has to be enabled, because the
+# offload path, the queued job path and the UI all refuse a disabled target mailbox.
+#
+# An enabled target would normally be synced, which would archive the mail an offload just
+# appended straight back into the archive under the target account. That is only noise for
+# testing, so the target gets a per-account sync interval of a year to keep the background
+# service away from it. Note that IsImportOnly does not help here: the column exists in the
+# schema but is not read anywhere in the code.
+step "ensuring accounts"
+# Only the id goes to stdout; progress goes to stderr. psql prints the command tag
+# alongside a RETURNING value, so the id is read back with a separate SELECT instead.
+ensure_account() {
+  local name="$1" email="$2" server="$3" port="$4" user="$5" pass="$6" ssl="$7" importonly="$8" enabled="${9:-false}"
+  local id
+  id="$(psql_q "select \"Id\" from mail_archiver.\"MailAccounts\" where \"Name\"='$name';" || true)"
+  if [[ -z "$id" ]]; then
+    psql_q "insert into mail_archiver.\"MailAccounts\"
+            (\"Name\",\"EmailAddress\",\"ImapServer\",\"ImapPort\",\"Username\",\"Password\",
+             \"UseSSL\",\"LastSync\",\"IsEnabled\",\"ExcludedFolders\",\"IsImportOnly\",\"Provider\")
+          values ('$name','$email','$server',$port,'$user','$pass',
+             $ssl, now(), $enabled, '', $importonly, 'IMAP');" >/dev/null
+    # A year, so the background sync service effectively never picks this account up.
+    psql_q "update mail_archiver.\"MailAccounts\" set \"SyncIntervalMinutes\"=525600
+            where \"Name\"='$name';" >/dev/null
+    id="$(psql_q "select \"Id\" from mail_archiver.\"MailAccounts\" where \"Name\"='$name';")"
+    echo "created '$name' -> id $id" >&2
+  else
+    echo "reusing '$name' -> id $id" >&2
+  fi
+  printf '%s' "$id"
+}
+
+SOURCE_ID="$(ensure_account "$SOURCE_NAME" "$SOURCE_EMAIL" "imap.source.invalid" 993 "$SOURCE_EMAIL" "unused" false true  false)"
+TARGET_ID="$(ensure_account "$TARGET_NAME" "$TARGET_EMAIL" "localhost"           1143 "$TARGET_EMAIL" "pass"   false false true)"
+
+if [[ -z "$SOURCE_ID" || -z "$TARGET_ID" ]]; then
+  echo "ERROR: could not resolve account ids (source='$SOURCE_ID' target='$TARGET_ID')" >&2
+  exit 1
+fi
+
+# --------------------------------------------------------------- fixtures
+step "checking fixtures"
+if [[ ! -f "$FIXTURE_DIR/manifest.tsv" ]]; then
+  echo "ERROR: no manifest at $FIXTURE_DIR/manifest.tsv" >&2
+  exit 1
+fi
+while IFS=$'\t' read -r file folder count; do
+  [[ -f "$FIXTURE_DIR/$file" ]] || { echo "ERROR: missing fixture $file" >&2; exit 1; }
+done < "$FIXTURE_DIR/manifest.tsv"
+# Actual SentDate ranges are reported per folder from the database further down, once
+# the importer has parsed and converted them.
+printf 'found %s mbox files, %s messages\n' \
+  "$(wc -l < "$FIXTURE_DIR/manifest.tsv")" \
+  "$(awk -F'\t' '{n+=$3} END {print n}' "$FIXTURE_DIR/manifest.tsv")"
+
+# --------------------------------------------------------------- import
+# LocalImport:AllowedPaths defaults to /app/imports and the CLI enforces it, so the
+# fixture directory is allowed through the environment rather than by editing
+# appsettings.Development.json.
+step "importing fixtures into account $SOURCE_ID"
+export ASPNETCORE_ENVIRONMENT=Development
+export LocalImport__AllowedPaths__0="$FIXTURE_DIR"
+
+# Exit code handling. MBoxImportService.cs:274 sets CompletedWithErrors when
+# SkippedAlreadyExistsCount > 0, and Program.cs:669 exits 1 for any status other than
+# Completed. So a re-run that correctly skips duplicates -- the expected outcome of
+# importing the same file twice -- also exits 1. The real failure signals are the
+# failed and malformed counts, so those are what is checked here.
+imported=0
+dupes_total=0
+while IFS=$'\t' read -r file folder count; do
+  printf '  %-28s <- %-30s (%2s msg) ... ' "$folder" "$file" "$count"
+  set +e
+  out="$(dotnet "$DLL" --import-mbox --file "$FIXTURE_DIR/$file" \
+           --account-id "$SOURCE_ID" --folder "$folder" 2>&1)"
+  rc=$?
+  set -e
+
+  ok_line="$(printf '%s\n' "$out" | grep -E '^Imported Successfully:' | head -1)"
+  failed="$(printf '%s\n' "$out" | sed -n 's/^Failed: *\([0-9]*\).*/\1/p' | head -1)"
+  malformed="$(printf '%s\n' "$out" | sed -n 's/^Skipped (malformed): *\([0-9]*\).*/\1/p' | head -1)"
+  dupes="$(printf '%s\n' "$out" | sed -n 's/^Skipped (duplicates): *\([0-9]*\).*/\1/p' | head -1)"
+  ok_n="${ok_line##*: }"
+
+  if [[ -z "$ok_line" || "${failed:-1}" != "0" || "${malformed:-1}" != "0" ]]; then
+    echo "FAILED (exit $rc)"
+    printf '%s\n' "$out" | tail -25 >&2
+    exit 1
+  fi
+
+  if [[ "${dupes:-0}" != "0" ]]; then
+    echo "ok ($ok_n imported, ${dupes} already present)"
+  else
+    echo "ok ($ok_n imported)"
+  fi
+  imported=$((imported + 1))
+  dupes_total=$((dupes_total + ${dupes:-0}))
+done < "$FIXTURE_DIR/manifest.tsv"
+echo "$imported mbox files processed, $dupes_total message(s) skipped as already present"
+
+# --------------------------------------------------------------- verification
+step "what landed in the archive"
+psql_q "select \"FolderName\" || '  |  ' || count(*) || ' mails  |  ' ||
+               to_char(min(\"SentDate\"),'YYYY-MM-DD') || ' .. ' ||
+               to_char(max(\"SentDate\"),'YYYY-MM-DD')
+        from mail_archiver.\"ArchivedEmails\" where \"MailAccountId\"=$SOURCE_ID
+        group by \"FolderName\" order by 1;" | sed 's/^/  /'
+
+total="$(psql_q "select count(*) from mail_archiver.\"ArchivedEmails\" where \"MailAccountId\"=$SOURCE_ID;")"
+echo "  ----"
+echo "  total: $total"
+
+step "edge cases available for testing"
+psql_q "select
+    'Message-ID without @        : ' || count(*) filter (where \"MessageId\" <> '' and \"MessageId\" not like '%@%') || E'\n' ||
+    'deterministic fallback IDs  : ' || count(*) filter (where \"MessageId\" like '%@mail-archiver.local') || E'\n' ||
+    'rows with 2+ To recipients  : ' || count(*) filter (where \"To\" like '%,%') || E'\n' ||
+    'rows with a Received chain  : ' || count(*) filter (where \"RawHeaders\" ilike '%Received:%')
+  from mail_archiver.\"ArchivedEmails\" where \"MailAccountId\"=$SOURCE_ID;" | sed 's/^/  /'
+
+step "import de-duplication, defect 4 made visible"
+psql_q "select \"Subject\" || '  ->  ' || count(*) || ' row(s) stored'
+        from mail_archiver.\"ArchivedEmails\"
+        where \"MailAccountId\"=$SOURCE_ID and \"Subject\" like 'Near duplicate%'
+        group by \"Subject\" order by 1;" | sed 's/^/  /'
+echo "  Each pair was one second apart with distinct Message-IDs."
+echo "  The single-recipient pair collapses to 1 row; the two-recipient pair does not,"
+echo "  because the dedup query joins addresses with ',' while the stored column uses ', '."
+
+cat <<SUMMARY
+
+=== ready ===
+  source account id : $SOURCE_ID  ($SOURCE_NAME, import-only, sync disabled)
+  target account id : $TARGET_ID  ($TARGET_NAME -> localhost:1143, password 'pass')
+  fixtures          : $FIXTURE_DIR
+
+The target mailbox already holds Dovecot's special-use folders (Sent, Trash, Junk,
+Drafts), so the source folder 'Sent Items' collides with the existing 'Sent' exactly
+as it would against mailcow.
+SUMMARY

--- a/tests/seed/seed.sh
+++ b/tests/seed/seed.sh
@@ -95,15 +95,19 @@ fi
 # offload path, the queued job path and the UI all refuse a disabled target mailbox.
 #
 # An enabled target would normally be synced, which would archive the mail an offload just
-# appended straight back into the archive under the target account. That is only noise for
-# testing, so the target gets a per-account sync interval of a year to keep the background
-# service away from it. Note that IsImportOnly does not help here: the column exists in the
-# schema but is not read anywhere in the code.
+# appended straight back into the archive under the target account. The target therefore gets
+# a per-account sync interval of a year. That keeps the background sync service away only
+# within one process lifetime: the scheduling state is in-memory, so every application
+# restart schedules the target once, immediately (MailSyncBackgroundService initialises
+# nextRunUtc to nowUtc for accounts it has not seen). The target's ExcludedFolders therefore
+# also list the Dovecot special-use folders, so that one restart sync has nothing to archive.
+# Note that IsImportOnly does not help here: the column exists in the schema but is not read
+# anywhere in the code.
 step "ensuring accounts"
 # Only the id goes to stdout; progress goes to stderr. psql prints the command tag
 # alongside a RETURNING value, so the id is read back with a separate SELECT instead.
 ensure_account() {
-  local name="$1" email="$2" server="$3" port="$4" user="$5" pass="$6" ssl="$7" importonly="$8" enabled="${9:-false}"
+  local name="$1" email="$2" server="$3" port="$4" user="$5" pass="$6" ssl="$7" importonly="$8" enabled="${9:-false}" excluded="${10:-}"
   local id
   id="$(psql_q "select \"Id\" from mail_archiver.\"MailAccounts\" where \"Name\"='$name';" || true)"
   if [[ -z "$id" ]]; then
@@ -111,7 +115,7 @@ ensure_account() {
             (\"Name\",\"EmailAddress\",\"ImapServer\",\"ImapPort\",\"Username\",\"Password\",
              \"UseSSL\",\"LastSync\",\"IsEnabled\",\"ExcludedFolders\",\"IsImportOnly\",\"Provider\")
           values ('$name','$email','$server',$port,'$user','$pass',
-             $ssl, now(), $enabled, '', $importonly, 'IMAP');" >/dev/null
+             $ssl, now(), $enabled, '$excluded', $importonly, 'IMAP');" >/dev/null
     # A year, so the background sync service effectively never picks this account up.
     psql_q "update mail_archiver.\"MailAccounts\" set \"SyncIntervalMinutes\"=525600
             where \"Name\"='$name';" >/dev/null
@@ -123,8 +127,11 @@ ensure_account() {
   printf '%s' "$id"
 }
 
+# ExcludedFolders is semicolon-separated (MailAccount.ExcludedFoldersList). The target
+# excludes Dovecot's special-use folders so the single sync an application restart
+# schedules finds nothing to archive.
 SOURCE_ID="$(ensure_account "$SOURCE_NAME" "$SOURCE_EMAIL" "imap.source.invalid" 993 "$SOURCE_EMAIL" "unused" false true  false)"
-TARGET_ID="$(ensure_account "$TARGET_NAME" "$TARGET_EMAIL" "localhost"           1143 "$TARGET_EMAIL" "pass"   false false true)"
+TARGET_ID="$(ensure_account "$TARGET_NAME" "$TARGET_EMAIL" "localhost"           1143 "$TARGET_EMAIL" "pass"   false false true 'INBOX;Drafts;Junk;Sent;Trash')"
 
 if [[ -z "$SOURCE_ID" || -z "$TARGET_ID" ]]; then
   echo "ERROR: could not resolve account ids (source='$SOURCE_ID' target='$TARGET_ID')" >&2


### PR DESCRIPTION
There is no IMAP test target in the repository. The two existing IMAP test classes cover pure logic around the protocol rather than the protocol itself, so the append path, folder creation and bulk fetch have no automated coverage, and 188 of the 519 tests need a PostgreSQL that nothing provides.

docker-compose.test.yml brings up both backing services on loopback: PostgreSQL on 5433, and Dovecot on 1143 and 1993. The application is deliberately not included, because running it from the host iterates faster than rebuilding the image.

The Dovecot configuration is modelled on the image's own default, with three differences that make it behave like a real target: Maildir storage rather than sdbox, "/" as the hierarchy separator, and the special-use folders Drafts, Junk, Sent and Trash pre-created. That last one matters for migration testing, because it reproduces the collision between an Exchange "Sent Items" and an existing "Sent".

Two databases are created so that `dotnet test` and a manually run application do not share state; a full test run leaves several dozen fixture accounts behind, which the background sync would otherwise try to reach.

tests/seed seeds an Exchange-shaped archive from checked-in mbox fixtures through the application's own --import-mbox CLI, so the rows land in exactly the format the IMAP sync would have produced. Each fixture message carries an X-Fixture-Purpose header explaining why it is there.