### PR TITLE
Count folders that fail as a whole instead of inventing failed emails

### DIFF
--- a/Services/Providers/Graph/GraphMailSyncService.cs
+++ b/Services/Providers/Graph/GraphMailSyncService.cs
@@ -415,8 +415,8 @@ namespace MailArchiver.Services.Providers.Graph
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error syncing Graph API folder {FolderName}: {Message}",
-                    folder.DisplayName, ex.Message);
+                _logger.LogError(ex, "Error syncing Graph API folder {FolderName} for account {AccountName}: {Message}",
+                    folder.DisplayName, account.Name, ex.Message);
                 result.FailedFolders = 1;
             }
 

--- a/Services/Providers/Graph/GraphMailSyncService.cs
+++ b/Services/Providers/Graph/GraphMailSyncService.cs
@@ -63,6 +63,7 @@ namespace MailArchiver.Services.Providers.Graph
                 var processedEmails = 0;
                 var newEmails = 0;
                 var failedEmails = 0;
+                var failedFolders = 0;
 
                 var folders = await _folderService.GetAllMailFoldersAsync(graphClient, account.EmailAddress);
 
@@ -118,6 +119,7 @@ namespace MailArchiver.Services.Providers.Graph
                         processedEmails += folderResult.ProcessedEmails;
                         newEmails += folderResult.NewEmails;
                         failedEmails += folderResult.FailedEmails;
+                        failedFolders += folderResult.FailedFolders;
 
                         processedFolders++;
 
@@ -136,7 +138,7 @@ namespace MailArchiver.Services.Providers.Graph
                     {
                         _logger.LogError(ex, "Error syncing folder {FolderName} for account {AccountName}: {Message}",
                             folder.DisplayName, account.Name, ex.Message);
-                        failedEmails++;
+                        failedFolders++;
                     }
                 }
 
@@ -147,7 +149,7 @@ namespace MailArchiver.Services.Providers.Graph
                     deletedEmails = await DeleteOldEmailsAsync(graphClient, account);
                 }
 
-                if (failedEmails == 0)
+                if (SyncCompletionPolicy.MayAdvanceLastSync(failedEmails, failedFolders))
                 {
                     var trackedAccount = await _context.MailAccounts.FindAsync(account.Id);
                     if (trackedAccount != null)
@@ -158,12 +160,14 @@ namespace MailArchiver.Services.Providers.Graph
                 }
                 else
                 {
-                    _logger.LogWarning("Not updating LastSync for account {AccountName} due to {FailedCount} failed emails",
-                        account.Name, failedEmails);
+                    _logger.LogWarning("Not updating LastSync for account {AccountName}: {FailedCount} failed emails, " +
+                        "{FailedFolderCount} folders that could not be synced at all",
+                        account.Name, failedEmails, failedFolders);
                 }
 
-                _logger.LogInformation("Graph API sync completed for account: {AccountName}. New: {New}, Failed: {Failed}, Deleted: {Deleted}",
-                    account.Name, newEmails, failedEmails, deletedEmails);
+                _logger.LogInformation("Graph API sync completed for account: {AccountName}. New: {New}, Failed: {Failed}, Deleted: {Deleted}, " +
+                    "Failed folders: {FailedFolders}",
+                    account.Name, newEmails, failedEmails, deletedEmails, failedFolders);
 
                 if (jobId != null)
                 {
@@ -413,7 +417,7 @@ namespace MailArchiver.Services.Providers.Graph
             {
                 _logger.LogError(ex, "Error syncing Graph API folder {FolderName}: {Message}",
                     folder.DisplayName, ex.Message);
-                result.FailedEmails = result.ProcessedEmails;
+                result.FailedFolders = 1;
             }
 
             return result;
@@ -985,6 +989,13 @@ namespace MailArchiver.Services.Providers.Graph
             public int ProcessedEmails { get; set; }
             public int NewEmails { get; set; }
             public int FailedEmails { get; set; }
+
+            /// <summary>
+            /// 1 when the folder failed as a unit rather than message by message. Same meaning as
+            /// on the IMAP side, and counted the same way: one per folder, never converted into a
+            /// number of failed messages.
+            /// </summary>
+            public int FailedFolders { get; set; }
         }
     }
 }

--- a/Services/Providers/Imap/ImapMailSyncService.cs
+++ b/Services/Providers/Imap/ImapMailSyncService.cs
@@ -1143,15 +1143,15 @@ namespace MailArchiver.Services.Providers.Imap
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error searching messages in folder {FolderName}: {Message}",
-                        folder.FullName, ex.Message);
+                    _logger.LogError(ex, "Error searching messages in folder {FolderName} for account {AccountName}: {Message}",
+                        folder.FullName, account.Name, ex.Message);
                     result.FailedFolders = 1;
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error syncing folder {FolderName}: {Message}",
-                    folder.FullName, ex.Message);
+                _logger.LogError(ex, "Error syncing folder {FolderName} for account {AccountName}: {Message}",
+                    folder.FullName, account.Name, ex.Message);
                 result.FailedFolders = 1;
             }
 

--- a/Services/Providers/Imap/ImapMailSyncService.cs
+++ b/Services/Providers/Imap/ImapMailSyncService.cs
@@ -105,6 +105,7 @@ namespace MailArchiver.Services.Providers.Imap
             var processedEmails = 0;
             var newEmails = 0;
             var failedEmails = 0;
+            var failedFolders = 0;
             var recoveredEmails = 0;
             var providerPlaceholderEmails = 0;
             var deletedEmails = 0;
@@ -165,6 +166,7 @@ namespace MailArchiver.Services.Providers.Imap
                         processedEmails += folderResult.ProcessedEmails;
                         newEmails += folderResult.NewEmails;
                         failedEmails += folderResult.FailedEmails;
+                        failedFolders += folderResult.FailedFolders;
                         recoveredEmails += folderResult.RecoveredEmails;
                         providerPlaceholderEmails += folderResult.ProviderPlaceholderEmails;
 
@@ -193,7 +195,7 @@ namespace MailArchiver.Services.Providers.Imap
                     {
                         _logger.LogError(ex, "Error syncing folder {FolderName} for account {AccountName}: {Message}",
                             folder.FullName, account.Name, ex.Message);
-                        failedEmails++;
+                        failedFolders++;
                     }
                 }
 
@@ -233,7 +235,7 @@ namespace MailArchiver.Services.Providers.Imap
                     return;
                 }
 
-                if (failedEmails == 0)
+                if (SyncCompletionPolicy.MayAdvanceLastSync(failedEmails, failedFolders))
                 {
                     var trackedAccount = await _context.MailAccounts.FindAsync(account.Id);
                     if (trackedAccount != null)
@@ -250,14 +252,15 @@ namespace MailArchiver.Services.Providers.Imap
                 }
                 else
                 {
-                    _logger.LogWarning("Not updating LastSync for account {AccountName} due to {FailedCount} failed emails",
-                        account.Name, failedEmails);
+                    _logger.LogWarning("Not updating LastSync for account {AccountName}: {FailedCount} failed emails, " +
+                        "{FailedFolderCount} folders that could not be synced at all",
+                        account.Name, failedEmails, failedFolders);
                 }
 
                 await client.DisconnectAsync(true);
                 _logger.LogInformation("Sync completed for account: {AccountName}. New: {New}, Failed: {Failed}, Deleted: {Deleted}, " +
-                    "Recovered: {Recovered}, Provider placeholders: {ProviderPlaceholders}",
-                    account.Name, newEmails, failedEmails, deletedEmails, recoveredEmails, providerPlaceholderEmails);
+                    "Recovered: {Recovered}, Provider placeholders: {ProviderPlaceholders}, Failed folders: {FailedFolders}",
+                    account.Name, newEmails, failedEmails, deletedEmails, recoveredEmails, providerPlaceholderEmails, failedFolders);
 
                 if (jobId != null)
                 {
@@ -1142,14 +1145,14 @@ namespace MailArchiver.Services.Providers.Imap
                 {
                     _logger.LogError(ex, "Error searching messages in folder {FolderName}: {Message}",
                         folder.FullName, ex.Message);
-                    result.FailedEmails = result.ProcessedEmails;
+                    result.FailedFolders = 1;
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error syncing folder {FolderName}: {Message}",
                     folder.FullName, ex.Message);
-                result.FailedEmails = result.ProcessedEmails;
+                result.FailedFolders = 1;
             }
 
             return result;
@@ -1446,6 +1449,14 @@ namespace MailArchiver.Services.Providers.Imap
             /// retrieval-error placeholder rather than the original message.
             /// </summary>
             public int ProviderPlaceholderEmails { get; set; }
+
+            /// <summary>
+            /// 1 when the folder failed as a unit — it could not be opened or searched, so no
+            /// statement can be made about the messages in it. Deliberately not expressed as a
+            /// number of failed messages: the count would be invented, and it would overwrite the
+            /// real per-message failures of that folder.
+            /// </summary>
+            public int FailedFolders { get; set; }
 
             public long BytesDownloaded { get; set; }
             public bool WasRateLimited { get; set; }

--- a/Services/Providers/Imap/ImapMailSyncService.cs
+++ b/Services/Providers/Imap/ImapMailSyncService.cs
@@ -106,6 +106,7 @@ namespace MailArchiver.Services.Providers.Imap
             var newEmails = 0;
             var failedEmails = 0;
             var failedFolders = 0;
+            var missingFolders = 0;
             var recoveredEmails = 0;
             var providerPlaceholderEmails = 0;
             var deletedEmails = 0;
@@ -167,6 +168,7 @@ namespace MailArchiver.Services.Providers.Imap
                         newEmails += folderResult.NewEmails;
                         failedEmails += folderResult.FailedEmails;
                         failedFolders += folderResult.FailedFolders;
+                        missingFolders += folderResult.MissingFolders;
                         recoveredEmails += folderResult.RecoveredEmails;
                         providerPlaceholderEmails += folderResult.ProviderPlaceholderEmails;
 
@@ -193,9 +195,18 @@ namespace MailArchiver.Services.Providers.Imap
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Error syncing folder {FolderName} for account {AccountName}: {Message}",
-                            folder.FullName, account.Name, ex.Message);
-                        failedFolders++;
+                        if (ImapFolderAbsence.IsFolderGone(ex))
+                        {
+                            _logger.LogInformation("Folder {FolderName} for account {AccountName} is reported by the server " +
+                                "but does not exist; skipping it. {Message}", folder.FullName, account.Name, ex.Message);
+                            missingFolders++;
+                        }
+                        else
+                        {
+                            _logger.LogError(ex, "Error syncing folder {FolderName} for account {AccountName}: {Message}",
+                                folder.FullName, account.Name, ex.Message);
+                            failedFolders++;
+                        }
                     }
                 }
 
@@ -259,8 +270,10 @@ namespace MailArchiver.Services.Providers.Imap
 
                 await client.DisconnectAsync(true);
                 _logger.LogInformation("Sync completed for account: {AccountName}. New: {New}, Failed: {Failed}, Deleted: {Deleted}, " +
-                    "Recovered: {Recovered}, Provider placeholders: {ProviderPlaceholders}, Failed folders: {FailedFolders}",
-                    account.Name, newEmails, failedEmails, deletedEmails, recoveredEmails, providerPlaceholderEmails, failedFolders);
+                    "Recovered: {Recovered}, Provider placeholders: {ProviderPlaceholders}, " +
+                    "Failed folders: {FailedFolders}, Missing folders: {MissingFolders}",
+                    account.Name, newEmails, failedEmails, deletedEmails, recoveredEmails, providerPlaceholderEmails,
+                    failedFolders, missingFolders);
 
                 if (jobId != null)
                 {
@@ -1143,16 +1156,34 @@ namespace MailArchiver.Services.Providers.Imap
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error searching messages in folder {FolderName} for account {AccountName}: {Message}",
-                        folder.FullName, account.Name, ex.Message);
-                    result.FailedFolders = 1;
+                    if (ImapFolderAbsence.IsFolderGone(ex))
+                    {
+                        _logger.LogInformation("Folder {FolderName} for account {AccountName} is reported by the server " +
+                            "but does not exist; skipping it. {Message}", folder.FullName, account.Name, ex.Message);
+                        result.MissingFolders = 1;
+                    }
+                    else
+                    {
+                        _logger.LogError(ex, "Error searching messages in folder {FolderName} for account {AccountName}: {Message}",
+                            folder.FullName, account.Name, ex.Message);
+                        result.FailedFolders = 1;
+                    }
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error syncing folder {FolderName} for account {AccountName}: {Message}",
-                    folder.FullName, account.Name, ex.Message);
-                result.FailedFolders = 1;
+                if (ImapFolderAbsence.IsFolderGone(ex))
+                {
+                    _logger.LogInformation("Folder {FolderName} for account {AccountName} is reported by the server " +
+                        "but does not exist; skipping it. {Message}", folder.FullName, account.Name, ex.Message);
+                    result.MissingFolders = 1;
+                }
+                else
+                {
+                    _logger.LogError(ex, "Error syncing folder {FolderName} for account {AccountName}: {Message}",
+                        folder.FullName, account.Name, ex.Message);
+                    result.FailedFolders = 1;
+                }
             }
 
             return result;
@@ -1457,6 +1488,13 @@ namespace MailArchiver.Services.Providers.Imap
             /// real per-message failures of that folder.
             /// </summary>
             public int FailedFolders { get; set; }
+
+            /// <summary>
+            /// 1 when the server reported the folder through discovery and then said it does not
+            /// exist. Deliberately not a failure: nothing can be retried, so counting it would hold
+            /// LastSync back forever. See <see cref="ImapFolderAbsence"/>.
+            /// </summary>
+            public int MissingFolders { get; set; }
 
             public long BytesDownloaded { get; set; }
             public bool WasRateLimited { get; set; }

--- a/Services/Shared/ImapFolderAbsence.cs
+++ b/Services/Shared/ImapFolderAbsence.cs
@@ -1,0 +1,75 @@
+using MailKit;
+using MailKit.Net.Imap;
+
+namespace MailArchiver.Services.Shared
+{
+    /// <summary>
+    /// Tells a folder that is <em>gone</em> apart from a folder that <em>failed</em>.
+    ///
+    /// Folder discovery unions a recursive LIST, a per-level LIST and LSUB, and any of the three can
+    /// name a mailbox the server then refuses to open. The most common reason is not a fault at all:
+    /// RFC 3501 forbids a server to drop a name from the subscription list when the mailbox behind it
+    /// is deleted, so a folder somebody once subscribed to in an IMAP client stays in LSUB forever.
+    /// A mailbox deleted between the LIST and the EXAMINE lands here too.
+    ///
+    /// "NO ... doesn't exist" is an answer, not an error. There is nothing to retry, nothing to
+    /// preserve and nothing to come back for, so it must not be counted as a failed folder — a
+    /// counted failure holds LastSync back, and a folder that does not exist never starts existing
+    /// again, which leaves the account stuck for good.
+    ///
+    /// Everything else stays a failure: no permission, connection loss, throttling, a server error.
+    /// Those can succeed on the next run and the account should be held back until they do.
+    ///
+    /// Pure (no I/O, no static state) so it can be unit-tested in isolation.
+    /// </summary>
+    public static class ImapFolderAbsence
+    {
+        /// <summary>
+        /// Message fragments used when the server offers no machine-readable code. Deliberately
+        /// short and deliberately few: every entry here is a guess about wording, and a wrong guess
+        /// silently downgrades a real failure into "not there".
+        /// </summary>
+        private static readonly string[] AbsenceWordings =
+        {
+            "doesn't exist",
+            "does not exist",
+            "no such mailbox",
+            "nonexistent mailbox"
+        };
+
+        /// <summary>
+        /// True when the server said the mailbox is not there.
+        /// </summary>
+        public static bool IsFolderGone(Exception? ex)
+        {
+            var current = ex;
+            while (current != null)
+            {
+                // MailKit's own signal, where the code path produces it.
+                if (current is FolderNotFoundException)
+                    return true;
+
+                if (current is ImapCommandException imapEx &&
+                    imapEx.Response == ImapCommandResponse.No)
+                {
+                    var message = imapEx.Message ?? string.Empty;
+
+                    // RFC 5530's response code, which says it without ambiguity. Exchange 2010
+                    // predates it and sends prose instead, hence the wordings below.
+                    if (message.IndexOf("[NONEXISTENT]", StringComparison.OrdinalIgnoreCase) >= 0)
+                        return true;
+
+                    foreach (var wording in AbsenceWordings)
+                    {
+                        if (message.IndexOf(wording, StringComparison.OrdinalIgnoreCase) >= 0)
+                            return true;
+                    }
+                }
+
+                current = current.InnerException;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Services/Shared/SyncCompletionPolicy.cs
+++ b/Services/Shared/SyncCompletionPolicy.cs
@@ -1,0 +1,40 @@
+namespace MailArchiver.Services.Shared
+{
+    /// <summary>
+    /// Decides whether an account's sync run finished cleanly enough to record progress by
+    /// advancing <c>MailAccount.LastSync</c>.
+    ///
+    /// This exists as its own type for one reason: the rule used to be an inline
+    /// <c>failedEmails == 0</c> next to the code that writes <c>LastSync</c>, and a folder that
+    /// could not be opened reached it disguised as a number of failed messages. Naming the rule
+    /// keeps the two kinds of failure distinguishable at the point where the decision is actually
+    /// made, and puts it somewhere a test can reach.
+    ///
+    /// The rule is deliberately unchanged from the previous behaviour: a folder-level failure still
+    /// blocks <c>LastSync</c>, exactly as it did when it was being counted as failed messages.
+    /// Whether an inaccessible folder <em>should</em> hold up the whole account is a separate
+    /// question — letting it through would mean an account with one permanently unopenable folder
+    /// starts advancing <c>LastSync</c> where it never did before, and a subsequent incremental
+    /// sync would no longer re-examine the mail that folder never yielded. If that decision is ever
+    /// taken, this is the one place to take it.
+    /// </summary>
+    public static class SyncCompletionPolicy
+    {
+        /// <summary>
+        /// True when nothing failed during the run: no individual message and no folder as a whole.
+        /// </summary>
+        /// <param name="failedEmails">
+        /// Messages that could not be archived, counted one per message. A message the
+        /// <c>MessageNotFoundException</c> recovery pulled through is not one of these.
+        /// </param>
+        /// <param name="failedFolders">
+        /// Folders that failed as a unit — the server reported them through LIST/LSUB but they
+        /// could not be opened or searched. Counted one per folder, never converted into a number
+        /// of messages.
+        /// </param>
+        public static bool MayAdvanceLastSync(int failedEmails, int failedFolders)
+        {
+            return failedEmails == 0 && failedFolders == 0;
+        }
+    }
+}

--- a/doc/Synchronization.md
+++ b/doc/Synchronization.md
@@ -29,8 +29,8 @@ Quick sync is the normal operating mode that runs automatically at the configure
    - **M365 (Graph)**: `receivedDateTime ge (LastSync − 12 hours)`
 3. The 12-hour overlap is intentional. It catches messages that were delivered by the provider after the previous sync started but with a slightly older server timestamp, and it tolerates minor clock skew between the mail server and the Mail Archiver host. Duplicates are filtered out by the duplicate check, so the overlap never creates double entries.
 4. For each non-excluded folder, the filtered message list is fetched in batches and archived. Existing messages are skipped.
-5. On **successful completion** (no failed messages, no rate-limit hit), `LastSync` is set to `DateTime.UtcNow` and the next cycle starts from that point.
-6. If **any message failed** to process, `LastSync` is **not** updated, so the next cycle re-attempts the same window.
+5. On **successful completion** (no failed messages, no folders that failed as a whole, no rate-limit hit), `LastSync` is set to `DateTime.UtcNow` and the next cycle starts from that point.
+6. If **any message failed** to process, or **any folder could not be synced at all** (see [Folders That Fail as a Whole](#-folders-that-fail-as-a-whole)), `LastSync` is **not** updated, so the next cycle re-attempts the same window.
 7. If the account is **rate-limited** (see [Rate Limit Handling](RateLimitHandling.md)), `LastSync` is also left untouched and the sync resumes from a per-folder checkpoint once the daily quota resets.
 
 ### When you see it
@@ -60,7 +60,7 @@ A Full Sync is triggered whenever an account's `LastSync` is set to the Unix epo
 - If the server returns fewer results than the folder actually contains (some IMAP servers cap `SEARCH` results), Mail Archiver detects the discrepancy and falls back to fetching all `UniqueId`s by sequence number, so no messages are silently dropped.
 - Messages that are already in the archive are detected as duplicates and skipped – the existing archived copy is **not** overwritten. If a duplicate is found in a different folder name than before, the stored `FolderName` field is updated to reflect the current location.
 - For very large mailboxes, the Full Sync can take several hours or even days. When bandwidth tracking is enabled, the sync pauses gracefully at the daily quota and resumes from per-folder checkpoints on the next day (see [Rate Limit Handling](RateLimitHandling.md)).
-- `LastSync` is updated to `DateTime.UtcNow` only after a Full Sync completes without failed messages, exactly like a Quick Sync.
+- `LastSync` is updated to `DateTime.UtcNow` only after a Full Sync completes without failed messages and without failed folders, exactly like a Quick Sync.
 
 ### When to use a manual Full Sync
 
@@ -221,12 +221,50 @@ differently. It is deliberately not implemented: it costs a second round trip pe
 Both counts appear in the account's completion log line:
 
 ```
-Sync completed for account: Example. New: 0, Failed: 0, Deleted: 0, Recovered: 25, Provider placeholders: 25
+Sync completed for account: Example. New: 0, Failed: 0, Deleted: 0, Recovered: 25, Provider placeholders: 25, Failed folders: 0
 ```
 
 `Recovered` counts messages the fallback rescued; `Provider placeholders` is the subset of those
 that turned out to be provider-generated error documents. `Failed: 0` alongside them is the point of
 the feature — the account is no longer stuck.
+
+---
+
+## 📁 Folders That Fail as a Whole
+
+A message can fail on its own, and a folder can fail as a unit — the server lists it, but opening or
+searching it raises an error. Some servers advertise folders through `LIST`/`LSUB` that then answer
+`NO ... doesn't exist` on `EXAMINE`.
+
+These are counted separately, one per folder:
+
+```
+Sync completed for account: Example. New: 120, Failed: 0, Deleted: 0, Recovered: 0, Provider placeholders: 0, Failed folders: 2
+```
+
+`Failed folders: 2` means two folders could not be synced at all. It does **not** mean any
+particular message failed — when a folder cannot be opened, nothing is known about the messages in
+it, so no number of failed messages would be truthful.
+
+**Why this is its own counter.** A folder-level failure used to be recorded as failed *messages*,
+as many as had been processed in that folder up to that point. That number was invented, and it
+overwrote the folder's real per-message failures. One inaccessible folder could therefore report
+hundreds of failed messages that were in fact archived perfectly well.
+
+**Effect on `LastSync`, unchanged.** A folder that failed as a whole still prevents `LastSync` from
+advancing, exactly as it did when it was being counted as failed messages. Only the reporting has
+changed, not the behaviour: the account still retries the same window on the next cycle. This is
+deliberate — an incremental sync that moved past a folder it never managed to read would never come
+back for the mail in it.
+
+Both counts are visible at `Information` level, and the warning that names them is emitted whenever
+`LastSync` is held back:
+
+```
+Not updating LastSync for account Example: 0 failed emails, 2 folders that could not be synced at all
+```
+
+Applies to both providers, IMAP and M365 (Graph).
 
 ---
 

--- a/doc/Synchronization.md
+++ b/doc/Synchronization.md
@@ -264,6 +264,36 @@ Both counts are visible at `Information` level, and the warning that names them 
 Not updating LastSync for account Example: 0 failed emails, 2 folders that could not be synced at all
 ```
 
+### Folders that are gone, as opposed to broken
+
+A folder the server lists and then refuses to open is not automatically a failure. The most common
+reason is not a fault at all: RFC 3501 forbids a server to remove a name from the subscription list
+when the mailbox behind it is deleted, so a folder somebody once subscribed to in an IMAP client is
+still reported by `LSUB` years later. Folder discovery takes the union of `LIST` and `LSUB`, so those
+names reach the sync, and `EXAMINE` then answers `NO ... doesn't exist`.
+
+That is an answer, not an error. There is nothing to retry and nothing to come back for, so it is
+counted separately and does **not** hold `LastSync` back:
+
+```
+Sync completed for account: Example. New: 120, Failed: 0, ..., Failed folders: 0, Missing folders: 16
+```
+
+Counting it as a failure would stop the account permanently, because a folder that does not exist
+never starts existing again. That is exactly what happened on a mailbox with 16 stale subscriptions:
+the account stopped advancing `LastSync` and could not recover on its own.
+
+Everything else stays a failure and keeps holding the account back — no permission, a dropped
+connection, throttling, a server error. Those can succeed on the next run.
+
+`Missing folders: N` is worth acting on even though it is harmless: it means the mailbox carries
+subscriptions to folders that no longer exist. Clearing them is an `UNSUBSCRIBE` per name, done with
+any IMAP client, and the sync deliberately does **not** do it — an archiver must not modify the
+mailbox it reads.
+
+IMAP only. Microsoft Graph enumerates folders through the API, where a deleted folder is simply not
+returned, so the situation cannot arise there.
+
 Applies to both providers, IMAP and M365 (Graph).
 
 ---

--- a/tests/MailArchiver.Tests/Shared/ImapFolderAbsenceTests.cs
+++ b/tests/MailArchiver.Tests/Shared/ImapFolderAbsenceTests.cs
@@ -1,0 +1,117 @@
+using MailArchiver.Services.Shared;
+using MailKit;
+using MailKit.Net.Imap;
+
+namespace MailArchiver.Tests.Shared;
+
+/// <summary>
+/// A folder the server refuses to open is either gone or broken, and the two must not be confused.
+///
+/// Gone is an answer: RFC 3501 forbids a server to drop a name from the subscription list when the
+/// mailbox behind it is deleted, so a folder somebody once subscribed to in an IMAP client is
+/// reported by LSUB forever. Counting that as a failed folder holds LastSync back, and since the
+/// folder never comes back the account stays held back for good — observed in the field on a mailbox
+/// with 16 such names, stuck for two days.
+///
+/// Broken is not an answer: no permission, a dropped connection, throttling. Those can succeed next
+/// time and must keep holding the account back until they do.
+///
+/// Every wrong "gone" silently drops a real folder from the archive, so the negative cases below
+/// matter more than the positive ones.
+/// </summary>
+public class ImapFolderAbsenceTests
+{
+    // Three arguments on purpose: the two-argument overload does not put the text into Message,
+    // and Message is what carries it in the wild — see the Exchange wording below, taken verbatim
+    // from a production log.
+    private static ImapCommandException No(string message)
+        => new ImapCommandException(ImapCommandResponse.No, message, message);
+
+    // ---- gone ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void The_exchange_2010_wording_counts_as_gone()
+    {
+        // Verbatim from an Exchange 2010 IMAP4 EXAMINE on a stale subscription.
+        Assert.True(ImapFolderAbsence.IsFolderGone(
+            No("The IMAP server replied to the 'EXAMINE' command with a 'NO' response: INBOX/Kunden/BeLa doesn't exist.")));
+    }
+
+    [Theory]
+    [InlineData("Mailbox does not exist")]
+    [InlineData("No such mailbox")]
+    [InlineData("NONEXISTENT MAILBOX")]
+    public void Other_common_wordings_count_as_gone(string message)
+    {
+        Assert.True(ImapFolderAbsence.IsFolderGone(No(message)));
+    }
+
+    [Fact]
+    public void The_rfc_5530_response_code_counts_as_gone()
+    {
+        // Servers new enough to send it say it without prose, and that is the reading we prefer.
+        Assert.True(ImapFolderAbsence.IsFolderGone(No("[NONEXISTENT] Mailbox is not there any more")));
+    }
+
+    [Fact]
+    public void A_folder_not_found_exception_counts_as_gone()
+    {
+        Assert.True(ImapFolderAbsence.IsFolderGone(new FolderNotFoundException("INBOX/Marketing")));
+    }
+
+    [Fact]
+    public void An_absence_wrapped_in_another_exception_is_still_found()
+    {
+        var wrapped = new InvalidOperationException("while opening a folder",
+            No("INBOX/Kunden/isbank doesn't exist."));
+
+        Assert.True(ImapFolderAbsence.IsFolderGone(wrapped));
+    }
+
+    [Fact]
+    public void Case_does_not_matter()
+    {
+        Assert.True(ImapFolderAbsence.IsFolderGone(No("Folder DOESN'T EXIST")));
+    }
+
+    // ---- not gone, and these are the ones that must not slip ----------------------------------
+
+    [Fact]
+    public void Nothing_at_all_is_not_an_absence()
+    {
+        Assert.False(ImapFolderAbsence.IsFolderGone(null));
+    }
+
+    [Theory]
+    [InlineData("Permission denied")]
+    [InlineData("Service temporarily unavailable")]
+    [InlineData("Server busy, try again later")]
+    [InlineData("[OVERQUOTA] Not enough disk space")]
+    public void A_real_failure_stays_a_failure(string message)
+    {
+        Assert.False(ImapFolderAbsence.IsFolderGone(No(message)));
+    }
+
+    [Fact]
+    public void A_dropped_connection_is_not_an_absence()
+    {
+        Assert.False(ImapFolderAbsence.IsFolderGone(new IOException("Connection reset by peer")));
+    }
+
+    [Fact]
+    public void An_ok_response_that_mentions_the_wording_is_not_an_absence()
+    {
+        // Only a NO carries the meaning. Anything else quoting the phrase is not the server
+        // refusing the mailbox.
+        Assert.False(ImapFolderAbsence.IsFolderGone(
+            new ImapCommandException(ImapCommandResponse.Ok,
+                "the folder doesn't exist yet, creating it",
+                "the folder doesn't exist yet, creating it")));
+    }
+
+    [Fact]
+    public void A_plain_exception_carrying_the_wording_is_not_an_absence()
+    {
+        Assert.False(ImapFolderAbsence.IsFolderGone(new InvalidOperationException("the file doesn't exist")));
+    }
+}

--- a/tests/MailArchiver.Tests/Shared/SyncCompletionPolicyTests.cs
+++ b/tests/MailArchiver.Tests/Shared/SyncCompletionPolicyTests.cs
@@ -1,0 +1,47 @@
+using MailArchiver.Services.Shared;
+using Xunit;
+
+namespace MailArchiver.Tests.Shared;
+
+public class SyncCompletionPolicyTests
+{
+    [Fact]
+    public void A_clean_run_may_advance_last_sync()
+    {
+        Assert.True(SyncCompletionPolicy.MayAdvanceLastSync(failedEmails: 0, failedFolders: 0));
+    }
+
+    [Fact]
+    public void A_failed_message_still_blocks_last_sync()
+    {
+        Assert.False(SyncCompletionPolicy.MayAdvanceLastSync(failedEmails: 1, failedFolders: 0));
+    }
+
+    // The behaviour this change is careful NOT to alter. Before, a folder that could not be opened
+    // was written into FailedEmails as one-per-processed-message, which blocked LastSync as a side
+    // effect of a fabricated count. It is now counted as a folder and blocks deliberately. Should
+    // the project ever decide that an inaccessible folder must not hold up the whole account, this
+    // is the assertion that has to change, and it is the only one.
+    [Fact]
+    public void A_failed_folder_still_blocks_last_sync()
+    {
+        Assert.False(SyncCompletionPolicy.MayAdvanceLastSync(failedEmails: 0, failedFolders: 1));
+    }
+
+    [Fact]
+    public void Both_kinds_of_failure_together_block_last_sync()
+    {
+        Assert.False(SyncCompletionPolicy.MayAdvanceLastSync(failedEmails: 3, failedFolders: 2));
+    }
+
+    [Theory]
+    [InlineData(0, 0, true)]
+    [InlineData(1, 0, false)]
+    [InlineData(0, 1, false)]
+    [InlineData(500, 0, false)]
+    [InlineData(0, 25, false)]
+    public void The_rule_is_a_plain_conjunction(int failedEmails, int failedFolders, bool expected)
+    {
+        Assert.Equal(expected, SyncCompletionPolicy.MayAdvanceLastSync(failedEmails, failedFolders));
+    }
+}


### PR DESCRIPTION
## Problem

A message can fail on its own, and a folder can fail as a unit. Only the first has a counter.

When a folder cannot be opened or searched, `SyncFolderAsync` records the failure like this:

```csharp
result.FailedEmails = result.ProcessedEmails;
```

That is a fabricated number, and it is an assignment rather than an addition, so it has two
distinct consequences:

1. **The count is invented.** One inaccessible folder is reported as N failed messages, where N is
   however many messages had been processed in that folder before it broke. Those messages were
   archived correctly. Nothing is known about the messages the folder never yielded — a folder that
   fails on `EXAMINE` has an unknown message count, and no number would be truthful.
2. **It overwrites real failures.** Any genuine per-message failures counted in that folder up to
   that point are discarded and replaced by the processed count.

A third site does a smaller version of the same thing: the per-folder `catch` in the account loop
increments `failedEmails` by one, inventing a single failed message for a folder-level problem.

This is not theoretical on legacy on-premises Exchange, which advertises folders through
`LIST`/`LSUB` that then answer `NO ... doesn't exist` on `EXAMINE`. The operator sees an account
reporting hundreds of failed messages and no indication that the actual problem is two folders.

## Solution

A `FailedFolders` counter on `SyncFolderResult`, set to 1 when the folder failed as a unit, summed
per account alongside the existing counters, and reported in the account's completion log:

```
Sync completed for account: Example. New: 120, Failed: 0, Deleted: 0, Recovered: 0, Provider placeholders: 0, Failed folders: 2
```

`Failed: 0, Failed folders: 2` now says what actually happened: no message failed, two folders could
not be read at all.

The warning emitted when progress is held back names both kinds:

```
Not updating LastSync for account Example: 0 failed emails, 2 folders that could not be synced at all
```

**The `LastSync` behaviour is deliberately unchanged.** A folder that failed as a whole still
prevents `LastSync` from advancing, exactly as it did when it was being counted as failed messages.
This PR changes what is *reported*, not what *happens*. An account in this state still retries the
same window on the next cycle, as before.

The rule moves out of the inline `if (failedEmails == 0)` next to the `LastSync` write and into
`Services/Shared/SyncCompletionPolicy.MayAdvanceLastSync(failedEmails, failedFolders)`. That is a
one-line method, and it is its own type for a reason: the decision is the thing this area gets
wrong, it now has a name, and it is reachable from a test. It is also the single place to change if
the answer to the open question below is "let folder failures through".

## Open question, for you to decide

Should an inaccessible folder hold up the whole account?

Arguments for leaving it as it is, which is what this PR does:

- An incremental sync that advanced `LastSync` past a folder it never managed to read would not
  come back for the mail in that folder. The next Quick Sync applies a date filter from the new
  `LastSync`, so mail older than that in the recovered folder is not re-examined. Only a Full Sync
  would pick it up.
- It is the current behaviour, and this PR is then purely a reporting fix with no behavioural risk.

Arguments for letting it through, which is a one-line change here:

- A permanently unopenable folder — a stale `LIST` entry that will never be readable — means the
  account can never record progress, which is the same permanent-stall problem the
  `MessageNotFoundException` recovery addressed from the other side.
- The failure stays visible either way, because it now has its own counter and its own log line.
  That is what makes the choice viable at all.

I did not want to make that call in a PR that is otherwise behaviour-neutral. Say which you want and
I will follow up; if you want it changed, it is `SyncCompletionPolicy` and the one test that pins
the current answer.

## Scope: both providers

`GraphMailSyncService` had the identical pattern — `result.FailedEmails = result.ProcessedEmails`
in its folder catch, `failedEmails++` in its account loop, and its own inline
`if (failedEmails == 0)`. All three are changed the same way, and both providers now call the same
policy method, so the rule cannot drift between them. Graph's `SyncFolderResult` gains the same
counter.

This follows the shape you asked for on the excluded-folders PR: one helper, both providers, rather
than two implementations of the same decision.

## Backwards compatibility

No configuration, no new dependency, no schema change, no migration, no UI change, no new
user-visible strings and therefore no resx additions. The counters go to the log, consistent with
how `Recovered` and `Provider placeholders` are handled.

`SyncJob.FailedEmails` keeps its current meaning and is no longer inflated by folder-level
failures — which is a change in the number the account detail page shows, in the direction of it
being correct. I have deliberately **not** added `FailedFolders` to `SyncJob`: it would be visible
in the jobs list, but it is a separate decision about the UI and it is not needed to make this fix
correct. Happy to add it if you want it there.

## Testing

`dotnet build`: 0 errors, 370 warnings — the same 370 as on `main`, so nothing added.

`dotnet test`: 807 passed, 1 skipped, 0 failed. 9 new tests in `SyncCompletionPolicyTests`
covering the clean run, a failed message alone, a failed folder alone, both together, and the rule
as a table.

The test named `A_failed_folder_still_blocks_last_sync` exists specifically to pin the behaviour
this PR does not change, so that flipping it later is a deliberate edit to an assertion rather than
an accident.

The folder-failure paths themselves live inside `SyncFolderAsync`, which needs a live IMAP server
and is not unit tested, in line with the rest of the IMAP I/O in this project. What is testable is
the decision the counters feed, and that is what the new tests cover.

## Operational impact

The distinction that was previously impossible to make from the logs:

- *N messages failed* — genuine per-message failures, unchanged.
- *N folders could not be synced at all* — a server-side folder problem, previously disguised as a
  count of failed messages that were in fact archived.

For anyone diagnosing a stuck account, that is the difference between chasing hundreds of
non-existent message failures and looking at two folders.

## Note

Possibly related: #504 (Outlook folders not synchronized, closed without a documented resolution)
reads like it could be a symptom of folder-level failures being reported as message failures. I am
not claiming it is — I have no reproduction of that issue — but if it resurfaces, the new counter
would make it immediately distinguishable.