### PR TITLE
Feature/imap messagenotfound recovery - Recover IMAP messages the server reports as missing instead of failing them forever

### DIFF
--- a/Services/Providers/Imap/ImapMailSyncService.cs
+++ b/Services/Providers/Imap/ImapMailSyncService.cs
@@ -105,6 +105,8 @@ namespace MailArchiver.Services.Providers.Imap
             var processedEmails = 0;
             var newEmails = 0;
             var failedEmails = 0;
+            var recoveredEmails = 0;
+            var providerPlaceholderEmails = 0;
             var deletedEmails = 0;
             var totalBytesDownloaded = 0L;
             var wasRateLimited = false;
@@ -163,6 +165,8 @@ namespace MailArchiver.Services.Providers.Imap
                         processedEmails += folderResult.ProcessedEmails;
                         newEmails += folderResult.NewEmails;
                         failedEmails += folderResult.FailedEmails;
+                        recoveredEmails += folderResult.RecoveredEmails;
+                        providerPlaceholderEmails += folderResult.ProviderPlaceholderEmails;
 
                         if (folderResult.WasRateLimited)
                         {
@@ -251,8 +255,9 @@ namespace MailArchiver.Services.Providers.Imap
                 }
 
                 await client.DisconnectAsync(true);
-                _logger.LogInformation("Sync completed for account: {AccountName}. New: {New}, Failed: {Failed}, Deleted: {Deleted}",
-                    account.Name, newEmails, failedEmails, deletedEmails);
+                _logger.LogInformation("Sync completed for account: {AccountName}. New: {New}, Failed: {Failed}, Deleted: {Deleted}, " +
+                    "Recovered: {Recovered}, Provider placeholders: {ProviderPlaceholders}",
+                    account.Name, newEmails, failedEmails, deletedEmails, recoveredEmails, providerPlaceholderEmails);
 
                 if (jobId != null)
                 {
@@ -848,6 +853,8 @@ namespace MailArchiver.Services.Providers.Imap
                                 MimeKit.MimeMessage? message = null;
                                 var maxAttempts = TransientFetchRetryDelaysMs.Length + 1;
                                 var mboxRecoveryAttempted = false;
+                                var notFoundRecoveryAttempted = false;
+                                var wasRecovered = false;
                                 for (int attempt = 1; attempt <= maxAttempts; attempt++)
                                 {
                                     try
@@ -888,6 +895,32 @@ namespace MailArchiver.Services.Providers.Imap
                                                 "Failed to parse message headers even after mbox From-line recovery.",
                                                 parseEx);
                                         }
+                                        consecutiveTransientFailures = 0;
+                                        break;
+                                    }
+                                    catch (MessageNotFoundException) when (!notFoundRecoveryAttempted)
+                                    {
+                                        // One-shot recovery: legacy servers can refuse a message through
+                                        // GetMessageAsync and still hand out a usable MIME document for a
+                                        // plain BODY[] fetch. Without this the UID fails on every run, and
+                                        // because LastSync is not advanced while FailedEmails > 0 the whole
+                                        // account keeps re-reading the same messages forever.
+                                        notFoundRecoveryAttempted = true;
+                                        _logger.LogDebug(
+                                            "Server reported UID {Uid} in folder {FolderName} as missing, attempting IMAP fallback fetch",
+                                            uid, folder.FullName);
+
+                                        message = await ImapMessageRecovery.TryRecoverAsync(
+                                            folder, uid, _logger, CancellationToken.None);
+
+                                        if (message == null)
+                                        {
+                                            // Nothing usable came back, so this stays a failure and keeps
+                                            // its original exception for the outer handler to log.
+                                            throw;
+                                        }
+
+                                        wasRecovered = true;
                                         consecutiveTransientFailures = 0;
                                         break;
                                     }
@@ -962,6 +995,33 @@ namespace MailArchiver.Services.Providers.Imap
                                         $"FETCH for UID {uid} in folder {folder.FullName} returned no message and no exception.");
                                 }
 
+                                var recoveredIsPlaceholder = false;
+                                if (wasRecovered)
+                                {
+                                    recoveredIsPlaceholder =
+                                        ProviderPlaceholderDetector.IsProviderRetrievalErrorPlaceholder(message);
+
+                                    if (recoveredIsPlaceholder)
+                                    {
+                                        // Archived as-is: it is the best representation the server is able
+                                        // to expose for this UID. Never rewritten into the values quoted
+                                        // inside it, so the archive cannot claim to hold the original.
+                                        _logger.LogWarning(
+                                            "Recovered UID {Uid} in folder {FolderName} for account {AccountName} using the IMAP fallback. " +
+                                            "The server returned a provider retrieval-error placeholder instead of the original message. " +
+                                            "Placeholder subject: {PlaceholderSubject}. Original subject: {OriginalSubject}",
+                                            uid, folder.FullName, account.Name, message.Subject,
+                                            ProviderPlaceholderDetector.TryGetOriginalSubject(message) ?? "(not quoted)");
+                                    }
+                                    else
+                                    {
+                                        _logger.LogWarning(
+                                            "Recovered UID {Uid} in folder {FolderName} for account {AccountName} using the IMAP fallback " +
+                                            "after the server reported it as missing. Subject: {Subject}",
+                                            uid, folder.FullName, account.Name, message.Subject);
+                                    }
+                                }
+
                                 _mailCleaner.PreCleanMessage(message);
 
 
@@ -1006,6 +1066,18 @@ namespace MailArchiver.Services.Providers.Imap
                                 }
 
                                 result.ProcessedEmails++;
+
+                                if (wasRecovered)
+                                {
+                                    // Counted next to ProcessedEmails, not at the moment of the fetch, so a
+                                    // message that is recovered but then deferred by the bandwidth limit is
+                                    // not counted twice once the sync resumes and fetches it again.
+                                    result.RecoveredEmails++;
+                                    if (recoveredIsPlaceholder)
+                                    {
+                                        result.ProviderPlaceholderEmails++;
+                                    }
+                                }
 
                                 if (_bandwidthOptions.Enabled && messageSize > 0)
                                 {
@@ -1394,6 +1466,19 @@ namespace MailArchiver.Services.Providers.Imap
             public int ProcessedEmails { get; set; }
             public int NewEmails { get; set; }
             public int FailedEmails { get; set; }
+
+            /// <summary>
+            /// Messages the normal fetch reported as missing and the IMAP fallback retrieved
+            /// anyway. They are processed like any other message and are never failures.
+            /// </summary>
+            public int RecoveredEmails { get; set; }
+
+            /// <summary>
+            /// Subset of <see cref="RecoveredEmails"/>: what came back was the provider's own
+            /// retrieval-error placeholder rather than the original message.
+            /// </summary>
+            public int ProviderPlaceholderEmails { get; set; }
+
             public long BytesDownloaded { get; set; }
             public bool WasRateLimited { get; set; }
         }

--- a/Services/Providers/Imap/ImapMessageRecovery.cs
+++ b/Services/Providers/Imap/ImapMessageRecovery.cs
@@ -13,11 +13,18 @@ namespace MailArchiver.Services.Providers.Imap
     /// exception is not a statement about the mailbox, it is MailKit reporting that the response it
     /// correlated to the request did not contain the message it asked for.
     ///
-    /// Why <c>GetStreamsAsync</c>: it is callback-driven. MailKit hands each stream to the callback
-    /// as it arrives and never checks afterwards whether the requested message was among them, so
-    /// it does not raise <see cref="MessageNotFoundException"/> at all — a message the server does
-    /// not return simply never reaches the callback. That makes it structurally, not accidentally,
-    /// a different path from the call that just failed.
+    /// Why <c>GetStreamsAsync</c>: both calls put the same command on the wire,
+    /// <c>UID FETCH … (BODY.PEEK[])</c>, so this is not a different request. What differs is the
+    /// correlation. <c>GetMessageAsync</c> collects the sections and then looks the message up by
+    /// exact UID, and a miss on that lookup is what raises the exception — even when the body did
+    /// arrive. <c>GetStreamsAsync</c> hands each section to the callback as it arrives, for
+    /// whatever UID the response carries, resolves a section that arrived without one by sequence
+    /// index once the UID turns up, and performs no lookup afterwards, so it cannot raise
+    /// <see cref="MessageNotFoundException"/> at all.
+    ///
+    /// So this helps precisely when the body is in the response but the exact-UID lookup misses it.
+    /// If the server genuinely returns nothing, the callback is never invoked, this returns null,
+    /// and the caller keeps the original failure.
     ///
     /// What this is not: a retry. It runs at most once per UID, issues exactly one fetch, and never
     /// reports success unless raw bytes actually arrived and parsed. Anything less stays a failure,

--- a/Services/Providers/Imap/ImapMessageRecovery.cs
+++ b/Services/Providers/Imap/ImapMessageRecovery.cs
@@ -39,6 +39,14 @@ namespace MailArchiver.Services.Providers.Imap
         /// <summary>
         /// Attempts to retrieve and parse the message behind <paramref name="uid"/> after the
         /// normal fetch reported it as missing.
+        ///
+        /// Held in reserve, deliberately not implemented: should a server ever answer this with
+        /// nothing at all, the next thing to try is fetching <c>BODY.PEEK[HEADER]</c> and
+        /// <c>BODY.PEEK[TEXT]</c> separately and assembling the two into one MIME document. That
+        /// costs a second round trip and introduces a "header without text" state to define, which
+        /// is why it is not the first choice — but it is a different request, where this one is the
+        /// same request read differently. Swapping it in means replacing this method only; the
+        /// parsing below is independent of how the bytes were obtained.
         /// </summary>
         /// <returns>The parsed message, or null when nothing usable came back.</returns>
         public static async Task<MimeMessage?> TryRecoverAsync(
@@ -88,10 +96,24 @@ namespace MailArchiver.Services.Providers.Imap
                 return null;
             }
 
-            if (!received || buffer.Length == 0)
+            if (!received)
             {
-                logger.LogDebug(
-                    "IMAP fallback returned no data for UID {Uid} in folder {FolderName}",
+                // The callback firing is the only signal that the server returned anything for this
+                // UID. A fetch that completes without it means the message was not delivered, and
+                // that must never pass quietly: the caller rethrows the original exception, so the
+                // message stays a failed email and an unretrieved UID cannot look archived.
+                logger.LogWarning(
+                    "IMAP fallback fetch for UID {Uid} in folder {FolderName} completed without the server " +
+                    "returning the message; it stays a failed email",
+                    uid, folder.FullName);
+                return null;
+            }
+
+            if (buffer.Length == 0)
+            {
+                logger.LogWarning(
+                    "IMAP fallback returned an empty stream for UID {Uid} in folder {FolderName}; " +
+                    "it stays a failed email",
                     uid, folder.FullName);
                 return null;
             }

--- a/Services/Providers/Imap/ImapMessageRecovery.cs
+++ b/Services/Providers/Imap/ImapMessageRecovery.cs
@@ -1,0 +1,126 @@
+using MailKit;
+using MailKit.Net.Imap;
+using MimeKit;
+
+namespace MailArchiver.Services.Providers.Imap
+{
+    /// <summary>
+    /// One bounded second attempt at a message that <c>GetMessageAsync</c> reported as missing.
+    ///
+    /// Why this exists: on some legacy servers — reproduced on on-premises Exchange 2010 — a UID
+    /// fetch through <c>GetMessageAsync</c> raises <see cref="MessageNotFoundException"/> while the
+    /// very same message still yields a well-formed MIME document over a plain BODY[] fetch. The
+    /// exception is not a statement about the mailbox, it is MailKit reporting that the response it
+    /// correlated to the request did not contain the message it asked for.
+    ///
+    /// Why <c>GetStreamsAsync</c>: it is callback-driven. MailKit hands each stream to the callback
+    /// as it arrives and never checks afterwards whether the requested message was among them, so
+    /// it does not raise <see cref="MessageNotFoundException"/> at all — a message the server does
+    /// not return simply never reaches the callback. That makes it structurally, not accidentally,
+    /// a different path from the call that just failed.
+    ///
+    /// What this is not: a retry. It runs at most once per UID, issues exactly one fetch, and never
+    /// reports success unless raw bytes actually arrived and parsed. Anything less stays a failure,
+    /// so an unretrieved UID can never be mistaken for an archived one. Read-only throughout —
+    /// no flag is set, nothing is marked seen, moved or deleted.
+    ///
+    /// The retrieval and the parsing are separate on purpose: the parsing half is pure and unit
+    /// tested, and the retrieval half can be replaced without touching the sync pipeline.
+    /// </summary>
+    public static class ImapMessageRecovery
+    {
+        /// <summary>
+        /// Attempts to retrieve and parse the message behind <paramref name="uid"/> after the
+        /// normal fetch reported it as missing.
+        /// </summary>
+        /// <returns>The parsed message, or null when nothing usable came back.</returns>
+        public static async Task<MimeMessage?> TryRecoverAsync(
+            IMailFolder folder,
+            UniqueId uid,
+            ILogger logger,
+            CancellationToken cancellationToken = default)
+        {
+            // GetStreamsAsync is IMAP-specific. Every caller in the sync pipeline holds an
+            // ImapFolder, but the parameter is IMailFolder, so this stays a check rather than a cast.
+            if (folder is not IImapFolder imapFolder)
+            {
+                logger.LogDebug(
+                    "No IMAP fallback available for UID {Uid} in folder {FolderName}: not an IMAP folder",
+                    uid, folder.FullName);
+                return null;
+            }
+
+            using var buffer = new MemoryStream();
+            var received = false;
+
+            try
+            {
+                await imapFolder.GetStreamsAsync(
+                    new[] { uid },
+                    async (callbackFolder, index, callbackUid, stream, token) =>
+                    {
+                        // One UID was asked for, so one stream is expected. Should a server echo
+                        // more than one response, taking only the first keeps the buffer a single
+                        // MIME document instead of two concatenated ones.
+                        if (received)
+                            return;
+
+                        // MailKit disposes the stream as soon as this callback returns, so the
+                        // bytes have to be taken now rather than queued for later.
+                        received = true;
+                        await stream.CopyToAsync(buffer, token);
+                    },
+                    cancellationToken,
+                    null);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "IMAP fallback fetch failed for UID {Uid} in folder {FolderName}",
+                    uid, folder.FullName);
+                return null;
+            }
+
+            if (!received || buffer.Length == 0)
+            {
+                logger.LogDebug(
+                    "IMAP fallback returned no data for UID {Uid} in folder {FolderName}",
+                    uid, folder.FullName);
+                return null;
+            }
+
+            buffer.Position = 0;
+            var message = await ParseAsync(buffer, cancellationToken);
+
+            if (message == null)
+            {
+                logger.LogWarning(
+                    "IMAP fallback retrieved {Bytes} bytes for UID {Uid} in folder {FolderName} " +
+                    "but they did not parse as a MIME message",
+                    buffer.Length, uid, folder.FullName);
+            }
+
+            return message;
+        }
+
+        /// <summary>
+        /// Parses raw bytes into a message. Returns null instead of throwing, because a fallback
+        /// that cannot parse what it received has simply failed and the caller counts it as such.
+        /// </summary>
+        internal static async Task<MimeMessage?> ParseAsync(Stream raw, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await MimeMessage.LoadAsync(raw, cancellationToken);
+            }
+            catch (FormatException)
+            {
+                return null;
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Services/Shared/ProviderPlaceholderDetector.cs
+++ b/Services/Shared/ProviderPlaceholderDetector.cs
@@ -1,0 +1,107 @@
+using System.Text.RegularExpressions;
+using MimeKit;
+
+namespace MailArchiver.Services.Shared
+{
+    /// <summary>
+    /// Recognises the MIME document a mail provider substitutes for a message it cannot itself
+    /// convert to MIME. Observed on on-premises Microsoft Exchange, which answers a BODY[] fetch
+    /// for such a message with a generated "Retrieval using the IMAP4 protocol failed" mail
+    /// instead of the original.
+    ///
+    /// Archiving that document is the honest outcome — it is the best representation the server is
+    /// able to expose — but it must be recognisable afterwards, so an operator can tell
+    /// "the archive holds the original" apart from "the archive holds the server's apology for it".
+    ///
+    /// Detection is deliberately conservative: the subject marker AND a body marker must both be
+    /// present. The sender is never required, because the string differs between Exchange versions
+    /// and localisations, and a subject alone would misclassify a genuine mail that merely quotes
+    /// the error text.
+    ///
+    /// This class is pure (no I/O, no static state) so it can be unit-tested in isolation.
+    /// </summary>
+    public static class ProviderPlaceholderDetector
+    {
+        /// <summary>
+        /// Subject prefix Exchange uses. The trailing message number varies, so this is a prefix
+        /// test, not an equality test.
+        /// </summary>
+        private const string SubjectMarker =
+            "Retrieval using the IMAP4 protocol failed for the following message:";
+
+        /// <summary>
+        /// Body markers, apostrophe-normalised. Both the contracted and the spelled-out form are
+        /// accepted because the wording differs between Exchange builds.
+        /// </summary>
+        private static readonly string[] BodyMarkers =
+        {
+            "the server couldn't retrieve the following message",
+            "the server could not retrieve the following message"
+        };
+
+        /// <summary>
+        /// Pulls the original subject out of the placeholder body, which quotes it on its own line
+        /// as <c>Subject: "..."</c>. Only for logging, so a miss is not an error.
+        /// </summary>
+        private static readonly Regex OriginalSubjectPattern = new(
+            "^[ \\t]*Subject:[ \\t]*\"(?<subject>.*)\"[ \\t]*$",
+            RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+        /// <summary>
+        /// True when the message looks like a provider-generated retrieval error rather than real
+        /// mail. Both the subject and the body have to say so.
+        /// </summary>
+        public static bool IsProviderRetrievalErrorPlaceholder(MimeMessage? message)
+        {
+            if (message == null)
+                return false;
+
+            var subject = NormalizeApostrophes(message.Subject);
+            if (string.IsNullOrWhiteSpace(subject))
+                return false;
+
+            if (!subject.TrimStart().StartsWith(SubjectMarker, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            var body = NormalizeApostrophes(message.TextBody);
+            if (string.IsNullOrWhiteSpace(body))
+                return false;
+
+            foreach (var marker in BodyMarkers)
+            {
+                if (body.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// The subject of the message the provider could not deliver, as quoted inside the
+        /// placeholder body, or null when it cannot be read cheaply. Logging only — the archived
+        /// message is never rewritten with it.
+        /// </summary>
+        public static string? TryGetOriginalSubject(MimeMessage? message)
+        {
+            var body = message?.TextBody;
+            if (string.IsNullOrWhiteSpace(body))
+                return null;
+
+            var match = OriginalSubjectPattern.Match(body);
+            if (!match.Success)
+                return null;
+
+            var subject = match.Groups["subject"].Value.Trim();
+            return string.IsNullOrEmpty(subject) ? null : subject;
+        }
+
+        /// <summary>
+        /// Exchange writes the typographic apostrophe in "couldn't". Fold it onto the ASCII one so
+        /// a single marker matches both.
+        /// </summary>
+        private static string NormalizeApostrophes(string? value)
+            => string.IsNullOrEmpty(value)
+                ? string.Empty
+                : value.Replace('\u2019', '\'').Replace('\u02BC', '\'');
+    }
+}

--- a/Services/Shared/ProviderPlaceholderDetector.cs
+++ b/Services/Shared/ProviderPlaceholderDetector.cs
@@ -43,8 +43,15 @@ namespace MailArchiver.Services.Shared
         /// Pulls the original subject out of the placeholder body, which quotes it on its own line
         /// as <c>Subject: "..."</c>. Only for logging, so a miss is not an error.
         /// </summary>
+        /// <remarks>
+        /// The trailing <c>\r?</c> is load-bearing: MimeKit's <see cref="MimeKit.TextPart.Text"/>
+        /// decoder normalises line endings to the running platform's <c>Environment.NewLine</c>,
+        /// so on Windows the body carries CRLF. With <see cref="RegexOptions.Multiline"/>, .NET's
+        /// <c>$</c> matches only before <c>\n</c> and not before <c>\r\n</c> — without the optional
+        /// carriage return the pattern would not match at all on Windows deployments.
+        /// </remarks>
         private static readonly Regex OriginalSubjectPattern = new(
-            "^[ \\t]*Subject:[ \\t]*\"(?<subject>.*)\"[ \\t]*$",
+            "^[ \\t]*Subject:[ \\t]*\"(?<subject>.*)\"[ \\t]*\\r?$",
             RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
         /// <summary>

--- a/doc/Synchronization.md
+++ b/doc/Synchronization.md
@@ -165,6 +165,14 @@ it preserves is the best representation the server is able to expose, plus the f
 placeholder is what arrived. Each one is logged at `Warning` level with account, folder, UID and
 subject.
 
+**When the fallback comes back empty**, the message stays a failed email exactly as before, and the
+attempt is logged at `Warning` rather than passing quietly — an unretrieved message must never be
+able to look archived. Should a server ever behave that way consistently, the documented next step is
+to fetch `BODY.PEEK[HEADER]` and `BODY.PEEK[TEXT]` separately and assemble them into one MIME
+document. That is a genuinely different request, where the current fallback is the same request read
+differently. It is deliberately not implemented: it costs a second round trip per message and adds a
+"header arrived, text did not" state to define, and no server seen so far needs it.
+
 Both counts appear in the account's completion log line:
 
 ```

--- a/doc/Synchronization.md
+++ b/doc/Synchronization.md
@@ -127,6 +127,56 @@ The archived copies in Mail Archiver are **not** affected by this – only the s
 
 ---
 
+## 🛟 Recovering Messages the Server Reports as Missing
+
+Some servers refuse a message through the normal UID fetch and still return a usable MIME document
+for a plain `BODY[]` fetch. This has been observed on legacy on-premises Exchange, where the fetch
+fails with:
+
+```
+MailKit.MessageNotFoundException: The IMAP server did not return the requested message.
+```
+
+Without a fallback such a message is counted as a failed email, and because `LastSync` is not
+advanced while an account has failures, the account re-reads the same messages on every run and
+never makes progress.
+
+**What Mail Archiver does:** exactly one further fetch attempt for that UID, and only for this
+specific error. Authentication problems, connection loss, throttling and parse errors are not
+affected, and the existing transient-retry behaviour is unchanged. The attempt is read-only: no
+message is marked as read, no flag is changed, nothing is moved or deleted. It counts as a success
+only if raw data actually arrived **and** parsed as a MIME message — anything less remains a failed
+email. Recovered messages then take the normal archiving path, including duplicate detection, so a
+repeated full sync does not archive them twice.
+
+**Provider error placeholders:** what the server returns is often not the original message but a
+document the provider generated in its place, for example:
+
+```
+Subject: Retrieval using the IMAP4 protocol failed for the following message: 270198
+From: Microsoft Exchange Server 2010
+
+The server couldn't retrieve the following message: ...
+```
+
+This is archived exactly as received and is never rewritten into the sender, subject or body quoted
+inside it. Mail Archiver cannot recover content the provider itself refuses to convert to MIME; what
+it preserves is the best representation the server is able to expose, plus the fact that a
+placeholder is what arrived. Each one is logged at `Warning` level with account, folder, UID and
+subject.
+
+Both counts appear in the account's completion log line:
+
+```
+Sync completed for account: Example. New: 0, Failed: 0, Deleted: 0, Recovered: 25, Provider placeholders: 25
+```
+
+`Recovered` counts messages the fallback rescued; `Provider placeholders` is the subset of those
+that turned out to be provider-generated error documents. `Failed: 0` alongside them is the point of
+the feature — the account is no longer stuck.
+
+---
+
 ## 👀 Observing the Sync
 
 - **Account Details page**: Shows the current `LastSync` timestamp and the active sync job (folder, processed count, new count, failed count). The **Full Resync** button is located here.

--- a/tests/MailArchiver.Tests/Services/ImapMessageRecoveryTests.cs
+++ b/tests/MailArchiver.Tests/Services/ImapMessageRecoveryTests.cs
@@ -1,0 +1,63 @@
+using System.Text;
+using MailArchiver.Services.Providers.Imap;
+
+namespace MailArchiver.Tests.Services;
+
+/// <summary>
+/// The fetch half of the fallback needs a live IMAP server and is not unit tested, in line with
+/// the rest of the IMAP I/O in this project. The parsing half is what decides whether a fallback
+/// counts as a success, and that is pure: bytes in, message or null out. Returning null rather
+/// than throwing is the contract the sync loop relies on to keep an unparseable response a
+/// failure instead of an archived message.
+/// </summary>
+public class ImapMessageRecoveryTests
+{
+    private static MemoryStream Stream(string raw)
+        => new(Encoding.UTF8.GetBytes(raw));
+
+    [Fact]
+    public async Task ParseAsync_valid_message_returns_it()
+    {
+        var raw = """
+            From: Colleague <colleague@example.com>
+            To: User <user@example.com>
+            Subject: Recovered by the fallback
+
+            Body text.
+            """;
+
+        var message = await ImapMessageRecovery.ParseAsync(Stream(raw));
+
+        Assert.NotNull(message);
+        Assert.Equal("Recovered by the fallback", message!.Subject);
+    }
+
+    [Fact]
+    public async Task ParseAsync_exchange_placeholder_returns_it()
+    {
+        // The placeholder is a syntactically valid MIME document, so parsing it has to succeed.
+        // Whether it is the original message is a separate question, answered by
+        // ProviderPlaceholderDetector, not here.
+        var raw = """
+            MIME-Version: 1.0
+            Content-Type: text/plain; charset="utf-8"
+            From: Microsoft Exchange Server 2010 <exchange@example.com>
+            To: User <user@example.com>
+            Subject: Retrieval using the IMAP4 protocol failed for the following message: 270198
+
+            The server couldn't retrieve the following message:
+            Subject: "Example meeting"
+            """;
+
+        var message = await ImapMessageRecovery.ParseAsync(Stream(raw));
+
+        Assert.NotNull(message);
+        Assert.StartsWith("Retrieval using the IMAP4 protocol failed", message!.Subject);
+    }
+
+    [Fact]
+    public async Task ParseAsync_empty_stream_returns_null()
+    {
+        Assert.Null(await ImapMessageRecovery.ParseAsync(new MemoryStream()));
+    }
+}

--- a/tests/MailArchiver.Tests/Shared/ProviderPlaceholderDetectorTests.cs
+++ b/tests/MailArchiver.Tests/Shared/ProviderPlaceholderDetectorTests.cs
@@ -1,0 +1,157 @@
+using System.Text;
+using MailArchiver.Services.Shared;
+using MimeKit;
+
+namespace MailArchiver.Tests.Shared;
+
+/// <summary>
+/// The detector decides whether an archived message is real mail or the provider's apology for
+/// mail it could not convert. A false positive would label a genuine message as a placeholder, so
+/// every negative case here is a message that comes close on purpose: the right subject without
+/// the body, the right body without the subject, and a Microsoft sender that means nothing by
+/// itself.
+///
+/// The fixture is synthetic and modelled on a sanitized Exchange response. No production data.
+/// </summary>
+public class ProviderPlaceholderDetectorTests
+{
+    private static MimeMessage Parse(string raw)
+        => MimeMessage.Load(new MemoryStream(Encoding.UTF8.GetBytes(raw)));
+
+    private const string Placeholder = """
+        MIME-Version: 1.0
+        Content-Type: text/plain; charset="utf-8"
+        From: Microsoft Exchange Server 2010 <exchange@example.com>
+        To: User <user@example.com>
+        Subject: Retrieval using the IMAP4 protocol failed for the following message: 270198
+
+        The server couldn't retrieve the following message:
+        Subject: "Example meeting"
+        From: "Example Sender"
+        Sent date: 20.12.2013 11:12:26
+
+        The message hasn't been deleted.
+        You might be able to view it using either Outlook or Outlook Web App.
+        """;
+
+    [Fact]
+    public void Placeholder_subject_and_body_are_detected()
+    {
+        Assert.True(ProviderPlaceholderDetector.IsProviderRetrievalErrorPlaceholder(Parse(Placeholder)));
+    }
+
+    [Fact]
+    public void Placeholder_with_typographic_apostrophe_is_detected()
+    {
+        var raw = Placeholder.Replace("couldn't", "couldn’t");
+        Assert.True(ProviderPlaceholderDetector.IsProviderRetrievalErrorPlaceholder(Parse(raw)));
+    }
+
+    [Fact]
+    public void Placeholder_with_spelled_out_wording_is_detected()
+    {
+        var raw = Placeholder.Replace(
+            "The server couldn't retrieve the following message:",
+            "The server could not retrieve the following message:");
+        Assert.True(ProviderPlaceholderDetector.IsProviderRetrievalErrorPlaceholder(Parse(raw)));
+    }
+
+    [Fact]
+    public void Placeholder_without_the_exchange_sender_is_still_detected()
+    {
+        var raw = Placeholder.Replace(
+            "From: Microsoft Exchange Server 2010 <exchange@example.com>",
+            "From: Mail Delivery System <postmaster@example.com>");
+        Assert.True(ProviderPlaceholderDetector.IsProviderRetrievalErrorPlaceholder(Parse(raw)));
+    }
+
+    [Fact]
+    public void Ordinary_mail_is_not_a_placeholder()
+    {
+        var raw = """
+            From: Colleague <colleague@example.com>
+            To: User <user@example.com>
+            Subject: Quarterly review
+
+            Please find the numbers attached.
+            """;
+        Assert.False(ProviderPlaceholderDetector.IsProviderRetrievalErrorPlaceholder(Parse(raw)));
+    }
+
+    [Fact]
+    public void Microsoft_sender_alone_is_not_a_placeholder()
+    {
+        var raw = """
+            From: Microsoft Exchange Server 2010 <exchange@example.com>
+            To: User <user@example.com>
+            Subject: Your mailbox is almost full
+
+            Please delete some messages.
+            """;
+        Assert.False(ProviderPlaceholderDetector.IsProviderRetrievalErrorPlaceholder(Parse(raw)));
+    }
+
+    [Fact]
+    public void Subject_marker_without_the_body_marker_is_not_a_placeholder()
+    {
+        var raw = """
+            From: Colleague <colleague@example.com>
+            To: User <user@example.com>
+            Subject: Retrieval using the IMAP4 protocol failed for the following message: 270198
+
+            Forwarding this because our archiver logged it. Any idea what it means?
+            """;
+        Assert.False(ProviderPlaceholderDetector.IsProviderRetrievalErrorPlaceholder(Parse(raw)));
+    }
+
+    [Fact]
+    public void Body_marker_without_the_subject_marker_is_not_a_placeholder()
+    {
+        var raw = """
+            From: Colleague <colleague@example.com>
+            To: User <user@example.com>
+            Subject: Re: that Exchange problem again
+
+            The server couldn't retrieve the following message: that is the exact wording we see.
+            """;
+        Assert.False(ProviderPlaceholderDetector.IsProviderRetrievalErrorPlaceholder(Parse(raw)));
+    }
+
+    [Fact]
+    public void Message_without_a_subject_is_not_a_placeholder()
+    {
+        var raw = """
+            From: Colleague <colleague@example.com>
+            To: User <user@example.com>
+
+            The server couldn't retrieve the following message:
+            """;
+        Assert.False(ProviderPlaceholderDetector.IsProviderRetrievalErrorPlaceholder(Parse(raw)));
+    }
+
+    [Fact]
+    public void Null_message_is_not_a_placeholder()
+    {
+        Assert.False(ProviderPlaceholderDetector.IsProviderRetrievalErrorPlaceholder(null));
+    }
+
+    [Fact]
+    public void Original_subject_is_read_out_of_the_placeholder_body()
+    {
+        Assert.Equal("Example meeting",
+            ProviderPlaceholderDetector.TryGetOriginalSubject(Parse(Placeholder)));
+    }
+
+    [Fact]
+    public void Original_subject_is_null_when_the_body_does_not_quote_one()
+    {
+        var raw = Placeholder.Replace("Subject: \"Example meeting\"", "Subject: not quoted");
+        Assert.Null(ProviderPlaceholderDetector.TryGetOriginalSubject(Parse(raw)));
+    }
+
+    [Fact]
+    public void Original_subject_is_null_for_a_message_without_a_text_body()
+    {
+        Assert.Null(ProviderPlaceholderDetector.TryGetOriginalSubject(null));
+    }
+}

--- a/tests/MailArchiver.Tests/Shared/ProviderPlaceholderDetectorTests.cs
+++ b/tests/MailArchiver.Tests/Shared/ProviderPlaceholderDetectorTests.cs
@@ -143,6 +143,28 @@ public class ProviderPlaceholderDetectorTests
     }
 
     [Fact]
+    public void Original_subject_is_read_out_of_a_crlf_placeholder_body()
+    {
+        // MimeKit's TextBody getter normalises line endings to Environment.NewLine of the
+        // running platform, so on Windows the body arrives with CRLF even when the raw
+        // message used LF. Setting the body via TextPart stores the string as-is, so CRLF
+        // can be forced here regardless of the platform the tests run on.
+        var message = new MimeMessage
+        {
+            Subject = "Retrieval using the IMAP4 protocol failed for the following message: 270198",
+        };
+        message.Body = new TextPart("plain")
+        {
+            Text = "The server couldn't retrieve the following message:\r\n" +
+                   "Subject: \"Example meeting\"\r\n" +
+                   "From: \"Example Sender\"\r\n"
+        };
+
+        Assert.Equal("Example meeting",
+            ProviderPlaceholderDetector.TryGetOriginalSubject(message));
+    }
+
+    [Fact]
     public void Original_subject_is_null_when_the_body_does_not_quote_one()
     {
         var raw = Placeholder.Replace("Subject: \"Example meeting\"", "Subject: not quoted");


### PR DESCRIPTION
## Problem

On some IMAP servers a message can be fetched at the protocol level but not through
`GetMessageAsync`, which raises:

```
MailKit.MessageNotFoundException: The IMAP server did not return the requested message.
```

There is no handler for this exception anywhere in the sync pipeline, so it falls through to the
per-message handler in `ImapMailSyncService` and increments `FailedEmails`. Because `LastSync` is
only advanced when an account finishes with zero failures, a single such message stops the account
from ever recording progress: every sync run re-reads the same mailbox, hits the same UIDs, and
ends the same way. The archive keeps working, but the account never converges and the failure count
never goes down.

This is not hypothetical for legacy on-premises Exchange, where it affects a stable set of UIDs per
mailbox rather than a random few.

## Reproduction

Against a legacy on-premises Exchange mailbox, using plain IMAP commands and no Mail Archiver, for
every affected UID:

1. `UID SEARCH` finds the UID.
2. `HEADER` can be fetched.
3. `TEXT` can be fetched.
4. `BODY[]` can be fetched.
5. The returned document is well-formed MIME and can be saved and parsed as `.eml`.

Yet `folder.GetMessageAsync(uid)` throws `MessageNotFoundException` for the same UID.

What `BODY[]` returns is usually not the original message but a document Exchange generated in its
place:

```
Subject: Retrieval using the IMAP4 protocol failed for the following message: 270198
From: Microsoft Exchange Server 2010

The server couldn't retrieve the following message:
Subject: "..."
```

So the server cannot convert the underlying item to MIME and says so in MIME. For an archive that
is the best available truth about that UID — but today it is discarded and the UID is retried
forever instead.

## Root cause

`MessageNotFoundException` is not a statement about the mailbox. MailKit raises it when the
response it correlated to its own request did not contain the message it asked for. The message can
still be reachable through a differently-shaped fetch, which is exactly what the protocol-level
reproduction above shows.

## Solution

**One bounded recovery attempt, only for this exception.**

`Services/Providers/Imap/ImapMessageRecovery.cs` fetches the UID once more through
`IImapFolder.GetStreamsAsync`. Both calls put the same command on the wire —
`UID FETCH … (BODY.PEEK[])` — so this is not a different request. What differs is how MailKit
correlates the response:

- `GetMessageAsync` collects the sections and then looks the message up by exact UID
  (`ProcessGetMessageResponse` → `FetchStreamContext.TryGetSection(uid, …)`, which requires
  `item.UniqueId.HasValue && item.UniqueId.Value == uid`). A miss is what raises
  `MessageNotFoundException`.
- `GetStreamsAsync` uses `FetchStreamCallbackContext`, which invokes the callback for each section
  **as it arrives**, for whatever UID the response carries, and resolves a section that arrived
  without one by **sequence index** when the UID does turn up. It performs no lookup afterwards and
  raises `MessageNotFoundException` nowhere.

So the fallback helps precisely when the body is in the response but MailKit's exact-UID lookup
misses it — the case where the exception is about correlation rather than about the mailbox. If the
server genuinely returns nothing for the UID, `GetStreamsAsync` returns without invoking the
callback, this code returns null, the original exception is rethrown and the message stays a
failure, exactly as today.

It is a public API; there is no reflection on MailKit internals and no fork.

Wired into the existing fetch loop as one more `catch`, next to the mbox From-line recovery that
already sits there and follows the same shape:

- Fires **only** on `MessageNotFoundException`, at most **once per UID**, guarded by a flag. Not on
  `ImapCommandException` in general, not on authentication or connection failures, not on
  throttling, not on parse errors. The existing transient-retry and rate-limit behaviour is
  untouched — a second `MessageNotFoundException` for the same UID is not classified as transient
  and propagates exactly as before.
- Counts as success **only** if raw bytes actually arrived **and** parsed into a `MimeMessage`.
  Anything less rethrows the original exception, so the message stays a failure and an unretrieved
  UID can never be recorded as archived.
- Read-only: `GetStreamsAsync` does not set `\Seen`, change flags, move or delete anything.
- On success the message goes through the **normal** pipeline — `PreCleanMessage`, bandwidth
  tracking and checkpoints, then `EmailCoreService.ArchiveEmailAsync`. No second archiving
  implementation and no custom duplicate detection, so the existing handling of messages without a
  usable `Message-ID` applies to placeholders as it does to anything else.

**Provider placeholder detection.** `Services/Shared/ProviderPlaceholderDetector.cs` recognises the
generated document conservatively: the subject marker **and** a body marker must both be present,
and the sender is never required, because that string differs between Exchange versions and
localisations. A subject alone would misclassify a genuine mail that quotes the error text. The
placeholder is archived exactly as received — never rewritten into the sender, subject or body
quoted inside it, and never silently dropped. It is logged at `Warning` with account, folder, UID
and subject; the body is never logged.

**Counters.** `RecoveredEmails` and `ProviderPlaceholderEmails` (the latter a subset of the former)
are tracked per folder, summed per account and reported in the account's completion log line:

```
Sync completed for account: Example. New: 0, Failed: 0, Deleted: 0, Recovered: 25, Provider placeholders: 25
```

They are deliberately **not** persisted. `SyncJob` is short-lived operational state and this is
diagnostic information, so adding a database migration for it did not seem proportionate. Happy to
surface them in the sync-job UI instead if you would prefer that.

## Backwards compatibility

For a standards-compliant server nothing changes. `GetMessageAsync` remains the normal fast path and
successful messages cost no extra round trip — the fallback only exists inside a `catch` for an
exception that today ends in a failed email. There is no new configuration, no per-account flag, no
Exchange-specific mode, no new dependency and no database migration. The behaviour change is
confined to messages that currently fail: they now get archived, and the account can advance
`LastSync` again.

## Testing

16 new tests, `dotnet test` green with no new warnings.

- `ProviderPlaceholderDetectorTests` — positive sample; typographic apostrophe; the spelled-out
  "could not" wording; a non-Exchange sender; and four negatives that come close on purpose:
  ordinary mail, a Microsoft sender with an unrelated subject, the subject marker without the body
  marker, and the body marker without the subject marker. Plus original-subject extraction and its
  misses. The fixture is synthetic and modelled on a sanitized response; no production data.
- `ImapMessageRecoveryTests` — the parsing half, which is what decides whether a fallback counts as
  a success: valid message, the placeholder itself (a valid MIME document, so it must parse), and an
  empty stream returning null rather than throwing.

The fetch half needs a live IMAP server and is not unit tested, in line with the rest of the IMAP
I/O in this project. That is why the retrieval and the parsing are separate: the pure half is
tested, and the retrieval half can be replaced without touching the sync pipeline.

**Verified against a live legacy Exchange.** The reasoning above about `GetStreamsAsync` seeing what
`GetMessageAsync` discards is not left as theory — a build carrying this change was run against the
server the reproduction came from. An account that had never been able to advance `LastSync`
completed like this (account name and subject redacted):

```
Recovered UID 44917 in folder INBOX for account <account> using the IMAP fallback.
The server returned a provider retrieval-error placeholder instead of the original message.
Placeholder subject: Retrieval using the IMAP4 protocol failed for the following message: 44917.
Original subject: <the message Exchange could not convert>

Sync completed for account: <account>. New: 2, Failed: 0, Deleted: 0, Recovered: 1, Provider placeholders: 1
```

Three things that matter are in those two lines. `GetStreamsAsync` returned a body for a UID
`GetMessageAsync` had raised `MessageNotFoundException` for, so the correlation explanation is the
right one. The placeholder detector fired on a real Exchange document rather than the synthetic
fixture. And `Failed: 0` next to `Recovered: 1` is the account becoming able to advance `LastSync`
for the first time — which is the entire point of the change.

A second, larger mailbox on the same server then recovered **every** UID the original diagnostic had
reported as affected — the same count, including the example UID quoted under Reproduction and each
of the subjects that diagnostic had named. Nothing was left behind and nothing else broke.

What that run also showed is that the affected messages are not a random scattering. Practically all
of them are calendar and meeting objects — acceptances, declines, cancellations, rescheduled
invitations, delivery failures for those, and recurring series where one series alone accounts for
several UIDs. That fits the failure: these are MAPI items the provider cannot render as MIME, rather
than ordinary mail that happens to break.

## Operational impact

The distinction this creates in the logs is the point:

- *Mail Archiver could not sync the item* — a genuine failure, still counted, still blocking
  `LastSync`.
- *Mail Archiver archived exactly what the IMAP server was able to return* — recovered, counted
  separately, and if it was a placeholder, said so.

## Limitations, stated plainly

- The recovery has been **run against the affected server** (see Testing above). What it cannot do is
  recover the original item: where the provider answers with a retrieval-error placeholder, the
  placeholder is what gets archived, because it is all IMAP exposes. No EWS, no Graph, no attempt to
  reconstruct the original from the text quoted inside it.
- Placeholders that arrive through the **normal** fetch path, without any exception, are archived
  without the warning and without incrementing the counter. Keeping `ProviderPlaceholderEmails` a
  strict subset of `RecoveredEmails` seemed more useful than a string test on every message of every
  sync.
- This recovers the best MIME representation IMAP actually exposes. It does not recover the original
  item that the provider itself refuses to convert, and it makes no attempt to — no EWS, no Graph.