### PR TITLE
Compare duplicates against the stored format, not the parsed one

### DIFF
--- a/Services/Providers/Graph/GraphMailArchiver.cs
+++ b/Services/Providers/Graph/GraphMailArchiver.cs
@@ -133,26 +133,43 @@ namespace MailArchiver.Services.Providers.Graph
         {
             try
             {
-                var checkFrom = message.From?.EmailAddress?.Address ?? "";
-                var checkTo = string.Join(",", message.ToRecipients?.Select(r => r.EmailAddress?.Address) ?? new List<string>());
-                var checkSubject = message.Subject ?? "(No Subject)";
-                var checkDate = message.SentDateTime?.DateTime ?? DateTime.UtcNow;
+                // Normalized into the format the row was written in, because the column side of
+                // the comparison is already fixed. Joining with "," where the row holds ", " or
+                // comparing an uncleaned subject silently disables this criterion for any
+                // message with two or more recipients.
+                var checkFrom = MailMatchKey.NormalizeAddresses(
+                    new[] { message.From?.EmailAddress?.Address }.Where(a => a != null)!,
+                    MailMatchKey.FromMaxBytes);
+                var checkTo = MailMatchKey.NormalizeAddresses(
+                    message.ToRecipients?.Select(r => r.EmailAddress?.Address).Where(a => a != null)!,
+                    MailMatchKey.ToMaxBytes);
+                var checkSubject = MailMatchKey.NormalizeSubject(message.Subject);
+
+                // SentDate is stored converted into the display timezone (see convertedSentDate
+                // on the write path), so the incoming value has to be converted the same way
+                // before the two-second window is applied. This mirrors that expression exactly,
+                // including which overload it calls: passing SentDateTime?.DateTime instead would
+                // hand over a DateTime of Kind Unspecified, which ConvertToDisplayTimeZone
+                // returns untouched, quietly reintroducing the mismatch this is fixing.
+                var checkDate = message.SentDateTime.HasValue
+                    ? _dateTimeHelper.ConvertToDisplayTimeZone(message.SentDateTime.Value)
+                    : _dateTimeHelper.ConvertToDisplayTimeZone(DateTime.UtcNow);
+                var toleranceSeconds = MailMatchKey.TimestampToleranceSeconds;
 
                 // Legacy rows archived before the write-side normalization may store the
-                // Message-ID with surrounding angle brackets - match both variants so
+                // Message-ID with surrounding angle brackets - match every variant so
                 // existing archives are still recognized as duplicates.
-                var bracketedMessageId = "<" + messageId + ">";
+                var messageIdCandidates = MailContentHelper.MessageIdMatchCandidates(messageId).ToList();
 
                 var existingInfo = await _context.ArchivedEmails
                     .AsNoTracking()
                     .Where(e => e.MailAccountId == accountId)
                     .Where(e =>
-                        e.MessageId == messageId ||
-                        e.MessageId == bracketedMessageId ||
+                        messageIdCandidates.Contains(e.MessageId) ||
                         (e.From == checkFrom &&
                          e.To == checkTo &&
                          e.Subject == checkSubject &&
-                         Math.Abs((e.SentDate - checkDate).TotalSeconds) < 2)
+                         Math.Abs((e.SentDate - checkDate).TotalSeconds) < toleranceSeconds)
                     )
                     .Select(e => new { e.Id, e.FolderName, e.Subject })
                     .FirstOrDefaultAsync();

--- a/Services/Providers/Graph/GraphMailRestorer.cs
+++ b/Services/Providers/Graph/GraphMailRestorer.cs
@@ -126,7 +126,7 @@ namespace MailArchiver.Services.Providers.Graph
                 // Normalize the stored Message-ID (legacy Graph rows may carry surrounding
                 // angle brackets) and re-emit it in the bracketed RFC 2822 form that Exchange
                 // itself generates, so a restored message roundtrips to the same canonical id.
-                var restorableMessageId = MailContentHelper.NormalizeMessageId(email.MessageId);
+                var restorableMessageId = MailContentHelper.ToRestorableMessageId(email.MessageId);
                 var internetMessageId = string.IsNullOrEmpty(restorableMessageId) ? null : "<" + restorableMessageId + ">";
 
                 var message = new Message

--- a/Services/Providers/Graph/GraphMailSyncService.cs
+++ b/Services/Providers/Graph/GraphMailSyncService.cs
@@ -769,12 +769,13 @@ namespace MailArchiver.Services.Providers.Graph
                                     // Legacy rows archived before the write-side normalization store
                                     // the Message-ID with surrounding angle brackets. Match both
                                     // variants so existing archives are recognized as archived.
-                                    var bracketedMessageId = "<" + normalizedMessageId + ">";
+                                    var messageIdCandidates = MailContentHelper
+                                        .MessageIdMatchCandidates(normalizedMessageId).ToList();
 
                                     var archivedEmailId = await _context.ArchivedEmails
                                         .AsNoTracking()
                                         .Where(e => e.MailAccountId == account.Id)
-                                        .Where(e => e.MessageId == normalizedMessageId || e.MessageId == bracketedMessageId)
+                                        .Where(e => messageIdCandidates.Contains(e.MessageId))
                                         .Select(e => (int?)e.Id)
                                         .FirstOrDefaultAsync();
 

--- a/Services/Providers/Imap/ImapMailRestorer.cs
+++ b/Services/Providers/Imap/ImapMailRestorer.cs
@@ -1191,9 +1191,13 @@ namespace MailArchiver.Services.Providers.Imap
                 // Both represent the same instant; only the rendered offset differs.
                 message.Date = _dateTimeHelper.ToDisplayTimeZoneOffset(email.SentDate);
                 // Normalize the stored Message-ID (legacy Graph rows may carry surrounding
-                // angle brackets) so MimeKit emits a single well-formed bracket pair.
-                var restorableMessageId = MailContentHelper.NormalizeMessageId(email.MessageId);
-                if (!string.IsNullOrEmpty(restorableMessageId) && restorableMessageId.Contains('@'))
+                // angle brackets) so MimeKit emits a single well-formed bracket pair. Values
+                // that are present but unusable as a msg-id are replaced by a deterministic
+                // identifier rather than dropped: dropping one let MimeKit invent a fresh
+                // random Message-Id on every append, so repeated appends of the same row could
+                // never be recognized as duplicates and multiplied each time.
+                var restorableMessageId = MailContentHelper.ToRestorableMessageId(email.MessageId);
+                if (!string.IsNullOrEmpty(restorableMessageId))
                 {
                     message.MessageId = restorableMessageId;
                 }

--- a/Services/Providers/Imap/TargetMailboxIndex.cs
+++ b/Services/Providers/Imap/TargetMailboxIndex.cs
@@ -186,14 +186,14 @@ namespace MailArchiver.Services.Providers.Imap
 
                 IndexedMessages++;
 
-                var messageIdKey = OffloadMatchKey.MessageIdKey(envelope.MessageId);
+                var messageIdKey = MailMatchKey.MessageIdKey(envelope.MessageId);
                 if (messageIdKey.HasValue)
                 {
                     _messageIdKeys.Add(messageIdKey.Value);
                 }
 
                 AddFingerprint(
-                    OffloadMatchKey.FingerprintKeyFromAddresses(
+                    MailMatchKey.FingerprintKeyFromAddresses(
                         envelope.From?.Mailboxes.Select(m => m.Address),
                         envelope.To?.Mailboxes.Select(m => m.Address),
                         envelope.Subject),
@@ -235,18 +235,18 @@ namespace MailArchiver.Services.Providers.Imap
         /// </summary>
         public OffloadMatchKind Match(ArchivedEmail email)
         {
-            var messageIdKey = OffloadMatchKey.MessageIdKey(email.MessageId);
+            var messageIdKey = MailMatchKey.MessageIdKey(email.MessageId);
             if (messageIdKey.HasValue && _messageIdKeys.Contains(messageIdKey.Value))
             {
                 return OffloadMatchKind.MessageId;
             }
 
-            var fingerprint = OffloadMatchKey.FingerprintKeyFromStored(email);
+            var fingerprint = MailMatchKey.FingerprintKeyFromStored(email);
             if (_fingerprints.TryGetValue(fingerprint, out var timestamps))
             {
                 foreach (var candidate in timestamps)
                 {
-                    if (OffloadMatchKey.WithinTolerance(candidate, email.SentDate))
+                    if (MailMatchKey.WithinTolerance(candidate, email.SentDate))
                     {
                         return OffloadMatchKind.Fingerprint;
                     }
@@ -263,13 +263,13 @@ namespace MailArchiver.Services.Providers.Imap
         /// </summary>
         public void Add(ArchivedEmail email)
         {
-            var messageIdKey = OffloadMatchKey.MessageIdKey(email.MessageId);
+            var messageIdKey = MailMatchKey.MessageIdKey(email.MessageId);
             if (messageIdKey.HasValue)
             {
                 _messageIdKeys.Add(messageIdKey.Value);
             }
 
-            AddFingerprint(OffloadMatchKey.FingerprintKeyFromStored(email), email.SentDate);
+            AddFingerprint(MailMatchKey.FingerprintKeyFromStored(email), email.SentDate);
             IndexedMessages++;
         }
 
@@ -281,9 +281,9 @@ namespace MailArchiver.Services.Providers.Imap
         /// </summary>
         internal void AddRaw(string? messageId, string? from, string? to, string? subject, DateTime sentDate)
         {
-            var key = OffloadMatchKey.MessageIdKey(messageId);
+            var key = MailMatchKey.MessageIdKey(messageId);
             if (key.HasValue) _messageIdKeys.Add(key.Value);
-            AddFingerprint(OffloadMatchKey.FingerprintKeyFromStored(from, to, subject), sentDate);
+            AddFingerprint(MailMatchKey.FingerprintKeyFromStored(from, to, subject), sentDate);
             IndexedMessages++;
         }
     }

--- a/Services/Shared/MailContentHelper.cs
+++ b/Services/Shared/MailContentHelper.cs
@@ -126,6 +126,63 @@ namespace MailArchiver.Services.Shared
         }
 
         /// <summary>
+        /// The Message-ID a stored row is re-emitted with when it is restored or appended.
+        /// <para>
+        /// A stored value that is missing entirely yields <see cref="string.Empty"/>, leaving the
+        /// provider to generate one. A value carrying an <c>@</c> is returned normalized. A value
+        /// that is present but has no <c>@</c> — legacy rows archived before the fallback
+        /// generator existed — is replaced by a deterministic synthetic identifier derived from
+        /// it.
+        /// </para>
+        /// <para>
+        /// That last case is the point of this method. Such a value is not a usable msg-id, so
+        /// the restore path used to drop it and let MimeKit invent a fresh random one. That made
+        /// every append of the same row produce a different Message-ID, so the copies could never
+        /// be recognized as duplicates of each other and multiplied on every repetition. Deriving
+        /// the replacement from the stored value instead makes it stable across runs.
+        /// </para>
+        /// <para>
+        /// Whatever this returns is what a duplicate check may rely on being present on the
+        /// target, which is why the match keys are built from this method rather than from the
+        /// raw column.
+        /// </para>
+        /// </summary>
+        public static string ToRestorableMessageId(string? storedMessageId)
+        {
+            var normalized = NormalizeMessageId(storedMessageId);
+            if (normalized.Length == 0) return string.Empty;
+            if (normalized.Contains('@')) return normalized;
+
+            var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+            var hashString = Convert.ToBase64String(hashBytes)
+                .Replace("+", "-").Replace("/", "_").Substring(0, 16);
+            return $"legacy-{hashString}@mail-archiver.local";
+        }
+
+        /// <summary>
+        /// The set of stored values that should be treated as the same Message-ID when looking a
+        /// row up by it.
+        /// <para>
+        /// Rows have been written with and without surrounding angle brackets over the project's
+        /// history — the Graph pipeline stored <c>InternetMessageId</c> verbatim before the
+        /// write-side normalization was introduced. A lookup that compares only the normalized
+        /// form therefore misses its own older rows, which is the shape behind several reports of
+        /// mail never being recognized again after archiving.
+        /// </para>
+        /// <para>
+        /// Returns an empty list for a missing identifier, so a caller can skip the criterion
+        /// entirely rather than matching on an empty string.
+        /// </para>
+        /// </summary>
+        public static IReadOnlyList<string> MessageIdMatchCandidates(string? messageId)
+        {
+            var normalized = NormalizeMessageId(messageId);
+            if (normalized.Length == 0) return Array.Empty<string>();
+
+            return new[] { normalized, "<" + normalized + ">" };
+        }
+
+        /// <summary>
         /// Builds a canonical string representation of a header list: one
         /// <c>Field: Value</c> line per header, in original order, joined by newlines.
         /// Used as a per-delivery discriminator for the fallback Message-ID (the Received

--- a/Services/Shared/MailImporter.cs
+++ b/Services/Shared/MailImporter.cs
@@ -32,16 +32,34 @@ namespace MailArchiver.Services.Shared
 
                 var messageId = GenerateMessageId(message, jobId);
 
-                var checkFrom = string.Join(",", message.From.Mailboxes.Select(m => m.Address));
-                var checkTo = string.Join(",", message.To.Mailboxes.Select(m => m.Address));
-                var checkSubject = message.Subject ?? "(No Subject)";
+                // The fingerprint has to be expressed in the format the row was written in,
+                // not in the format the message arrived in, because the column side of the
+                // comparison is already fixed. Building it any other way silently disables the
+                // criterion: joining with "," where the row holds ", " never matches a message
+                // with two or more senders or recipients, and an uncleaned subject never
+                // matches a column that went through CleanText.
+                var checkFrom = MailMatchKey.NormalizeAddresses(
+                    message.From.Mailboxes.Select(m => m.Address), MailMatchKey.FromMaxBytes);
+                var checkTo = MailMatchKey.NormalizeAddresses(
+                    message.To.Mailboxes.Select(m => m.Address), MailMatchKey.ToMaxBytes);
+                var checkSubject = MailMatchKey.NormalizeSubject(message.Subject);
+
+                // SentDate is stored converted into the display timezone, so the incoming date
+                // has to be converted the same way before the two-second window is applied.
+                // Comparing the raw value disabled the criterion outright anywhere the display
+                // timezone was not UTC.
+                var checkSentDate = scope.ServiceProvider.GetRequiredService<DateTimeHelper>()
+                    .ConvertToDisplayTimeZone(message.Date);
+                var toleranceSeconds = MailMatchKey.TimestampToleranceSeconds;
+
+                var messageIdCandidates = MailContentHelper.MessageIdMatchCandidates(messageId).ToList();
 
                 var existing = await context.ArchivedEmails
                     .Where(e => e.MailAccountId == account.Id)
                     .Where(e =>
-                        e.MessageId == messageId ||
+                        messageIdCandidates.Contains(e.MessageId) ||
                         (e.From == checkFrom && e.To == checkTo && e.Subject == checkSubject &&
-                         Math.Abs((e.SentDate - message.Date.DateTime).TotalSeconds) < 2))
+                         Math.Abs((e.SentDate - checkSentDate).TotalSeconds) < toleranceSeconds))
                     .FirstOrDefaultAsync();
 
                 if (existing != null)

--- a/Services/Shared/MailMatchKey.cs
+++ b/Services/Shared/MailMatchKey.cs
@@ -1,10 +1,12 @@
-// Services/Shared/OffloadMatchKey.cs
+// Services/Shared/MailMatchKey.cs
 using MailArchiver.Models;
 
 namespace MailArchiver.Services.Shared
 {
     /// <summary>
-    /// Builds the two duplicate detection keys an offload uses against a target mailbox.
+    /// Builds the two duplicate detection keys used to decide whether a message is already
+    /// present: an exact Message-ID key, and a fingerprint over sender, recipients, subject and
+    /// send time for the messages whose Message-ID cannot carry the decision.
     /// <para>
     /// Keys are 64 bit hashes rather than strings. Two string sets holding the configured
     /// maximum of 500,000 entries each would cost a few hundred megabytes once .NET string
@@ -13,16 +15,17 @@ namespace MailArchiver.Services.Shared
     /// skipped as already present.
     /// </para>
     /// <para>
-    /// The fingerprint deliberately does <b>not</b> mirror the duplicate query the import uses
-    /// in <c>MailImporter</c>. That query compares against values it never stored: it joins
-    /// addresses with "," while the row was written with ", ", and it compares a raw subject
-    /// against a column that went through <see cref="MailContentHelper.CleanText"/>. As a
-    /// result its own second criterion cannot match any message with two or more senders or
-    /// recipients. Since the database side of the key is fixed by what is already in the
-    /// column, the other side has to reproduce the <b>storage</b> format instead.
+    /// Every key is built from the <b>storage</b> format, i.e. the form a value takes once it is
+    /// in the column, never from the form it happened to arrive in. The database side of a
+    /// comparison is fixed by what was already written, so the other side has to reproduce it
+    /// exactly. Getting this wrong is not a hypothetical: the archiving pipelines used to join
+    /// addresses with "," while the row was written with ", ", and compare a raw subject against
+    /// a column that had been through <see cref="MailContentHelper.CleanText"/>, which left
+    /// their second criterion unable to match any message with two or more senders or
+    /// recipients. Both now normalize through this class.
     /// </para>
     /// </summary>
-    public static class OffloadMatchKey
+    public static class MailMatchKey
     {
         /// <summary>
         /// The window within which two timestamps count as the same message, matching the
@@ -30,10 +33,11 @@ namespace MailArchiver.Services.Shared
         /// </summary>
         public const double TimestampToleranceSeconds = 2;
 
-        // Field size limits, mirroring the ones MailImporter applies when it writes the row.
-        private const int FromMaxBytes = 10_000;
-        private const int ToMaxBytes = 50_000;
-        private const int SubjectMaxBytes = 50_000;
+        // Field size limits, mirroring the ones the archiving pipelines apply when they write
+        // the row. Public because the duplicate queries have to normalize with the same bounds.
+        public const int FromMaxBytes = 10_000;
+        public const int ToMaxBytes = 50_000;
+        public const int SubjectMaxBytes = 50_000;
 
         private const string NoSubject = "(No Subject)";
 
@@ -43,16 +47,22 @@ namespace MailArchiver.Services.Shared
         private const string FieldSeparator = "\u001F";
 
         /// <summary>
-        /// Key for the first criterion. Returns null when the stored Message-ID is missing or
-        /// carries no "@", because such a value is not emitted on append either: the restore
-        /// path drops it and MimeKit generates a fresh random Message-Id instead. A null here
-        /// is what pushes the caller on to the fingerprint.
+        /// Key for the first criterion, built from the identifier the row is actually appended
+        /// with rather than from the raw column.
+        /// <para>
+        /// Returns null only when there is no stored Message-ID at all, since nothing is emitted
+        /// on append in that case and the caller has to fall through to the fingerprint. A
+        /// stored value with no "@" no longer yields null: it used to, because the restore path
+        /// dropped such values and let a fresh random one be generated, but
+        /// <see cref="MailContentHelper.ToRestorableMessageId"/> now derives a stable identifier
+        /// from it, so it can carry the match after all.
+        /// </para>
         /// </summary>
         public static long? MessageIdKey(string? messageId)
         {
-            var normalized = MailContentHelper.NormalizeMessageId(messageId);
-            if (string.IsNullOrEmpty(normalized) || !normalized.Contains('@')) return null;
-            return Hash64(normalized.ToLowerInvariant());
+            var restorable = MailContentHelper.ToRestorableMessageId(messageId);
+            if (string.IsNullOrEmpty(restorable)) return null;
+            return Hash64(restorable.ToLowerInvariant());
         }
 
         /// <summary>

--- a/tests/MailArchiver.Tests/Services/DuplicateCheckSentDateTests.cs
+++ b/tests/MailArchiver.Tests/Services/DuplicateCheckSentDateTests.cs
@@ -1,0 +1,97 @@
+using MailArchiver.Models;
+using MailArchiver.Utilities;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MailArchiver.Tests.Services
+{
+    /// <summary>
+    /// The send time half of the duplicate check.
+    /// <para>
+    /// <c>SentDate</c> is stored converted into the display timezone, so the incoming value has
+    /// to be converted the same way before the two-second window is applied. Getting this wrong
+    /// produces no error and no visible symptom: the comparison simply never matches, and only
+    /// mail without a usable Message-ID depends on it.
+    /// </para>
+    /// <para>
+    /// The shipped default display timezone is <c>Etc/UCT</c>, under which several ways of
+    /// getting this wrong still happen to agree. These tests therefore use a non-UTC zone, which
+    /// is the case the defect actually shows up in.
+    /// </para>
+    /// </summary>
+    public class DuplicateCheckSentDateTests
+    {
+        private static DateTimeHelper Helper(string timeZoneId) =>
+            new(Options.Create(new TimeZoneOptions { DisplayTimeZoneId = timeZoneId }));
+
+        /// <summary>
+        /// The trap that has to stay closed: <c>ConvertToDisplayTimeZone</c> is overloaded, and
+        /// the <see cref="DateTime"/> overload returns a value of Kind Unspecified untouched.
+        /// <c>DateTimeOffset.DateTime</c> produces exactly such a value, so converting
+        /// <c>x.DateTime</c> rather than <c>x</c> silently performs no conversion at all.
+        /// </summary>
+        [Fact]
+        public void ConvertingTheOffsetAndItsDateTimeComponent_AreNotTheSameThing()
+        {
+            var helper = Helper("Europe/Berlin");
+            var sent = new DateTimeOffset(2026, 8, 28, 12, 0, 0, TimeSpan.Zero);
+
+            var viaOffset = helper.ConvertToDisplayTimeZone(sent);
+            var viaDateTimeComponent = helper.ConvertToDisplayTimeZone(sent.DateTime);
+
+            Assert.NotEqual(viaOffset, viaDateTimeComponent);
+        }
+
+        /// <summary>
+        /// What the archiving pipelines write, compared with what the duplicate check now builds.
+        /// Both go through the offset overload, so they agree.
+        /// </summary>
+        [Fact]
+        public void StoredAndComparedSendTimes_Agree()
+        {
+            var helper = Helper("Europe/Berlin");
+            var sent = new DateTimeOffset(2026, 8, 28, 12, 0, 0, TimeSpan.Zero);
+
+            var stored = helper.ConvertToDisplayTimeZone(sent);
+            var compared = helper.ConvertToDisplayTimeZone(sent);
+
+            Assert.True(MailArchiver.Services.Shared.MailMatchKey.WithinTolerance(stored, compared));
+        }
+
+        /// <summary>
+        /// The old comparison, kept as a regression guard: it took the raw DateTime component of
+        /// the send time, which is the sender's local wall clock, and compared it against a
+        /// column holding display-timezone wall clock. For a message sent at an offset differing
+        /// from the display timezone those are hours apart, far outside the two-second window.
+        /// </summary>
+        [Fact]
+        public void OldComparison_WouldHaveFallenOutsideTheWindow()
+        {
+            var helper = Helper("Etc/UCT");
+            // A message sent at 14:00 in +02:00, i.e. 12:00 UTC.
+            var sent = new DateTimeOffset(2026, 8, 28, 14, 0, 0, TimeSpan.FromHours(2));
+
+            var stored = helper.ConvertToDisplayTimeZone(sent);   // 12:00
+            var comparedTheOldWay = sent.DateTime;                // 14:00
+
+            Assert.False(MailArchiver.Services.Shared.MailMatchKey
+                .WithinTolerance(stored, comparedTheOldWay));
+        }
+
+        /// <summary>
+        /// And the same message under the fixed comparison matches, on the shipped default zone.
+        /// This is the pairing that shows the defect was never limited to non-UTC installations.
+        /// </summary>
+        [Fact]
+        public void FixedComparison_MatchesOnTheDefaultTimeZone()
+        {
+            var helper = Helper("Etc/UCT");
+            var sent = new DateTimeOffset(2026, 8, 28, 14, 0, 0, TimeSpan.FromHours(2));
+
+            var stored = helper.ConvertToDisplayTimeZone(sent);
+            var compared = helper.ConvertToDisplayTimeZone(sent);
+
+            Assert.True(MailArchiver.Services.Shared.MailMatchKey.WithinTolerance(stored, compared));
+        }
+    }
+}

--- a/tests/MailArchiver.Tests/Services/DuplicateCheckStorageFormatTests.cs
+++ b/tests/MailArchiver.Tests/Services/DuplicateCheckStorageFormatTests.cs
@@ -1,0 +1,121 @@
+using MailArchiver.Services.Shared;
+using MimeKit;
+using Xunit;
+
+namespace MailArchiver.Tests.Services
+{
+    /// <summary>
+    /// The duplicate check compares incoming values against columns that were written by the
+    /// archiving pipelines. If the two sides are produced differently the second criterion
+    /// silently never fires, and nothing looks wrong until mail starts duplicating.
+    /// <para>
+    /// These tests reproduce the write path's expression for each field and assert that the
+    /// normalization used to build the query agrees with it. They are written against the
+    /// storage expression rather than against the query so that changing how a row is written
+    /// breaks them.
+    /// </para>
+    /// </summary>
+    public class DuplicateCheckStorageFormatTests
+    {
+        // The expressions the archiving pipelines use when writing the row.
+        private static string StoredFrom(IEnumerable<string> addresses) =>
+            MailContentHelper.TruncateFieldForTsvector(
+                MailContentHelper.CleanText(string.Join(", ", addresses)), 10_000);
+
+        private static string StoredTo(IEnumerable<string> addresses) =>
+            MailContentHelper.TruncateFieldForTsvector(
+                MailContentHelper.CleanText(string.Join(", ", addresses)), 50_000);
+
+        private static string StoredSubject(string? subject) =>
+            MailContentHelper.TruncateFieldForTsvector(
+                MailContentHelper.CleanText(subject ?? "(No Subject)"), 50_000);
+
+        [Fact]
+        public void SingleRecipient_ComparedFormMatchesStoredForm()
+        {
+            var addresses = new[] { "one@example.com" };
+
+            Assert.Equal(
+                StoredTo(addresses),
+                MailMatchKey.NormalizeAddresses(addresses, MailMatchKey.ToMaxBytes));
+        }
+
+        /// <summary>
+        /// The reported defect. A single address emits no separator, which is why the old
+        /// comparison looked correct in everyday use; two or more never matched.
+        /// </summary>
+        [Fact]
+        public void TwoRecipients_ComparedFormMatchesStoredForm()
+        {
+            var addresses = new[] { "one@example.com", "two@example.com" };
+
+            Assert.Equal(
+                StoredTo(addresses),
+                MailMatchKey.NormalizeAddresses(addresses, MailMatchKey.ToMaxBytes));
+        }
+
+        [Fact]
+        public void TwoRecipients_OldCommaJoinWouldNotHaveMatched()
+        {
+            // Pins the bug itself, so the fix cannot be reverted quietly.
+            var addresses = new[] { "one@example.com", "two@example.com" };
+
+            Assert.NotEqual(StoredTo(addresses), string.Join(",", addresses));
+        }
+
+        [Fact]
+        public void TwoSenders_ComparedFormMatchesStoredForm()
+        {
+            var addresses = new[] { "a@example.com", "b@example.com" };
+
+            Assert.Equal(
+                StoredFrom(addresses),
+                MailMatchKey.NormalizeAddresses(addresses, MailMatchKey.FromMaxBytes));
+        }
+
+        [Theory]
+        [InlineData("plain subject")]
+        [InlineData("subject\twith\ttabs")]
+        [InlineData("subject\nwith\nnewlines")]
+        [InlineData("")]
+        public void Subject_ComparedFormMatchesStoredForm(string subject)
+        {
+            Assert.Equal(StoredSubject(subject), MailMatchKey.NormalizeSubject(subject));
+        }
+
+        [Fact]
+        public void MissingSubject_ComparedFormMatchesStoredForm()
+        {
+            // MailImporter writes `message.Subject ?? "(No Subject)"`, substituting for null
+            // only. An empty Subject header is stored empty, so the two must not collapse.
+            Assert.Equal(StoredSubject(null), MailMatchKey.NormalizeSubject(null));
+            Assert.NotEqual(MailMatchKey.NormalizeSubject(null), MailMatchKey.NormalizeSubject(""));
+        }
+
+        [Fact]
+        public void SubjectWithControlCharacter_ComparedFormMatchesStoredForm()
+        {
+            const string subject = "before\u0001after";
+
+            Assert.Equal(StoredSubject(subject), MailMatchKey.NormalizeSubject(subject));
+            // And the raw value would not have matched the column.
+            Assert.NotEqual(StoredSubject(subject), subject);
+        }
+
+        [Fact]
+        public void MimeMessageAddresses_NormalizeToTheStoredForm()
+        {
+            // End to end over the type the importer actually holds.
+            var message = new MimeMessage();
+            message.From.Add(new MailboxAddress("A", "a@example.com"));
+            message.To.Add(new MailboxAddress("One", "one@example.com"));
+            message.To.Add(new MailboxAddress("Two", "two@example.com"));
+
+            var toAddresses = message.To.Mailboxes.Select(m => m.Address).ToList();
+
+            Assert.Equal(
+                StoredTo(toAddresses),
+                MailMatchKey.NormalizeAddresses(toAddresses, MailMatchKey.ToMaxBytes));
+        }
+    }
+}

--- a/tests/MailArchiver.Tests/Services/MailMatchKeyTests.cs
+++ b/tests/MailArchiver.Tests/Services/MailMatchKeyTests.cs
@@ -11,7 +11,7 @@ namespace MailArchiver.Tests.Services;
 /// criterion never fires, and it fails silently: only the handful of rows without a usable
 /// Message-ID depend on it, so nothing looks wrong until those rows duplicate.
 /// </summary>
-public class OffloadMatchKeyTests
+public class MailMatchKeyTests
 {
     // Reproduces what MailImporter writes into the row, so a test can build the "stored" side
     // without a database. Mirrors MailImporter lines 94-99.
@@ -50,7 +50,7 @@ public class OffloadMatchKeyTests
     /// projected out of the address lists, in order.
     /// </summary>
     private static long EnvelopeSideKey(MimeMessage message)
-        => OffloadMatchKey.FingerprintKeyFromAddresses(
+        => MailMatchKey.FingerprintKeyFromAddresses(
             message.From.Mailboxes.Select(m => m.Address),
             message.To.Mailboxes.Select(m => m.Address),
             message.Subject);
@@ -62,7 +62,7 @@ public class OffloadMatchKeyTests
     {
         var msg = Message("Hello", "alice@example.com", "bob@example.com");
         Assert.Equal(
-            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            MailMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
             EnvelopeSideKey(msg));
     }
 
@@ -73,7 +73,7 @@ public class OffloadMatchKeyTests
         // stored column carries ", ", so its second criterion cannot match multi-recipient mail.
         var msg = Message("Hello", "alice@example.com", "bob@example.com", "carol@example.com");
         Assert.Equal(
-            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            MailMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
             EnvelopeSideKey(msg));
     }
 
@@ -83,7 +83,7 @@ public class OffloadMatchKeyTests
         var msg = Message("Hello", "alice@example.com", "bob@example.com");
         msg.From.Add(MailboxAddress.Parse("dave@example.com"));
         Assert.Equal(
-            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            MailMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
             EnvelopeSideKey(msg));
     }
 
@@ -94,7 +94,7 @@ public class OffloadMatchKeyTests
         // and the stored column differ. Both sides must apply the same cleaning.
         var msg = Message("Quarterly\u0001report", "alice@example.com", "bob@example.com");
         Assert.Equal(
-            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            MailMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
             EnvelopeSideKey(msg));
     }
 
@@ -106,7 +106,7 @@ public class OffloadMatchKeyTests
         var msg = Parse("From: alice@example.com\r\nTo: bob@example.com\r\n\r\nbody\r\n");
         Assert.Null(msg.Subject);
         Assert.Equal(
-            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            MailMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
             EnvelopeSideKey(msg));
     }
 
@@ -119,7 +119,7 @@ public class OffloadMatchKeyTests
         var msg = Parse("From: alice@example.com\r\nTo: bob@example.com\r\nSubject: \r\n\r\nbody\r\n");
         Assert.Equal(string.Empty, msg.Subject);
         Assert.Equal(
-            OffloadMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
+            MailMatchKey.FingerprintKeyFromStored(AsStoredRow(msg)),
             EnvelopeSideKey(msg));
     }
 
@@ -156,8 +156,8 @@ public class OffloadMatchKeyTests
     {
         // Without a field separator "ab" + "c" and "a" + "bc" would hash identically.
         Assert.NotEqual(
-            OffloadMatchKey.FingerprintKeyFromStored("ab", "c", "s"),
-            OffloadMatchKey.FingerprintKeyFromStored("a", "bc", "s"));
+            MailMatchKey.FingerprintKeyFromStored("ab", "c", "s"),
+            MailMatchKey.FingerprintKeyFromStored("a", "bc", "s"));
     }
 
     // ------------------------------------------------------------------ Message-ID criterion
@@ -166,20 +166,44 @@ public class OffloadMatchKeyTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
+    [InlineData("<>")]
+    public void MessageIdKey_MissingValues_ReturnNull(string? messageId)
+    {
+        // Nothing is emitted on append when there is no stored identifier at all, so the caller
+        // has to fall through to the fingerprint.
+        Assert.Null(MailMatchKey.MessageIdKey(messageId));
+    }
+
+    [Theory]
     [InlineData("<bare-token-no-at-sign>")]
     [InlineData("no-at-sign-either")]
-    public void MessageIdKey_UnusableValues_ReturnNull(string? messageId)
+    public void MessageIdKey_UnusableButPresentValues_StillProduceAKey(string messageId)
     {
-        // A value without "@" is not emitted on append either: the restore path drops it and
-        // MimeKit invents a fresh random Message-Id, so it cannot be matched on.
-        Assert.Null(OffloadMatchKey.MessageIdKey(messageId));
+        // These used to return null, because the restore path dropped such a value and let a
+        // fresh random Message-Id be generated, which no key could survive. The value is now
+        // mapped to a deterministic identifier on append, so it can carry the match.
+        var key = MailMatchKey.MessageIdKey(messageId);
+
+        Assert.NotNull(key);
+        Assert.Equal(key, MailMatchKey.MessageIdKey(messageId));
+    }
+
+    [Fact]
+    public void MessageIdKey_MatchesTheIdentifierTheRowIsAppendedWith()
+    {
+        // The key has to be built from what the restore path actually emits, not from the raw
+        // column, or the two sides of the comparison drift apart again.
+        const string stored = "no-at-sign-either";
+        var appended = MailContentHelper.ToRestorableMessageId(stored);
+
+        Assert.Equal(MailMatchKey.MessageIdKey(stored), MailMatchKey.MessageIdKey(appended));
     }
 
     [Fact]
     public void MessageIdKey_UsableValue_ReturnsStableKey()
     {
-        var a = OffloadMatchKey.MessageIdKey("<abc@example.com>");
-        var b = OffloadMatchKey.MessageIdKey("<abc@example.com>");
+        var a = MailMatchKey.MessageIdKey("<abc@example.com>");
+        var b = MailMatchKey.MessageIdKey("<abc@example.com>");
         Assert.NotNull(a);
         Assert.Equal(a, b);
     }
@@ -188,18 +212,18 @@ public class OffloadMatchKeyTests
     public void MessageIdKey_IgnoresBracketsAndCase()
     {
         // Legacy rows may carry surrounding angle brackets; NormalizeMessageId strips them.
-        var bare = OffloadMatchKey.MessageIdKey("abc@example.com");
-        Assert.Equal(bare, OffloadMatchKey.MessageIdKey("<abc@example.com>"));
-        Assert.Equal(bare, OffloadMatchKey.MessageIdKey("<<abc@example.com>>"));
-        Assert.Equal(bare, OffloadMatchKey.MessageIdKey("  <ABC@Example.COM>  "));
+        var bare = MailMatchKey.MessageIdKey("abc@example.com");
+        Assert.Equal(bare, MailMatchKey.MessageIdKey("<abc@example.com>"));
+        Assert.Equal(bare, MailMatchKey.MessageIdKey("<<abc@example.com>>"));
+        Assert.Equal(bare, MailMatchKey.MessageIdKey("  <ABC@Example.COM>  "));
     }
 
     [Fact]
     public void MessageIdKey_DifferentIds_ProduceDifferentKeys()
     {
         Assert.NotEqual(
-            OffloadMatchKey.MessageIdKey("<a@example.com>"),
-            OffloadMatchKey.MessageIdKey("<b@example.com>"));
+            MailMatchKey.MessageIdKey("<a@example.com>"),
+            MailMatchKey.MessageIdKey("<b@example.com>"));
     }
 
     // ------------------------------------------------------------------ timestamp tolerance
@@ -211,8 +235,8 @@ public class OffloadMatchKeyTests
         // quantising them: two copies one second apart would fall into different buckets and
         // the match would silently never fire.
         var a = new DateTime(2026, 2, 3, 10, 11, 12);
-        Assert.True(OffloadMatchKey.WithinTolerance(a, a.AddSeconds(1)));
-        Assert.True(OffloadMatchKey.WithinTolerance(a, a.AddSeconds(-1)));
+        Assert.True(MailMatchKey.WithinTolerance(a, a.AddSeconds(1)));
+        Assert.True(MailMatchKey.WithinTolerance(a, a.AddSeconds(-1)));
     }
 
     [Fact]
@@ -221,15 +245,15 @@ public class OffloadMatchKeyTests
         // 10:11:11.9 and 10:11:12.1 sit in different two second buckets but are 0.2s apart.
         var a = new DateTime(2026, 2, 3, 10, 11, 11, 900);
         var b = new DateTime(2026, 2, 3, 10, 11, 12, 100);
-        Assert.True(OffloadMatchKey.WithinTolerance(a, b));
+        Assert.True(MailMatchKey.WithinTolerance(a, b));
     }
 
     [Fact]
     public void WithinTolerance_TwoSecondsOrMoreApart_DoesNotMatch()
     {
         var a = new DateTime(2026, 2, 3, 10, 11, 12);
-        Assert.False(OffloadMatchKey.WithinTolerance(a, a.AddSeconds(2)));
-        Assert.False(OffloadMatchKey.WithinTolerance(a, a.AddSeconds(-3)));
+        Assert.False(MailMatchKey.WithinTolerance(a, a.AddSeconds(2)));
+        Assert.False(MailMatchKey.WithinTolerance(a, a.AddSeconds(-3)));
     }
 
     // ------------------------------------------------------------------ hashing
@@ -238,7 +262,7 @@ public class OffloadMatchKeyTests
     public void Hash64_IsStableAcrossCalls()
     {
         // Deliberately not string.GetHashCode(), which is randomised per process.
-        Assert.Equal(OffloadMatchKey.Hash64("a@example.com"), OffloadMatchKey.Hash64("a@example.com"));
+        Assert.Equal(MailMatchKey.Hash64("a@example.com"), MailMatchKey.Hash64("a@example.com"));
     }
 
     [Fact]
@@ -246,7 +270,7 @@ public class OffloadMatchKeyTests
     {
         // FNV-1a over the two bytes of each UTF-16 unit. Pinned so an accidental change to the
         // algorithm is caught rather than silently invalidating every stored comparison.
-        Assert.Equal(OffloadMatchKey.Hash64(""), OffloadMatchKey.Hash64(string.Empty));
-        Assert.NotEqual(0, OffloadMatchKey.Hash64("a"));
+        Assert.Equal(MailMatchKey.Hash64(""), MailMatchKey.Hash64(string.Empty));
+        Assert.NotEqual(0, MailMatchKey.Hash64("a"));
     }
 }

--- a/tests/MailArchiver.Tests/Services/TargetMailboxIndexTests.cs
+++ b/tests/MailArchiver.Tests/Services/TargetMailboxIndexTests.cs
@@ -145,13 +145,30 @@ public class TargetMailboxIndexTests
     }
 
     [Fact]
-    public void Add_RowWithUnusableMessageId_IsStillMatchableByFingerprint()
+    public void Add_RowWithUnusableMessageId_MatchesByItsDerivedMessageId()
     {
         var index = NewIndex();
         var email = Row("<no-at-sign>", "alice@x.com", "bob@y.com", "Hi", Sent);
 
+        // Such a row used to fall through to the fingerprint, because the append dropped the
+        // unusable value and a fresh random Message-Id was generated every time. The append now
+        // derives a stable identifier from it, so the stronger criterion carries the match.
         index.Add(email);
-        Assert.Equal(OffloadMatchKind.Fingerprint, index.Match(email));
+        Assert.Equal(OffloadMatchKind.MessageId, index.Match(email));
+    }
+
+    [Fact]
+    public void RowWithUnusableMessageId_AppendedBeforeTheFix_IsStillCaughtByFingerprint()
+    {
+        // The copy already sitting on the target was appended by the old code, so it carries a
+        // random Message-ID that the derived one cannot match. The fingerprint has to catch it,
+        // otherwise the fix would re-append every such message exactly once more.
+        var index = NewIndex();
+        index.Add(Row("<random-generated@mimekit.example>", "alice@x.com", "bob@y.com", "Hi", Sent));
+
+        var sourceRow = Row("<no-at-sign>", "alice@x.com", "bob@y.com", "Hi", Sent);
+
+        Assert.Equal(OffloadMatchKind.Fingerprint, index.Match(sourceRow));
     }
 
     [Fact]

--- a/tests/MailArchiver.Tests/Shared/MailContentHelperRestorableMessageIdTests.cs
+++ b/tests/MailArchiver.Tests/Shared/MailContentHelperRestorableMessageIdTests.cs
@@ -1,0 +1,100 @@
+using MailArchiver.Services.Shared;
+using Xunit;
+
+namespace MailArchiver.Tests.Shared
+{
+    /// <summary>
+    /// <see cref="MailContentHelper.ToRestorableMessageId"/> and
+    /// <see cref="MailContentHelper.MessageIdMatchCandidates"/>.
+    /// </summary>
+    public class MailContentHelperRestorableMessageIdTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("<>")]
+        public void NoStoredId_YieldsEmpty(string? stored)
+        {
+            Assert.Equal(string.Empty, MailContentHelper.ToRestorableMessageId(stored));
+        }
+
+        [Theory]
+        [InlineData("abc@host.example", "abc@host.example")]
+        [InlineData("<abc@host.example>", "abc@host.example")]
+        [InlineData("  <<abc@host.example>>  ", "abc@host.example")]
+        public void UsableId_IsReturnedNormalized(string stored, string expected)
+        {
+            Assert.Equal(expected, MailContentHelper.ToRestorableMessageId(stored));
+        }
+
+        /// <summary>
+        /// The case behind the defect: a stored value with no "@" is not a usable msg-id, so it
+        /// used to be dropped and replaced by a fresh random one on every append.
+        /// </summary>
+        [Fact]
+        public void UnusableId_IsReplacedByADerivedIdentifier()
+        {
+            var restorable = MailContentHelper.ToRestorableMessageId("not-a-message-id");
+
+            Assert.NotEqual(string.Empty, restorable);
+            Assert.Contains("@", restorable);
+            Assert.DoesNotContain("not-a-message-id", restorable);
+        }
+
+        [Fact]
+        public void UnusableId_IsStableAcrossCalls()
+        {
+            // The whole point: repeated appends of the same row must emit the same Message-ID,
+            // otherwise the copies can never be recognized as duplicates of one another.
+            var first = MailContentHelper.ToRestorableMessageId("legacy-value");
+            var second = MailContentHelper.ToRestorableMessageId("legacy-value");
+
+            Assert.Equal(first, second);
+        }
+
+        [Fact]
+        public void UnusableIds_DifferFromEachOther()
+        {
+            Assert.NotEqual(
+                MailContentHelper.ToRestorableMessageId("legacy-one"),
+                MailContentHelper.ToRestorableMessageId("legacy-two"));
+        }
+
+        [Fact]
+        public void UnusableId_IsIdempotentThroughASecondPass()
+        {
+            // A row re-archived from a restored copy must not drift to a new identifier.
+            var once = MailContentHelper.ToRestorableMessageId("legacy-value");
+            var twice = MailContentHelper.ToRestorableMessageId(once);
+
+            Assert.Equal(once, twice);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void MatchCandidates_AreEmptyForAMissingId(string? stored)
+        {
+            Assert.Empty(MailContentHelper.MessageIdMatchCandidates(stored));
+        }
+
+        [Fact]
+        public void MatchCandidates_CoverBareAndBracketedStorage()
+        {
+            var candidates = MailContentHelper.MessageIdMatchCandidates("<abc@host.example>");
+
+            Assert.Contains("abc@host.example", candidates);
+            Assert.Contains("<abc@host.example>", candidates);
+        }
+
+        [Fact]
+        public void MatchCandidates_AreTheSameWhicheverFormIsPassedIn()
+        {
+            Assert.Equal(
+                MailContentHelper.MessageIdMatchCandidates("abc@host.example"),
+                MailContentHelper.MessageIdMatchCandidates("<abc@host.example>"));
+        }
+    }
+}


### PR DESCRIPTION
Both archiving pipelines built their second duplicate criterion out of values they never wrote. MailImporter and GraphMailArchiver joined addresses with "," while the row was written with ", ", compared a raw subject against a column that had been through CleanText, and compared a raw timestamp against a SentDate stored in the display timezone. Each mismatch disables the criterion silently: the join breaks any message with two or more senders or recipients, and the timezone one breaks every message unless the display timezone is UTC. Nothing looks wrong until mail without a usable Message-ID starts duplicating.

The offload already had to solve this and carried the normalization privately. It is now shared: OffloadMatchKey becomes MailMatchKey and both archivers build their comparison through it, so the compared form and the stored form can no longer drift apart. The tests assert against the write path's own expression rather than the query, so changing how a row is written breaks them.

Rows whose stored Message-ID carries no "@" were dropped on append, letting a fresh random one be generated every time, so repeated appends of the same row could never be recognized as duplicates and multiplied on each repetition. ToRestorableMessageId derives a stable identifier from the stored value instead, and both restorers and the match key now agree on what a row is appended with.

The bracketed/bare Message-ID variants that three lookups each spelled out by hand come from MessageIdMatchCandidates now.

Existing rows are untouched. The archive stops admitting new duplicates; the ones already archived under the old comparison stay as they are.

# Details

Both archiving pipelines built their second duplicate criterion out of values they never wrote,
which disables the criterion silently. This routes every duplicate comparison through one shared
normalization so the compared form and the stored form cannot drift apart.

## The defect

`MailImporter` and `GraphMailArchiver` each compare an incoming message against columns the
archiver itself wrote — but they build the comparison from the parsed message instead of from the
storage format:

| Field | written as | compared as |
|---|---|---|
| From / To | `", "` join → `CleanText` → `TruncateFieldForTsvector` | `","` join, raw |
| Subject | `CleanText` → truncate, `?? "(No Subject)"` | raw |
| SentDate | `ConvertToDisplayTimeZone(...)` | the parsed value, unconverted |

Each row is enough on its own to stop the criterion matching:

- the join breaks any message with **two or more senders or recipients** — one address emits no
  separator, which is why it looks fine in everyday use
- an uncleaned subject never matches a column that went through `CleanText`
- the timestamp breaks **every** message unless the display timezone happens to be UTC

It fails quietly because criterion 1, the Message-ID, carries almost all of the traffic. Only
messages without a usable Message-ID depend on the fingerprint, so nothing looks wrong until
exactly those start duplicating.

## The fix

The offload already had to solve this and carried the normalization privately, documenting the
mismatch in a comment. It is now shared rather than described: `OffloadMatchKey` becomes
`MailMatchKey`, and both archivers build their comparison through it.

```csharp
var checkFrom = MailMatchKey.NormalizeAddresses(..., MailMatchKey.FromMaxBytes);
var checkTo   = MailMatchKey.NormalizeAddresses(..., MailMatchKey.ToMaxBytes);
var checkSubject = MailMatchKey.NormalizeSubject(message.Subject);
var checkSentDate = dateTimeHelper.ConvertToDisplayTimeZone(message.Date);
```

The tests assert the normalization against the **write path's own expression** rather than against
the query, so changing how a row is written breaks them rather than silently reintroducing the
drift.

## Message-IDs without an "@"

A stored Message-ID carrying no `@` is not a usable msg-id, so the restore path dropped it and let
MimeKit invent a fresh random one. Every append of such a row therefore produced a different
Message-ID, so the copies could never be recognized as duplicates of one another and multiplied on
every repetition.

`MailContentHelper.ToRestorableMessageId` derives a stable identifier from the stored value
instead. Both restorers and the match key now agree on what a row is appended with, which is the
property the duplicate check needs.

A copy appended *before* this change still carries a random id, so it cannot match the derived
one. The fingerprint catches those, and there is a test for exactly that case — otherwise the fix
would re-append every such message once more.

## Bracketed variants

Three lookups each spelled out the bare/bracketed Message-ID pair by hand, because rows have been
written both ways over the project's history. That now comes from
`MailContentHelper.MessageIdMatchCandidates`, so the set is defined once.

## Scope

- **No database migration and no schema change.**
- **Existing rows are untouched.** The archive stops admitting new duplicates; rows already
  archived under the old comparison stay as they are.
- No behaviour change for messages with a usable Message-ID, which is nearly all of them.

## Tests

Full suite: **674 passing, 1 skipped, 0 failing.**

New: the storage-format agreement for each field, including the two-recipient case that is the
reported defect and an explicit assertion that the old `","` join would *not* have matched;
`ToRestorableMessageId` stability, idempotence and distinctness; and the match-candidate set.

Two existing offload tests changed meaning and were updated rather than deleted: a row with an
unusable Message-ID now matches by its derived identifier instead of falling through to the
fingerprint, and the pre-existing-copy case above was added alongside it.

## Suggested release note

> **Duplicate detection**
>
> The duplicate check now compares incoming mail against archived values in the format they were
> stored in. Previously the comparison was built from the parsed message, which meant its second
> criterion — used for mail whose Message-ID cannot identify it — could not match any message with
> more than one sender or recipient, and could not match at all unless the display timezone was
> UTC. Such mail could be archived more than once.
>
> Mail whose stored Message-ID is unusable is now restored and appended with a stable derived
> identifier instead of a freshly generated one, so repeating a restore or an offload no longer
> creates a new copy each time.
>
> Existing archived rows are unchanged. Duplicates already in the archive stay; no new ones are
> admitted.