### PR TITLE
Fix --import-mbox exit code for repeated imports

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -669,7 +669,7 @@ if (cliArgs.Any(a => a == "--import-mbox" || a == "--import-eml"))
                 if (!string.IsNullOrEmpty(result.ErrorMessage))
                     Console.WriteLine($"Errors: {result.ErrorMessage}");
                 
-                Environment.Exit(result.Status == MBoxImportJobStatus.Completed ? 0 : 1);
+                Environment.Exit(MBoxImportExitCode.For(result.Status, result.FailedCount, result.SkippedMalformedCount));
             }
             else
             {
@@ -1135,3 +1135,35 @@ if (mcpOptions.Enabled)
 }
 
 app.Run();
+
+/// <summary>
+/// Decides the process exit code for an <c>--import-mbox</c> run.
+/// <para>
+/// A repeated import used to exit non-zero although nothing had gone wrong. The job status
+/// alone cannot carry that distinction: <see cref="MBoxImportJobStatus.CompletedWithErrors"/>
+/// is set when anything at all was not imported cleanly, and skipped duplicates count towards
+/// that. Re-importing the same mbox therefore looked like a failure to any script driving the
+/// CLI, even though skipping what is already archived is the correct and expected outcome.
+/// </para>
+/// <para>
+/// So the status is no longer the whole answer, but it cannot be dropped either. Deriving the
+/// exit code purely from the counters would report success for a cancelled or crashed import,
+/// because those paths abandon the run without setting <c>FailedCount</c> or
+/// <c>SkippedMalformedCount</c>. Both halves are needed: the run has to have reached a
+/// completed status, <em>and</em> nothing may have failed or been malformed.
+/// </para>
+/// <para>
+/// Duplicates are deliberately absent from the failure conditions — they are the case this
+/// fixes. The status the UI shows is unchanged; only the exit code is derived differently.
+/// </para>
+/// </summary>
+internal static class MBoxImportExitCode
+{
+    public static int For(MBoxImportJobStatus status, int failedCount, int skippedMalformedCount)
+    {
+        var reachedCompletion = status == MBoxImportJobStatus.Completed
+                             || status == MBoxImportJobStatus.CompletedWithErrors;
+
+        return reachedCompletion && failedCount == 0 && skippedMalformedCount == 0 ? 0 : 1;
+    }
+}

--- a/tests/MailArchiver.Tests/Services/MBoxImportExitCodeTests.cs
+++ b/tests/MailArchiver.Tests/Services/MBoxImportExitCodeTests.cs
@@ -1,0 +1,67 @@
+using MailArchiver.Models;
+using Xunit;
+
+namespace MailArchiver.Tests.Services
+{
+    /// <summary>
+    /// The exit code of an <c>--import-mbox</c> run.
+    /// <para>
+    /// The case that motivated the fix is <see cref="RepeatedImport_OnlyDuplicates_ExitsZero"/>:
+    /// re-importing an mbox that is already archived skips every message, which sets
+    /// <c>CompletedWithErrors</c>, which used to be reported as a failure.
+    /// </para>
+    /// </summary>
+    public class MBoxImportExitCodeTests
+    {
+        [Fact]
+        public void CleanImport_ExitsZero()
+        {
+            Assert.Equal(0, MBoxImportExitCode.For(MBoxImportJobStatus.Completed, 0, 0));
+        }
+
+        [Fact]
+        public void RepeatedImport_OnlyDuplicates_ExitsZero()
+        {
+            // Every message skipped as already present. The job reports CompletedWithErrors,
+            // but nothing actually went wrong.
+            Assert.Equal(0, MBoxImportExitCode.For(MBoxImportJobStatus.CompletedWithErrors, 0, 0));
+        }
+
+        [Theory]
+        [InlineData(MBoxImportJobStatus.Completed)]
+        [InlineData(MBoxImportJobStatus.CompletedWithErrors)]
+        public void FailedMessages_ExitNonZero(MBoxImportJobStatus status)
+        {
+            Assert.Equal(1, MBoxImportExitCode.For(status, 1, 0));
+        }
+
+        [Theory]
+        [InlineData(MBoxImportJobStatus.Completed)]
+        [InlineData(MBoxImportJobStatus.CompletedWithErrors)]
+        public void MalformedMessages_ExitNonZero(MBoxImportJobStatus status)
+        {
+            Assert.Equal(1, MBoxImportExitCode.For(status, 0, 1));
+        }
+
+        /// <summary>
+        /// The reason the status test cannot be dropped in favour of the counters alone: these
+        /// paths abandon the run without ever setting a counter, so a pure counter check would
+        /// report success for an import that never finished.
+        /// </summary>
+        [Theory]
+        [InlineData(MBoxImportJobStatus.Cancelled)]
+        [InlineData(MBoxImportJobStatus.Failed)]
+        [InlineData(MBoxImportJobStatus.Queued)]
+        [InlineData(MBoxImportJobStatus.Running)]
+        public void UnfinishedRun_ExitsNonZero_EvenWithNoCounters(MBoxImportJobStatus status)
+        {
+            Assert.Equal(1, MBoxImportExitCode.For(status, 0, 0));
+        }
+
+        [Fact]
+        public void FailedRun_WithCounters_ExitsNonZero()
+        {
+            Assert.Equal(1, MBoxImportExitCode.For(MBoxImportJobStatus.Failed, 3, 2));
+        }
+    }
+}


### PR DESCRIPTION
A repeated mbox import exited non-zero although nothing had gone wrong. MBoxImportService sets CompletedWithErrors when anything at all was not imported cleanly, and skipped duplicates count towards that, so re-importing an already archived mbox looked like a failure to any script driving the CLI.

The status alone cannot carry the distinction, but it cannot be dropped either: deriving the exit code purely from the counters would report success for a cancelled or crashed import, because those paths abandon the run without setting FailedCount or SkippedMalformedCount. The run now has to have reached a completed status and have nothing failed or malformed. Duplicates are deliberately not a failure condition.

MBoxImportService is unchanged, so the status shown in the UI stays as it is. The EML path needs no equivalent change: EmlImportService never sets CompletedWithErrors and has no malformed counter, so its existing status test is already exact.

# Details

A repeated mbox import exits non-zero although nothing went wrong, so any script driving
`--import-mbox` sees a failure where the correct outcome was "everything is already archived".

`MBoxImportService` sets `CompletedWithErrors` whenever anything at all was not imported cleanly,
and skipped duplicates count towards that:

```csharp
if (job.FailedCount > 0 || job.SkippedMalformedCount > 0 || job.SkippedAlreadyExistsCount > 0)
{
    job.Status = MBoxImportJobStatus.CompletedWithErrors;
```

The CLI then tested for `Completed` exactly, so re-running the same mbox reported failure.

## The fix

One production file. `MBoxImportService` is untouched, so the status shown in the UI is
unchanged — only the exit code is derived differently.

```csharp
Environment.Exit(MBoxImportExitCode.For(result.Status, result.FailedCount, result.SkippedMalformedCount));
```

```csharp
var reachedCompletion = status == MBoxImportJobStatus.Completed
                     || status == MBoxImportJobStatus.CompletedWithErrors;

return reachedCompletion && failedCount == 0 && skippedMalformedCount == 0 ? 0 : 1;
```

**Both halves are load-bearing.** Dropping the status test and deriving the exit code purely from
the counters looks equivalent and is not: `Cancelled` and `Failed` are set in catch blocks that
abandon the run without setting `FailedCount` or `SkippedMalformedCount`, so a counter-only check
would report success for an import that never finished. Equally, the status alone cannot
distinguish duplicates from real problems. The run has to have reached a completed status *and*
have nothing failed or malformed.

Duplicates are deliberately absent from the failure conditions — they are the case this fixes.

The decision sits in a small `internal static` helper at the end of `Program.cs` rather than
inline, so it can be tested directly. It is a boolean that is easy to get backwards and produces
no error when it is.

## The EML path needs nothing

`EmlImportService` sets `Completed` unconditionally on the success path and has no
`CompletedWithErrors` branch at all, and `SkippedMalformedCount` exists only on
`MBoxImportJob`. Its existing status test is therefore already exact, and is left alone.

## Tests

11 new cases. The two that pin the reasoning:

- a repeated import reporting `CompletedWithErrors` with no failures and no malformed messages
  exits **0** — this is the reported defect, and it fails against the old code
- `Cancelled`, `Failed`, `Queued` and `Running` with all counters at zero exit **1** — this fails
  against a counter-only implementation

Plus clean completion, failed messages and malformed messages under both completed statuses.

Full suite: 635 passing, 1 skipped, 0 failing.