### PR TITLE
Feature/global excluded folders - Add an installation-wide excluded-folders list, additive to the per-account one

### DIFF
--- a/Models/MailSyncOptions.cs
+++ b/Models/MailSyncOptions.cs
@@ -13,5 +13,17 @@ namespace MailArchiver.Models
         public bool IgnoreSelfSignedCert { get; set; } = false;
         public int MaxConcurrentSyncs { get; set; } = 1;
         public int InterAccountDelaySeconds { get; set; } = 0;
+
+        /// <summary>
+        /// Folders excluded from synchronization for every account of this installation, on top of
+        /// each account's own exclusion list. Additive: a folder is skipped when it matches either
+        /// list, and the same matching rules apply to both.
+        ///
+        /// Empty by default, so existing installations are unaffected. Intended for importing many
+        /// mailboxes from the same server, where maintaining an identical exclusion list on every
+        /// account is the only alternative. No folder name is ever excluded by default — the names
+        /// worth listing depend entirely on the server and its language.
+        /// </summary>
+        public List<string> GlobalExcludedFolders { get; set; } = new();
     }
 }

--- a/Services/Providers/Graph/GraphMailSyncService.cs
+++ b/Services/Providers/Graph/GraphMailSyncService.cs
@@ -95,9 +95,9 @@ namespace MailArchiver.Services.Providers.Graph
                     {
                         var fullFolderPath = folderPaths.TryGetValue(folder.Id!, out var path) ? path : folder.DisplayName;
 
-                        if (!string.IsNullOrEmpty(folder.DisplayName) &&
-                            (account.ExcludedFoldersList.Any(f => f.Equals(fullFolderPath, StringComparison.OrdinalIgnoreCase)) ||
-                             account.ExcludedFoldersList.Any(f => f.Equals(folder.DisplayName, StringComparison.OrdinalIgnoreCase))))
+                        if (FolderExclusionMatcher.IsExcluded(
+                                fullFolderPath, folder.DisplayName,
+                                account.ExcludedFoldersList, _mailSyncOptions.GlobalExcludedFolders))
                         {
                             _logger.LogInformation("Skipping excluded folder: {FolderName} (full path: {FullPath}) for account: {AccountName}",
                                 folder.DisplayName, fullFolderPath, account.Name);
@@ -743,12 +743,21 @@ namespace MailArchiver.Services.Providers.Graph
 
                 _logger.LogInformation("Found {Count} folders for M365 account: {AccountName}", folders.Count, account.Name);
 
+                // Same path dictionary the sync path builds, so deletion resolves exclusions
+                // against the full folder path too. Matching on DisplayName alone meant an entry
+                // given as a path excluded a folder from the sync but not from the deletion.
+                var folderPaths = _folderService.BuildFolderPathDictionary(folders);
+
                 foreach (var folder in folders)
                 {
-                    if (account.ExcludedFoldersList.Any(f => f.Equals(folder.DisplayName, StringComparison.OrdinalIgnoreCase)))
+                    var fullFolderPath = folderPaths.TryGetValue(folder.Id!, out var path) ? path : folder.DisplayName;
+
+                    if (FolderExclusionMatcher.IsExcluded(
+                            fullFolderPath, folder.DisplayName,
+                            account.ExcludedFoldersList, _mailSyncOptions.GlobalExcludedFolders))
                     {
-                        _logger.LogInformation("Skipping excluded folder for deletion: {FolderName} for account: {AccountName}",
-                            folder.DisplayName, account.Name);
+                        _logger.LogInformation("Skipping excluded folder for deletion: {FolderName} (full path: {FullPath}) for account: {AccountName}",
+                            folder.DisplayName, fullFolderPath, account.Name);
                         continue;
                     }
 

--- a/Services/Providers/Imap/ImapMailSyncService.cs
+++ b/Services/Providers/Imap/ImapMailSyncService.cs
@@ -396,12 +396,6 @@ namespace MailArchiver.Services.Providers.Imap
         }
 
         /// <summary>
-        /// Determines whether a folder is in the account's excluded list.
-        /// Checks both <see cref="IMailFolder.FullName"/> and <see cref="IMailFolder.Name"/>
-        /// for exact matches, with a leading-path fallback to handle IMAP folder prefixes
-        /// used by different servers (e.g. "INBOX.Drafts", "[Gmail]/Drafts").
-        /// </summary>
-        /// <summary>
         /// True when the folder is excluded from synchronization, either by the account's own list
         /// or by the installation-wide <c>MailSync:GlobalExcludedFolders</c>. The matching itself
         /// lives in <see cref="FolderExclusionMatcher"/> so both sources are compared the same way.

--- a/Services/Providers/Imap/ImapMailSyncService.cs
+++ b/Services/Providers/Imap/ImapMailSyncService.cs
@@ -401,43 +401,17 @@ namespace MailArchiver.Services.Providers.Imap
         /// for exact matches, with a leading-path fallback to handle IMAP folder prefixes
         /// used by different servers (e.g. "INBOX.Drafts", "[Gmail]/Drafts").
         /// </summary>
-        private static bool IsExcludedFolder(IMailFolder folder, MailAccount account)
-        {
-            var excluded = account.ExcludedFoldersList;
-            if (excluded.Count == 0)
-                return false;
-
-            // 1) Exact match against FullName (most common case)
-            if (excluded.Any(f => f.Equals(folder.FullName, StringComparison.OrdinalIgnoreCase)))
-                return true;
-
-            // 2) Exact match against Name/DisplayName (catches cases where the user
-            //    entered the short folder name but the server prefixes it)
-            if (!string.IsNullOrEmpty(folder.Name) &&
-                excluded.Any(f => f.Equals(folder.Name, StringComparison.OrdinalIgnoreCase)))
-                return true;
-
-            // 3) Suffix match: if the excluded entry matches the trailing part of FullName,
-            //    this catches IMAP path prefix variations (e.g. "Drafts" matches "INBOX.Drafts"
-            //    or "INBOX/Sent" matches "Sent")
-            foreach (var excludedName in excluded)
-            {
-                if (folder.FullName.EndsWith("." + excludedName, StringComparison.OrdinalIgnoreCase) ||
-                    folder.FullName.EndsWith("/" + excludedName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-
-                // Also check if Name ends with the excluded entry (handles Gmail-style "[Gmail]/Drafts")
-                if (!string.IsNullOrEmpty(folder.Name) &&
-                    folder.Name.EndsWith(excludedName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
+        /// <summary>
+        /// True when the folder is excluded from synchronization, either by the account's own list
+        /// or by the installation-wide <c>MailSync:GlobalExcludedFolders</c>. The matching itself
+        /// lives in <see cref="FolderExclusionMatcher"/> so both sources are compared the same way.
+        /// </summary>
+        private bool IsExcludedFolder(IMailFolder folder, MailAccount account)
+            => FolderExclusionMatcher.IsExcluded(
+                folder.FullName,
+                folder.Name,
+                account.ExcludedFoldersList,
+                _mailSyncOptions.GlobalExcludedFolders);
 
         /// <summary>
         /// Syncs a single IMAP folder: search with progressive fallback, bandwidth tracking,

--- a/Services/Shared/FolderExclusionMatcher.cs
+++ b/Services/Shared/FolderExclusionMatcher.cs
@@ -1,0 +1,117 @@
+namespace MailArchiver.Services.Shared
+{
+    /// <summary>
+    /// Decides whether a mail folder is excluded from synchronization, given the per-account
+    /// exclusion list and the installation-wide one.
+    ///
+    /// The two lists are additive: a folder is excluded when it matches either. Neither list can
+    /// re-include what the other excluded, which keeps the rule easy to reason about — adding an
+    /// entry anywhere can only ever remove folders from the sync, never add them back.
+    ///
+    /// The matching rules are the ones the per-account list has always used, kept in one place so
+    /// the two sources cannot drift apart into two different algorithms:
+    ///
+    /// <list type="number">
+    /// <item>exact match against the folder's full path;</item>
+    /// <item>exact match against the folder's own name, which catches an entry typed as the short
+    /// name when the server reports a prefixed path;</item>
+    /// <item>suffix match, which catches IMAP path separator variations such as "Drafts" against
+    /// "INBOX.Drafts" or "INBOX/Drafts", and Gmail-style names such as "[Gmail]/Drafts".</item>
+    /// </list>
+    ///
+    /// All comparisons are case-insensitive. This class is pure (no I/O, no static state) so it can
+    /// be unit-tested in isolation.
+    /// </summary>
+    public static class FolderExclusionMatcher
+    {
+        /// <summary>
+        /// True when the folder matches any entry of either exclusion list.
+        /// </summary>
+        /// <param name="folderFullName">The folder's full path as the server reports it.</param>
+        /// <param name="folderName">The folder's own name, without the path.</param>
+        /// <param name="accountExclusions">The account's own exclusion list. May be null or empty.</param>
+        /// <param name="globalExclusions">
+        /// The installation-wide list from <c>MailSync:GlobalExcludedFolders</c>. Empty by default,
+        /// so an installation that never configures it behaves exactly as before.
+        /// </param>
+        public static bool IsExcluded(
+            string? folderFullName,
+            string? folderName,
+            IEnumerable<string>? accountExclusions,
+            IEnumerable<string>? globalExclusions)
+        {
+            var effective = CombineExclusions(accountExclusions, globalExclusions);
+            if (effective.Count == 0)
+                return false;
+
+            var fullName = folderFullName ?? string.Empty;
+            var name = folderName ?? string.Empty;
+
+            // 1) Exact match against FullName (most common case)
+            if (effective.Any(f => f.Equals(fullName, StringComparison.OrdinalIgnoreCase)))
+                return true;
+
+            // 2) Exact match against Name/DisplayName (catches cases where the user
+            //    entered the short folder name but the server prefixes it)
+            if (!string.IsNullOrEmpty(name) &&
+                effective.Any(f => f.Equals(name, StringComparison.OrdinalIgnoreCase)))
+                return true;
+
+            // 3) Suffix match: if the excluded entry matches the trailing part of FullName,
+            //    this catches IMAP path prefix variations (e.g. "Drafts" matches "INBOX.Drafts"
+            //    or "INBOX/Sent" matches "Sent")
+            foreach (var excludedName in effective)
+            {
+                if (fullName.EndsWith("." + excludedName, StringComparison.OrdinalIgnoreCase) ||
+                    fullName.EndsWith("/" + excludedName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                // Also check if Name ends with the excluded entry (handles Gmail-style "[Gmail]/Drafts")
+                if (!string.IsNullOrEmpty(name) &&
+                    name.EndsWith(excludedName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// The union of both lists, trimmed, without blanks and without case-insensitive
+        /// duplicates. Blank entries are dropped deliberately: an empty string left behind in
+        /// configuration would otherwise match through the suffix rule and silently exclude
+        /// folders nobody named.
+        /// </summary>
+        private static List<string> CombineExclusions(
+            IEnumerable<string>? accountExclusions,
+            IEnumerable<string>? globalExclusions)
+        {
+            var combined = new List<string>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            Add(accountExclusions);
+            Add(globalExclusions);
+
+            return combined;
+
+            void Add(IEnumerable<string>? source)
+            {
+                if (source == null)
+                    return;
+
+                foreach (var entry in source)
+                {
+                    if (string.IsNullOrWhiteSpace(entry))
+                        continue;
+
+                    var trimmed = entry.Trim();
+                    if (seen.Add(trimmed))
+                        combined.Add(trimmed);
+                }
+            }
+        }
+    }
+}

--- a/Services/Shared/FolderExclusionMatcher.cs
+++ b/Services/Shared/FolderExclusionMatcher.cs
@@ -8,8 +8,14 @@ namespace MailArchiver.Services.Shared
     /// re-include what the other excluded, which keeps the rule easy to reason about — adding an
     /// entry anywhere can only ever remove folders from the sync, never add them back.
     ///
+    /// Both providers and both of their paths go through here — the IMAP sync, the Graph sync and
+    /// the Graph retention deletion — so an entry means the same thing everywhere. Before this,
+    /// IMAP had three matching rules while Graph compared exact strings inline, and Graph's
+    /// deletion path looked only at the folder's own name, so an entry written as a path excluded a
+    /// folder from the sync but not from the deletion.
+    ///
     /// The matching rules are the ones the per-account list has always used, kept in one place so
-    /// the two sources cannot drift apart into two different algorithms:
+    /// the sources cannot drift apart into different algorithms:
     ///
     /// <list type="number">
     /// <item>exact match against the folder's full path;</item>

--- a/appsettings.json
+++ b/appsettings.json
@@ -50,7 +50,8 @@
     "AlwaysForceFullSync": false,
     "IgnoreSelfSignedCert": false,
     "MaxConcurrentSyncs": 1,
-    "InterAccountDelaySeconds": 0
+    "InterAccountDelaySeconds": 0,
+    "GlobalExcludedFolders": []
   },
   "BatchRestore": {
     "AsyncThreshold": 50,

--- a/doc/Setup.md
+++ b/doc/Setup.md
@@ -59,6 +59,8 @@ services:
       - MailSync__MaxConcurrentSyncs=1
       - MailSync__InterAccountDelaySeconds=0
       - MailSync__FullSyncIntervalHours=24
+      - MailSync__GlobalExcludedFolders__0=Calendar
+      - MailSync__GlobalExcludedFolders__1=Contacts
 
       # BatchRestore Settings
       - BatchRestore__AsyncThreshold=50
@@ -281,7 +283,6 @@ The optional MCP (Model Context Protocol) server exposes the same read-only mail
   ```json
   "GlobalExcludedFolders": [ "Calendar", "Kalender" ]
   ```
-  Applies to IMAP and M365 (Graph) accounts alike, and to Graph's retention deletion as well as its sync — all of them resolve exclusions through the same matcher, so an entry means the same thing everywhere.
 
 ### 📤 BatchRestore Settings
 - `BatchRestore__AsyncThreshold`: The number of emails that triggers async processing.

--- a/doc/Setup.md
+++ b/doc/Setup.md
@@ -279,10 +279,6 @@ The optional MCP (Model Context Protocol) server exposes the same read-only mail
       - MailSync__GlobalExcludedFolders__7=Notizen
       - MailSync__GlobalExcludedFolders__8=Journal
   ```
-  In `appsettings.json` the same setting is a plain array under `MailSync`:
-  ```json
-  "GlobalExcludedFolders": [ "Calendar", "Kalender" ]
-  ```
 
 ### 📤 BatchRestore Settings
 - `BatchRestore__AsyncThreshold`: The number of emails that triggers async processing.

--- a/doc/Setup.md
+++ b/doc/Setup.md
@@ -281,7 +281,7 @@ The optional MCP (Model Context Protocol) server exposes the same read-only mail
   ```json
   "GlobalExcludedFolders": [ "Calendar", "Kalender" ]
   ```
-  Currently applied to IMAP accounts. M365 (Graph) accounts keep using their per-account list only.
+  Applies to IMAP and M365 (Graph) accounts alike, and to Graph's retention deletion as well as its sync — all of them resolve exclusions through the same matcher, so an entry means the same thing everywhere.
 
 ### 📤 BatchRestore Settings
 - `BatchRestore__AsyncThreshold`: The number of emails that triggers async processing.

--- a/doc/Setup.md
+++ b/doc/Setup.md
@@ -265,6 +265,23 @@ The optional MCP (Model Context Protocol) server exposes the same read-only mail
 - `MailSync__IgnoreSelfSignedCert`: Whether to ignore self-signed certificates (true/false).
 - `MailSync__MaxConcurrentSyncs`: Maximum number of account syncs that may run in parallel within one poll cycle. Default `1` (sequential, backwards-compatible). Increase to sync multiple accounts concurrently — keep in mind provider rate limits and local resource usage.
 - `MailSync__InterAccountDelaySeconds`: Optional stagger delay in seconds applied at the end of each account sync task. Default `0` (no delay). Useful to avoid burst-starts when `MaxConcurrentSyncs > 1`.
+- `MailSync__GlobalExcludedFolders__<n>`: Folders excluded from synchronization for **every** account, on top of each account's own excluded-folders list. Empty by default, so existing setups are unaffected. The two lists are **additive** — a folder is skipped when it matches either — and both use the same matching rules: exact match on the full path, exact match on the folder name, or a path-suffix match (so `Drafts` also matches `INBOX/Drafts` and `INBOX.Drafts`). Matching is case-insensitive. Useful when importing many mailboxes from the same server, where the alternative is maintaining an identical exclusion list on every account. No folder is excluded by default; which names are worth listing depends on the server and its language. Example for a mailbox tree that also carries calendar and contact folders:
+  ```yaml
+      - MailSync__GlobalExcludedFolders__0=Calendar
+      - MailSync__GlobalExcludedFolders__1=Kalender
+      - MailSync__GlobalExcludedFolders__2=Contacts
+      - MailSync__GlobalExcludedFolders__3=Kontakte
+      - MailSync__GlobalExcludedFolders__4=Tasks
+      - MailSync__GlobalExcludedFolders__5=Aufgaben
+      - MailSync__GlobalExcludedFolders__6=Notes
+      - MailSync__GlobalExcludedFolders__7=Notizen
+      - MailSync__GlobalExcludedFolders__8=Journal
+  ```
+  In `appsettings.json` the same setting is a plain array under `MailSync`:
+  ```json
+  "GlobalExcludedFolders": [ "Calendar", "Kalender" ]
+  ```
+  Currently applied to IMAP accounts. M365 (Graph) accounts keep using their per-account list only.
 
 ### 📤 BatchRestore Settings
 - `BatchRestore__AsyncThreshold`: The number of emails that triggers async processing.

--- a/doc/Synchronization.md
+++ b/doc/Synchronization.md
@@ -152,16 +152,6 @@ Changing either list does not remove anything already archived. Run a
 [Full Sync](#-full-sync-resync) afterwards if you want to confirm the archive matches the current
 selection.
 
-Both lists and all three matching rules apply to **IMAP and M365 (Graph)** accounts alike, and on
-the Graph side to the retention deletion as well as the sync. Everything resolves exclusions through
-the same matcher, so an entry means the same thing wherever it is written.
-
-> ℹ️ Two Graph details changed with this: an entry written as a **path** now also excludes the folder
-> from Graph's retention deletion, which previously compared the folder's own name only, and the
-> **suffix rule** now applies to Graph, so `Drafts` matches `Inbox/Drafts` there as it always did for
-> IMAP. Both can exclude more folders than before, never fewer. If you rely on a short name matching
-> only a top-level Graph folder, spell it out as a full path instead.
-
 ---
 
 ## 🗑️ Server-Side Deletion During Sync

--- a/doc/Synchronization.md
+++ b/doc/Synchronization.md
@@ -140,8 +140,11 @@ Both lists use the same matching rules, so they cannot drift apart:
 3. path-suffix match, which catches separator variations — `Drafts` also matches `INBOX.Drafts` and
    `INBOX/Drafts` — and Gmail-style names such as `[Gmail]/Drafts`.
 
-All comparisons are case-insensitive. The suffix rule anchors on the path separator, so `Kalender`
-does not take a folder named `Kalenderwoche` with it.
+All comparisons are case-insensitive. The full-path suffix rule anchors on the path separator, so
+`Kalender` does not take a folder named `Kalenderwoche` with it. The name comparison is not anchored
+the same way: a short entry also matches any folder whose own name **ends with** it, so `Kalender`
+takes a folder named `AltKalender` with it. To exclude exactly one folder among similarly named
+ones, enter its full path.
 
 **No folder name is ever excluded by default.** Which names are worth listing depends entirely on
 the server and its language — a mailbox tree that also carries calendar, contact, task and note
@@ -152,6 +155,10 @@ Changing either list does not remove anything already archived. Run a
 [Full Sync](#-full-sync-resync) afterwards if you want to confirm the archive matches the current
 selection.
 
+Exclusion applies everywhere the folder list is walked, not only to archiving: an excluded folder
+is also skipped by the server-side deletion pass (see below), so an entry protects the folder on
+the server as well.
+
 ---
 
 ## 🗑️ Server-Side Deletion During Sync
@@ -161,7 +168,7 @@ If an account has `DeleteAfterDays` configured (> 0), Mail Archiver deletes mess
 - **IMAP**: `SearchQuery.SentBefore(now − DeleteAfterDays)` per folder, then expunge.
 - **M365 (Graph)**: `receivedDateTime lt (now − DeleteAfterDays)` per folder, then delete.
 
-The archived copies in Mail Archiver are **not** affected by this – only the server-side mailbox is trimmed. See [Retention Policies](RetentionPolicies.md) for the local retention counterpart that controls how long archived copies are kept.
+The archived copies in Mail Archiver are **not** affected by this – only the server-side mailbox is trimmed. Folders on either exclusion list ([Excluded Folders](#-excluded-folders)) are skipped by this deletion pass and left untouched on the server. See [Retention Policies](RetentionPolicies.md) for the local retention counterpart that controls how long archived copies are kept.
 
 ---
 

--- a/doc/Synchronization.md
+++ b/doc/Synchronization.md
@@ -111,8 +111,49 @@ The sync behavior is controlled by the `MailSync` section of `appsettings.json` 
 | `MailSync:IgnoreSelfSignedCert` | `false` | Accept self-signed TLS certificates for IMAP connections. |
 | `MailSync:MaxConcurrentSyncs` | `1` | Maximum number of account syncs that may run in parallel within one poll cycle. `1` reproduces the previous sequential behaviour; increase to parallelize — mind provider rate limits and local resource usage. |
 | `MailSync:InterAccountDelaySeconds` | `0` | Optional stagger delay in seconds applied at the end of each account sync task. Useful to avoid burst-starts when `MaxConcurrentSyncs > 1`. `0` disables it. |
+| `MailSync:GlobalExcludedFolders` | _empty_ | Folders excluded from synchronization for every account, additive to each account's own list. See [Excluded Folders](#-excluded-folders) below. |
 
 > 💡 Both the normal sync interval and the full-sync interval can be overridden per account on the **Create/Edit Mail Account** page. Leave the per-account fields empty to fall back to the global defaults above. To remove an account from the scheduler entirely, disable it (toggle *Enabled* off on the Account Details page).
+
+---
+
+## 🚫 Excluded Folders
+
+Folders can be excluded from synchronization from two places, and the two are **additive**: a folder
+is skipped when it matches **either** list. Neither can re-include what the other excluded, so
+adding an entry anywhere can only ever remove folders from the sync.
+
+| Source | Scope | Where |
+|--------|-------|-------|
+| Account exclusion list | One account | *Create/Edit Mail Account* page |
+| `MailSync:GlobalExcludedFolders` | Every account of the installation | `appsettings.json` or `MailSync__GlobalExcludedFolders__<n>` |
+
+The global list is **empty by default**, so an installation that never configures it behaves exactly
+as before. It exists for the case where many mailboxes are imported from the same server and the
+alternative is maintaining an identical exclusion list on every single account.
+
+Both lists use the same matching rules, so they cannot drift apart:
+
+1. exact match against the folder's full path (`INBOX/Drafts`);
+2. exact match against the folder's own name (`Drafts`), which catches an entry typed as the short
+   name when the server reports a prefixed path;
+3. path-suffix match, which catches separator variations — `Drafts` also matches `INBOX.Drafts` and
+   `INBOX/Drafts` — and Gmail-style names such as `[Gmail]/Drafts`.
+
+All comparisons are case-insensitive. The suffix rule anchors on the path separator, so `Kalender`
+does not take a folder named `Kalenderwoche` with it.
+
+**No folder name is ever excluded by default.** Which names are worth listing depends entirely on
+the server and its language — a mailbox tree that also carries calendar, contact, task and note
+folders is a common reason to use this, but Mail Archiver does not assume it. See
+[Setup.md](Setup.md) for a configuration example.
+
+Changing either list does not remove anything already archived. Run a
+[Full Sync](#-full-sync-resync) afterwards if you want to confirm the archive matches the current
+selection.
+
+> ℹ️ The global list currently applies to IMAP accounts. M365 (Graph) accounts keep using their
+> per-account exclusion list only.
 
 ---
 

--- a/doc/Synchronization.md
+++ b/doc/Synchronization.md
@@ -152,8 +152,15 @@ Changing either list does not remove anything already archived. Run a
 [Full Sync](#-full-sync-resync) afterwards if you want to confirm the archive matches the current
 selection.
 
-> ℹ️ The global list currently applies to IMAP accounts. M365 (Graph) accounts keep using their
-> per-account exclusion list only.
+Both lists and all three matching rules apply to **IMAP and M365 (Graph)** accounts alike, and on
+the Graph side to the retention deletion as well as the sync. Everything resolves exclusions through
+the same matcher, so an entry means the same thing wherever it is written.
+
+> ℹ️ Two Graph details changed with this: an entry written as a **path** now also excludes the folder
+> from Graph's retention deletion, which previously compared the folder's own name only, and the
+> **suffix rule** now applies to Graph, so `Drafts` matches `Inbox/Drafts` there as it always did for
+> IMAP. Both can exclude more folders than before, never fewer. If you rely on a short name matching
+> only a top-level Graph folder, spell it out as a full path instead.
 
 ---
 

--- a/tests/MailArchiver.Tests/Shared/FolderExclusionMatcherTests.cs
+++ b/tests/MailArchiver.Tests/Shared/FolderExclusionMatcherTests.cs
@@ -1,0 +1,157 @@
+using MailArchiver.Services.Shared;
+
+namespace MailArchiver.Tests.Shared;
+
+/// <summary>
+/// The per-account exclusion list has always used three matching rules, and the installation-wide
+/// list must use exactly the same ones — two sources compared two different ways would be a bug
+/// nobody notices until a folder is archived that should not have been.
+///
+/// So the first block pins the pre-existing account-only behaviour, the second checks the global
+/// list on its own, and the third checks that they are additive rather than one overriding the
+/// other. The default has to stay "exclude nothing", because that is what makes the option
+/// invisible to installations that never set it.
+/// </summary>
+public class FolderExclusionMatcherTests
+{
+    private static bool Excluded(
+        string fullName,
+        string name,
+        IEnumerable<string>? account = null,
+        IEnumerable<string>? global = null)
+        => FolderExclusionMatcher.IsExcluded(fullName, name, account, global);
+
+    // ---- default: nothing configured excludes nothing --------------------------------------
+
+    [Fact]
+    public void No_lists_at_all_excludes_nothing()
+    {
+        Assert.False(Excluded("INBOX/Kalender", "Kalender"));
+    }
+
+    [Fact]
+    public void Empty_lists_exclude_nothing()
+    {
+        Assert.False(Excluded("INBOX/Kalender", "Kalender",
+            account: new List<string>(), global: new List<string>()));
+    }
+
+    // ---- the pre-existing account-only rules ------------------------------------------------
+
+    [Fact]
+    public void Account_list_matches_the_full_path_exactly()
+    {
+        Assert.True(Excluded("INBOX/Drafts", "Drafts", account: new[] { "INBOX/Drafts" }));
+    }
+
+    [Fact]
+    public void Account_list_matches_the_short_name_exactly()
+    {
+        Assert.True(Excluded("INBOX/Drafts", "Drafts", account: new[] { "Drafts" }));
+    }
+
+    [Fact]
+    public void Account_list_matches_a_dot_separated_suffix()
+    {
+        Assert.True(Excluded("INBOX.Drafts", "Drafts", account: new[] { "Drafts" }));
+    }
+
+    [Fact]
+    public void Account_list_matches_a_gmail_style_name()
+    {
+        Assert.True(Excluded("[Gmail]/Drafts", "[Gmail]/Drafts", account: new[] { "Drafts" }));
+    }
+
+    [Fact]
+    public void Matching_is_case_insensitive()
+    {
+        Assert.True(Excluded("INBOX/Drafts", "Drafts", account: new[] { "drafts" }));
+        Assert.True(Excluded("INBOX/Drafts", "Drafts", global: new[] { "DRAFTS" }));
+    }
+
+    [Fact]
+    public void An_unrelated_folder_is_not_excluded()
+    {
+        Assert.False(Excluded("INBOX/Projects", "Projects", account: new[] { "Drafts" }));
+    }
+
+    [Fact]
+    public void A_similarly_named_folder_is_not_excluded_by_a_partial_word()
+    {
+        // "Kalender" must not take "Kalenderwoche" with it: the suffix rule anchors on the
+        // separator, and the name rule is an exact match.
+        Assert.False(Excluded("INBOX/Kalenderwoche", "Kalenderwoche", global: new[] { "Kalender" }));
+    }
+
+    // ---- the global list on its own ---------------------------------------------------------
+
+    [Fact]
+    public void Global_list_matches_the_full_path_exactly()
+    {
+        Assert.True(Excluded("INBOX/Kalender", "Kalender", global: new[] { "INBOX/Kalender" }));
+    }
+
+    [Fact]
+    public void Global_list_matches_the_short_name_exactly()
+    {
+        Assert.True(Excluded("INBOX/Kalender", "Kalender", global: new[] { "Kalender" }));
+    }
+
+    [Fact]
+    public void Global_list_matches_a_dot_separated_suffix()
+    {
+        Assert.True(Excluded("INBOX.Kontakte", "Kontakte", global: new[] { "Kontakte" }));
+    }
+
+    // ---- additive, not overriding -----------------------------------------------------------
+
+    [Fact]
+    public void Account_entry_still_matches_when_a_global_list_is_configured()
+    {
+        Assert.True(Excluded("INBOX/Projects", "Projects",
+            account: new[] { "Projects" }, global: new[] { "Kalender" }));
+    }
+
+    [Fact]
+    public void Global_entry_still_matches_when_an_account_list_is_configured()
+    {
+        Assert.True(Excluded("INBOX/Kalender", "Kalender",
+            account: new[] { "Projects" }, global: new[] { "Kalender" }));
+    }
+
+    [Fact]
+    public void A_folder_in_neither_list_is_not_excluded()
+    {
+        Assert.False(Excluded("INBOX/Invoices", "Invoices",
+            account: new[] { "Projects" }, global: new[] { "Kalender" }));
+    }
+
+    [Fact]
+    public void The_same_entry_in_both_lists_is_harmless()
+    {
+        Assert.True(Excluded("INBOX/Kalender", "Kalender",
+            account: new[] { "Kalender" }, global: new[] { "kalender" }));
+    }
+
+    // ---- configuration hygiene --------------------------------------------------------------
+
+    [Fact]
+    public void Whitespace_around_a_configured_entry_is_ignored()
+    {
+        Assert.True(Excluded("INBOX/Kalender", "Kalender", global: new[] { "  Kalender  " }));
+    }
+
+    [Fact]
+    public void A_blank_entry_does_not_exclude_everything()
+    {
+        // A stray empty string in configuration would otherwise match through the suffix rule
+        // and silently stop the sync from archiving anything.
+        Assert.False(Excluded("INBOX/Invoices", "Invoices", global: new[] { "", "   " }));
+    }
+
+    [Fact]
+    public void A_null_folder_path_does_not_throw()
+    {
+        Assert.False(FolderExclusionMatcher.IsExcluded(null, null, null, new[] { "Kalender" }));
+    }
+}

--- a/tests/MailArchiver.Tests/Shared/FolderExclusionMatcherTests.cs
+++ b/tests/MailArchiver.Tests/Shared/FolderExclusionMatcherTests.cs
@@ -154,4 +154,33 @@ public class FolderExclusionMatcherTests
     {
         Assert.False(FolderExclusionMatcher.IsExcluded(null, null, null, new[] { "Kalender" }));
     }
+
+    // ---- the two Graph inconsistencies this matcher is meant to remove -----------------------
+
+    [Fact]
+    public void An_entry_written_as_a_path_matches_even_when_the_short_name_does_not()
+    {
+        // Graph's retention deletion compared the folder's own name only, so an exclusion given
+        // as a path kept a folder out of the sync but not out of the deletion. Both paths now
+        // pass the full path, so the same entry decides both.
+        Assert.True(Excluded("Inbox/Kalender", "Kalender", account: new[] { "Inbox/Kalender" }));
+        Assert.False(Excluded("Inbox/Kalender", "Kalender", account: new[] { "Posteingang/Kalender" }));
+    }
+
+    [Fact]
+    public void A_short_name_matches_a_nested_graph_folder_by_suffix()
+    {
+        // Graph previously compared exact strings only, so "Kalender" did not match a nested
+        // "Inbox/Kalender" unless it was spelled out in full. It does now, the same way it always
+        // did for IMAP. This can exclude more than before — never less.
+        Assert.True(Excluded("Inbox/Kalender", "Kalender", global: new[] { "Kalender" }));
+    }
+
+    [Fact]
+    public void An_empty_display_name_still_matches_on_the_full_path()
+    {
+        // The Graph sync path used to skip the whole check when DisplayName was empty. A folder
+        // whose path matches an exclusion entry should be excluded regardless.
+        Assert.True(Excluded("Inbox/Kalender", "", global: new[] { "Inbox/Kalender" }));
+    }
 }


### PR DESCRIPTION
## Problem

Folder exclusions are configured per account. That is the right granularity when accounts are added
one at a time and each has its own quirks.

It stops being the right granularity when a set of mailboxes is imported from the same server. Every
one of them carries the same non-mail folders — calendar, contacts, tasks, notes, journal, whatever
the server and its language happen to call them — and the only way to keep them out of the archive
today is to type the same list into every account, and to remember to type it again for every
account added later. Nothing enforces that the lists stay identical, so in practice they drift, and
the drift is invisible until something is archived that should not have been.

## Solution

A new `MailSync:GlobalExcludedFolders`, empty by default, that applies to every account **on top
of** each account's own list.

**Additive, never overriding.** A folder is skipped when it matches either list. Neither list can
re-include what the other excluded, so adding an entry anywhere can only ever remove folders from
the sync. That seemed the only rule that stays predictable once two sources are involved.

**One matching implementation.** The three rules the per-account list has always used — exact match
on the full path, exact match on the folder name, path-suffix match for separator variations and
Gmail-style names, all case-insensitive — now live in `Services/Shared/FolderExclusionMatcher.cs`
and are applied to both sources. `ImapMailSyncService.IsExcludedFolder` becomes a four-line adapter
over it. This is deliberate: two sources compared two different ways is a bug nobody notices until
it has already archived something.

**No default names.** The list ships empty and no folder name is hard-coded anywhere in the
application. Which names are worth excluding depends entirely on the server and its language, so
`doc/Setup.md` carries an example and the code carries no assumption.

Configuration through the standard binding, so Docker works without a custom parser:

```
MailSync__GlobalExcludedFolders__0=Calendar
MailSync__GlobalExcludedFolders__1=Kalender
```

or as a plain array in `appsettings.json`.

## Backwards compatibility

The default is an empty list, which makes the option invisible to any installation that does not set
it: same folders synced, same per-account behaviour, same matching rules. There is no schema change,
no migration, no new dependency and no UI change. The per-account list keeps working exactly as
before and remains the right place for anything specific to one mailbox.

Two small robustness details fall out of putting the matching in one place, neither of which changes
behaviour for an existing configuration:

- Blank entries are dropped. A stray empty string left behind in configuration would otherwise match
  through the suffix rule and silently stop the sync from archiving anything.
- Entries are trimmed and de-duplicated case-insensitively, so the same folder named in both lists is
  harmless. The per-account list already trimmed its own entries when splitting.

## Testing

22 new tests in `FolderExclusionMatcherTests`, `dotnet test` green with no new warnings (367 on the
branch, same as on `main`).

The first block pins the pre-existing account-only behaviour so this change cannot quietly alter it:
full path, short name, dot-separated suffix, Gmail-style name, case-insensitivity, and two negatives
— an unrelated folder, and `Kalender` not taking `Kalenderwoche` with it, because the suffix rule
anchors on the separator. The second block checks the global list on its own against the same rules.
The third checks that the lists are additive rather than one overriding the other, in both
directions. Plus the default (nothing configured excludes nothing), whitespace, blank entries, and a
null folder path. A fourth block covers the two Graph inconsistencies below: a path-only entry
matching where the short name does not, a short name reaching a nested Graph folder by suffix, and
an empty `DisplayName` still matching on the full path.

## Scope: both providers, and a Graph inconsistency removed along the way

Applied to the IMAP sync, the Graph sync **and** Graph's retention deletion. All three now resolve
exclusions through `FolderExclusionMatcher`, so an entry means the same thing wherever it is written.
That was the point of extracting it: `GraphMailSyncService` previously compared exact strings inline,
in two places, and the two did not agree with each other.

Two Graph behaviours change as a consequence, and both deserve to be called out rather than
discovered:

- **An entry written as a path now also excludes the folder from the retention deletion.** The
  deletion path compared `DisplayName` only, so an exclusion given as `Inbox/Calendar` kept the
  folder out of the sync while the deletion still walked it and deleted server-side mail from it.
  Both paths now build the same folder-path dictionary via
  `IGraphFolderService.BuildFolderPathDictionary` and pass the full path.
- **The suffix rule now applies to Graph.** `Drafts` matches `Inbox/Drafts` there, as it always did
  for IMAP. Previously Graph required the full path or an exact `DisplayName`.

Both can exclude **more** folders than before, never fewer, which is the safe direction for an
exclusion list — but an installation that relies on a short name matching only a top-level Graph
folder should spell it out as a full path. Documented in `doc/Synchronization.md`.

One smaller thing: the Graph sync skipped the exclusion check entirely when `DisplayName` was empty.
A folder whose full path matches an entry is now excluded regardless.