### PR TITLE
Allow offloading into a disabled account

### DIFF
--- a/Controllers/MailAccountsController.cs
+++ b/Controllers/MailAccountsController.cs
@@ -1553,7 +1553,7 @@ namespace MailArchiver.Controllers
 
             var candidates = await candidateQuery
                 .OrderBy(a => a.Name)
-                .Select(a => new { a.Id, a.Name, a.EmailAddress, a.Provider, a.IsEnabled })
+                .Select(a => new { a.Id, a.Name, a.EmailAddress, a.Provider })
                 .ToListAsync();
 
             var targets = candidates

--- a/Controllers/MailAccountsController.cs
+++ b/Controllers/MailAccountsController.cs
@@ -1438,7 +1438,7 @@ namespace MailArchiver.Controllers
             if (rejection != OffloadTargetRejection.None)
             {
                 // Being handed a target one may not use is worth noticing, and worth noticing
-                // repeatedly; picking the source or a disabled account is an ordinary form slip.
+                // repeatedly; picking the source is an ordinary form slip.
                 _logger.Log(
                     rejection == OffloadTargetRejection.NotAccessible ? LogLevel.Warning : LogLevel.Information,
                     "Rejected offload target {TargetId} for source {SourceId} requested by {User}: {Reason}",

--- a/Controllers/MailAccountsController.cs
+++ b/Controllers/MailAccountsController.cs
@@ -1431,7 +1431,6 @@ namespace MailArchiver.Controllers
                     Id = target.Id,
                     // The Graph restore path is untouched by this feature.
                     Provider = target.Provider,
-                    IsEnabled = target.IsEnabled,
                     IsAccessible = OffloadTargetEligibility.IsAccessible(target.Id, allowedAccountIds),
                 },
                 id);
@@ -1563,7 +1562,6 @@ namespace MailArchiver.Controllers
                     {
                         Id = a.Id,
                         Provider = a.Provider,
-                        IsEnabled = a.IsEnabled,
                         IsAccessible = OffloadTargetEligibility.IsAccessible(a.Id, allowedAccountIds),
                     },
                     account.Id))

--- a/Program.cs
+++ b/Program.cs
@@ -816,12 +816,9 @@ if (cliArgs.Any(a => a == "--offload"))
                               "offload targets must be IMAP");
             Environment.Exit(ExitBadArgs);
         }
-        // Same rule the queued job path and the UI apply, so all three agree.
-        if (!targetAccount.IsEnabled)
-        {
-            Console.WriteLine($"ERROR: target account '{targetAccount.Name}' is disabled");
-            Environment.Exit(ExitBadArgs);
-        }
+        // A disabled target is accepted here as it is in the UI and the queued job path: IsEnabled
+        // decides what the background sync collects from, and an offload appends rather than
+        // collects. See OffloadTargetEligibility.Evaluate.
 
         var offloadOptions = offloadServices.GetRequiredService<IOptions<OffloadOptions>>().Value;
         var batchRestoreOptions = offloadServices.GetRequiredService<IOptions<BatchRestoreOptions>>().Value;

--- a/Resources/SharedResource.de.resx
+++ b/Resources/SharedResource.de.resx
@@ -3274,10 +3274,10 @@
     <value>Auslagerung starten</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>Es ist kein weiteres aktives IMAP-Konto als Ziel verfügbar. Bitte zuerst eines anlegen.</value>
+    <value>Es ist kein weiteres IMAP-Konto als Ziel verfügbar. Bitte zuerst eines anlegen.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>Keines der Ihnen zugewiesenen Postfächer kann als Ziel verwendet werden. Bitte lassen Sie sich ein weiteres aktives IMAP-Konto zuweisen.</value>
+    <value>Keines der Ihnen zugewiesenen Postfächer kann als Ziel verwendet werden. Bitte lassen Sie sich ein weiteres IMAP-Konto zuweisen.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Bitte ein Zielpostfach auswählen.</value>

--- a/Resources/SharedResource.de.resx
+++ b/Resources/SharedResource.de.resx
@@ -3291,9 +3291,6 @@
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
     <value>Das Zielpostfach muss ein IMAP-Konto sein.</value>
   </data>
-  <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>Das gewählte Zielpostfach ist deaktiviert.</value>
-  </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
     <value>Bitte entweder ein Monatsfenster oder ein Von-Datum angeben.</value>
   </data>

--- a/Resources/SharedResource.en-GB.resx
+++ b/Resources/SharedResource.en-GB.resx
@@ -686,9 +686,6 @@
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
     <value>The target mailbox must be an IMAP account.</value>
   </data>
-  <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>The selected target mailbox is disabled.</value>
-  </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
     <value>Please provide either a month window or a from date.</value>
   </data>

--- a/Resources/SharedResource.en-GB.resx
+++ b/Resources/SharedResource.en-GB.resx
@@ -669,10 +669,10 @@
     <value>Start offload</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+    <value>No other IMAP account is available as a target. Create one first.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another IMAP account.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>

--- a/Resources/SharedResource.es.resx
+++ b/Resources/SharedResource.es.resx
@@ -3272,10 +3272,10 @@
     <value>Iniciar volcado</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>No hay otra cuenta IMAP habilitada disponible como destino. Cree una primero.</value>
+    <value>No hay otra cuenta IMAP disponible como destino. Cree una primero.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>Ninguno de los buzones asignados a usted puede usarse como destino. Pida a un administrador que le asigne otra cuenta IMAP habilitada.</value>
+    <value>Ninguno de los buzones asignados a usted puede usarse como destino. Pida a un administrador que le asigne otra cuenta IMAP.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Elija un buzón de destino.</value>

--- a/Resources/SharedResource.es.resx
+++ b/Resources/SharedResource.es.resx
@@ -3289,9 +3289,6 @@
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
     <value>El buzón de destino debe ser una cuenta IMAP.</value>
   </data>
-  <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>El buzón de destino seleccionado está deshabilitado.</value>
-  </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
     <value>Indique una ventana de meses o una fecha de inicio.</value>
   </data>

--- a/Resources/SharedResource.fr.resx
+++ b/Resources/SharedResource.fr.resx
@@ -3290,9 +3290,6 @@
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
     <value>La boîte aux lettres de destination doit être un compte IMAP.</value>
   </data>
-  <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>La boîte aux lettres de destination sélectionnée est désactivée.</value>
-  </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
     <value>Veuillez fournir soit une fenêtre de mois, soit une date de début.</value>
   </data>

--- a/Resources/SharedResource.fr.resx
+++ b/Resources/SharedResource.fr.resx
@@ -3273,10 +3273,10 @@
     <value>Lancer la décharge</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>Aucun autre compte IMAP activé n'est disponible comme destination. Créez-en un d'abord.</value>
+    <value>Aucun autre compte IMAP n'est disponible comme destination. Créez-en un d'abord.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>Aucune des boîtes aux lettres qui vous sont attribuées ne peut servir de destination. Demandez à un administrateur de vous attribuer un autre compte IMAP activé.</value>
+    <value>Aucune des boîtes aux lettres qui vous sont attribuées ne peut servir de destination. Demandez à un administrateur de vous attribuer un autre compte IMAP.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Veuillez choisir une boîte aux lettres de destination.</value>

--- a/Resources/SharedResource.hu.resx
+++ b/Resources/SharedResource.hu.resx
@@ -3265,10 +3265,10 @@
     <value>Átvitel indítása</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>Nincs másik engedélyezett IMAP-fiók célként. Hozzon létre először egyet.</value>
+    <value>Nincs másik IMAP-fiók célként. Hozzon létre először egyet.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>Az Önhöz rendelt postafiókok egyike sem használható célként. Kérjen egy másik engedélyezett IMAP-fiók hozzárendelését az adminisztrátortól.</value>
+    <value>Az Önhöz rendelt postafiókok egyike sem használható célként. Kérjen egy másik IMAP-fiók hozzárendelését az adminisztrátortól.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Válasszon célpostafiókot.</value>

--- a/Resources/SharedResource.hu.resx
+++ b/Resources/SharedResource.hu.resx
@@ -3282,9 +3282,6 @@
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
     <value>A célpostafióknak IMAP-fióknak kell lennie.</value>
   </data>
-  <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>A kiválasztott célpostafiók le van tiltva.</value>
-  </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
     <value>Adjon meg hónap-ablakot vagy dátumtól értéket.</value>
   </data>

--- a/Resources/SharedResource.it.resx
+++ b/Resources/SharedResource.it.resx
@@ -3273,10 +3273,10 @@
     <value>Avvia scaricamento</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>Nessun altro account IMAP abilitato disponibile come destinazione. Crearne uno prima.</value>
+    <value>Nessun altro account IMAP disponibile come destinazione. Crearne uno prima.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>Nessuna delle caselle assegnate a te può essere usata come destinazione. Chiedi a un amministratore di assegnarti un altro account IMAP abilitato.</value>
+    <value>Nessuna delle caselle assegnate a te può essere usata come destinazione. Chiedi a un amministratore di assegnarti un altro account IMAP.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Scegliere una casella di destinazione.</value>

--- a/Resources/SharedResource.it.resx
+++ b/Resources/SharedResource.it.resx
@@ -3290,9 +3290,6 @@
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
     <value>La casella di destinazione deve essere un account IMAP.</value>
   </data>
-  <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>La casella di destinazione selezionata è disabilitata.</value>
-  </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
     <value>Fornire una finestra di mesi o una data di inizio.</value>
   </data>

--- a/Resources/SharedResource.nl.resx
+++ b/Resources/SharedResource.nl.resx
@@ -3290,9 +3290,6 @@
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
     <value>Het doelpostvak moet een IMAP-account zijn.</value>
   </data>
-  <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>Het geselecteerde doelpostvak is uitgeschakeld.</value>
-  </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
     <value>Geef een maandvenster of een vanaf-datum op.</value>
   </data>

--- a/Resources/SharedResource.nl.resx
+++ b/Resources/SharedResource.nl.resx
@@ -3273,10 +3273,10 @@
     <value>Overbrengen starten</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>Geen ander ingeschakeld IMAP-account beschikbaar als doel. Maak er eerst een aan.</value>
+    <value>Geen ander IMAP-account beschikbaar als doel. Maak er eerst een aan.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>Geen van de aan u toegewezen postvakken kan als doel worden gebruikt. Vraag een beheerder om een ander ingeschakeld IMAP-account toe te wijzen.</value>
+    <value>Geen van de aan u toegewezen postvakken kan als doel worden gebruikt. Vraag een beheerder om een ander IMAP-account toe te wijzen.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Kies een doelpostvak.</value>

--- a/Resources/SharedResource.pl.resx
+++ b/Resources/SharedResource.pl.resx
@@ -3336,9 +3336,6 @@
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
     <value>Skrzynka docelowa musi być kontem IMAP.</value>
   </data>
-  <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>Wybrana skrzynka docelowa jest wyłączona.</value>
-  </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
     <value>Podaj okno miesięcy lub datę od.</value>
   </data>

--- a/Resources/SharedResource.pl.resx
+++ b/Resources/SharedResource.pl.resx
@@ -3319,10 +3319,10 @@
     <value>Rozpocznij przenoszenie</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>Brak innego włączonego konta IMAP jako celu. Najpierw utwórz takie konto.</value>
+    <value>Brak innego konta IMAP jako celu. Najpierw utwórz takie konto.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>Żadna ze skrzynek Ci przypisanych nie może być celem. Poproś administratora o przypisanie innego włączonego konta IMAP.</value>
+    <value>Żadna ze skrzynek Ci przypisanych nie może być celem. Poproś administratora o przypisanie innego konta IMAP.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Wybierz skrzynkę docelową.</value>

--- a/Resources/SharedResource.resx
+++ b/Resources/SharedResource.resx
@@ -3260,10 +3260,10 @@
     <value>Start Offload</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>No other enabled IMAP account is available as a target. Create one first.</value>
+    <value>No other IMAP account is available as a target. Create one first.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another enabled IMAP account.</value>
+    <value>None of the mailboxes assigned to you can be used as a target. Ask an administrator to assign you another IMAP account.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Please choose a target mailbox.</value>

--- a/Resources/SharedResource.resx
+++ b/Resources/SharedResource.resx
@@ -3277,9 +3277,6 @@
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
     <value>The target mailbox must be an IMAP account.</value>
   </data>
-  <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>The selected target mailbox is disabled.</value>
-  </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
     <value>Please give either a month window or a from date.</value>
   </data>

--- a/Resources/SharedResource.ru.resx
+++ b/Resources/SharedResource.ru.resx
@@ -3290,9 +3290,6 @@
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
     <value>Целевой почтовый ящик должен быть аккаунтом IMAP.</value>
   </data>
-  <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>Выбранный целевой почтовый ящик отключён.</value>
-  </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
     <value>Укажите окно месяцев или дату начала.</value>
   </data>

--- a/Resources/SharedResource.ru.resx
+++ b/Resources/SharedResource.ru.resx
@@ -3273,10 +3273,10 @@
     <value>Начать выгрузку</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>Нет другого включённого аккаунта IMAP в качестве цели. Сначала создайте его.</value>
+    <value>Нет другого аккаунта IMAP в качестве цели. Сначала создайте его.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>Ни один из назначенных вам ящиков нельзя использовать в качестве цели. Попросите администратора назначить вам ещё один включённый аккаунт IMAP.</value>
+    <value>Ни один из назначенных вам ящиков нельзя использовать в качестве цели. Попросите администратора назначить вам ещё один аккаунт IMAP.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Выберите целевой почтовый ящик.</value>

--- a/Resources/SharedResource.sl.resx
+++ b/Resources/SharedResource.sl.resx
@@ -3273,10 +3273,10 @@
     <value>Začni prenos</value>
   </data>
   <data name="OffloadNoTargets" xml:space="preserve">
-    <value>Na voljo ni drugega omogočenega računa IMAP kot cilja. Najprej ga ustvarite.</value>
+    <value>Na voljo ni drugega računa IMAP kot cilja. Najprej ga ustvarite.</value>
   </data>
   <data name="OffloadNoTargetsAssigned" xml:space="preserve">
-    <value>Nobeden od vam dodeljenih nabiralnikov ni mogoče uporabiti kot cilj. Prosite skrbnika, naj vam dodeli še en omogočen račun IMAP.</value>
+    <value>Nobeden od vam dodeljenih nabiralnikov ni mogoče uporabiti kot cilj. Prosite skrbnika, naj vam dodeli še en račun IMAP.</value>
   </data>
   <data name="OffloadTargetRequired" xml:space="preserve">
     <value>Izberite ciljni nabiralnik.</value>

--- a/Resources/SharedResource.sl.resx
+++ b/Resources/SharedResource.sl.resx
@@ -3290,9 +3290,6 @@
   <data name="OffloadTargetMustBeImap" xml:space="preserve">
     <value>Ciljni nabiralnik mora biti račun IMAP.</value>
   </data>
-  <data name="OffloadTargetDisabled" xml:space="preserve">
-    <value>Izbrani ciljni nabiralnik je onemogočen.</value>
-  </data>
   <data name="OffloadCutoffRequired" xml:space="preserve">
     <value>Navedite okno mesecev ali datum od.</value>
   </data>

--- a/Services/BatchRestoreService.cs
+++ b/Services/BatchRestoreService.cs
@@ -362,7 +362,9 @@ namespace MailArchiver.Services
             _logger.LogInformation("Job {JobId}: Target account found - Name: {AccountName}, Provider: {Provider}, Enabled: {Enabled}",
                 job.JobId, targetAccount.Name, targetAccount.Provider, targetAccount.IsEnabled);
 
-            if (!targetAccount.IsEnabled)
+            // Offload jobs are pure appends into a provisioned target and are allowed to run
+            // against a disabled account, matching the source-side and CLI path behavior.
+            if (!job.IsOffload && !targetAccount.IsEnabled)
             {
                 _logger.LogError("Job {JobId}: Target account {AccountId} is disabled", job.JobId, job.TargetAccountId);
                 throw new InvalidOperationException($"Target account '{targetAccount.Name}' is disabled");

--- a/Services/Shared/OffloadTargetEligibility.cs
+++ b/Services/Shared/OffloadTargetEligibility.cs
@@ -16,7 +16,6 @@ namespace MailArchiver.Services.Shared
         NotFound,
         NotAccessible,
         NotImap,
-        Disabled,
     }
 
     /// <summary>The facts about a candidate target that decide whether it may be used.</summary>
@@ -24,7 +23,6 @@ namespace MailArchiver.Services.Shared
     {
         public int Id { get; init; }
         public ProviderType Provider { get; init; }
-        public bool IsEnabled { get; init; }
 
         /// <summary>
         /// Whether the acting user may use this account, as resolved by
@@ -51,9 +49,15 @@ namespace MailArchiver.Services.Shared
             => allowedAccountIds == null || allowedAccountIds.Contains(accountId);
 
         /// <summary>
-        /// Order matters. Accessibility is decided before the provider and the enabled flag,
-        /// because a message naming either of those about an account the user may not see would
-        /// disclose something about it.
+        /// Order matters. Accessibility is decided before the provider, because a message naming
+        /// the provider of an account the user may not see would disclose something about it.
+        ///
+        /// A disabled account is deliberately accepted. IsEnabled governs exactly one thing — which
+        /// accounts the background sync collects from — and an offload does not collect, it appends.
+        /// Reading "do not archive from here" as "do not write here" was a rule of our own making,
+        /// and it blocked the one workflow the feature exists for: provisioning the targets of a
+        /// migration disabled, filling them ahead of time, and letting people switch archiving on
+        /// themselves afterwards. The source side never had the check either.
         /// </summary>
         public static OffloadTargetRejection Evaluate(OffloadTargetCandidate? target, int sourceAccountId)
         {
@@ -61,7 +65,6 @@ namespace MailArchiver.Services.Shared
             if (target.Id == sourceAccountId) return OffloadTargetRejection.SameAsSource;
             if (!target.IsAccessible) return OffloadTargetRejection.NotAccessible;
             if (target.Provider != ProviderType.IMAP) return OffloadTargetRejection.NotImap;
-            if (!target.IsEnabled) return OffloadTargetRejection.Disabled;
             return OffloadTargetRejection.None;
         }
 
@@ -78,7 +81,6 @@ namespace MailArchiver.Services.Shared
             OffloadTargetRejection.NotFound => "OffloadTargetNotFound",
             OffloadTargetRejection.NotAccessible => "OffloadTargetNotFound",
             OffloadTargetRejection.NotImap => "OffloadTargetMustBeImap",
-            OffloadTargetRejection.Disabled => "OffloadTargetDisabled",
             _ => throw new ArgumentOutOfRangeException(nameof(rejection), rejection, "No message for an accepted target."),
         };
     }

--- a/ViewModels/OffloadViewModel.cs
+++ b/ViewModels/OffloadViewModel.cs
@@ -50,7 +50,7 @@ namespace MailArchiver.Models.ViewModels
         [Display(Name = "OffloadMarkAsSeen")]
         public bool MarkAsSeen { get; set; } = true;
 
-        /// <summary>Accounts that can be offloaded into, i.e. enabled IMAP accounts.</summary>
+        /// <summary>Accounts that can be offloaded into, i.e. IMAP accounts (enabled or not).</summary>
         public List<TargetAccountOption> AvailableTargets { get; set; } = new();
 
         /// <summary>

--- a/doc/Offload.md
+++ b/doc/Offload.md
@@ -113,8 +113,9 @@ The job is queued and its progress and per-folder report appear on the job statu
 **Jobs**. The per-folder report names source folders, so it is shown only to the user who started
 the job and to administrators.
 
-The target mailbox must be an enabled IMAP account. Microsoft 365 accounts cannot be offload
-targets; the Graph restore path is unchanged.
+The target mailbox may be a disabled IMAP account, e.g. to provision a migration target before it
+goes live; the run fails loudly on connect if the target is unreachable. Microsoft 365 accounts
+cannot be offload targets; the Graph restore path is unchanged.
 
 ### Who may run it
 
@@ -142,7 +143,7 @@ docker compose exec mailarchive-app dotnet MailArchiver.dll \
 | Argument | Meaning |
 |---|---|
 | `--source-account-id` | Account to read archived mail from. Required. |
-| `--target-account-id` | Enabled IMAP account to append into. Required, and must differ from the source. |
+| `--target-account-id` | IMAP account to append into. Required, and must differ from the source. |
 | `--since` | Inclusive lower bound on the send date, `YYYY-MM-DD`. Required. |
 | `--until` | Optional inclusive upper bound. |
 | `--target-folder` | Root folder in the target mailbox. Defaults to `INBOX`. |

--- a/doc/Offload.md
+++ b/doc/Offload.md
@@ -156,7 +156,7 @@ Exit codes:
 |---|---|
 | `0` | Everything was appended or already present. |
 | `1` | At least one message failed, or the run itself failed. |
-| `2` | The invocation was wrong: bad or missing arguments, unknown account, target not IMAP, target disabled, source equal to target. |
+| `2` | The invocation was wrong: bad or missing arguments, unknown account, target not IMAP, source equal to target. |
 
 One invocation handles one mailbox, which makes a fleet of mailboxes scriptable from a CSV of
 source, target and cutoff.

--- a/tests/MailArchiver.Tests/Services/OffloadTargetEligibilityTests.cs
+++ b/tests/MailArchiver.Tests/Services/OffloadTargetEligibilityTests.cs
@@ -80,19 +80,6 @@ public class OffloadTargetEligibilityTests
         Assert.Equal(OffloadTargetRejection.NotImap, OffloadTargetEligibility.Evaluate(graph, SourceId));
     }
 
-    [Fact]
-    public void Evaluate_ADisabledAccount_IsAccepted()
-    {
-        // Deliberate, and the reason the rule was removed. IsEnabled governs which accounts the
-        // background sync collects from; an offload appends and collects nothing. Reading it as
-        // "do not write here" blocked provisioning a migration's targets disabled and filling them
-        // ahead of time — and the source side never had the check either.
-        //
-        // A disabled account can also mean a retired one with dead credentials. That fails loudly
-        // on connect, nothing is damaged, and somebody picked the target from a list on purpose.
-        Assert.Equal(OffloadTargetRejection.None, OffloadTargetEligibility.Evaluate(Candidate(), SourceId));
-    }
-
     /// <summary>
     /// Accessibility is checked before the provider. Otherwise the form would answer "that is not
     /// an IMAP account" about a mailbox the user is not allowed to know anything about.

--- a/tests/MailArchiver.Tests/Services/OffloadTargetEligibilityTests.cs
+++ b/tests/MailArchiver.Tests/Services/OffloadTargetEligibilityTests.cs
@@ -16,9 +16,8 @@ public class OffloadTargetEligibilityTests
     private static OffloadTargetCandidate Candidate(
         int id = 2,
         ProviderType provider = ProviderType.IMAP,
-        bool isEnabled = true,
         bool isAccessible = true)
-        => new() { Id = id, Provider = provider, IsEnabled = isEnabled, IsAccessible = isAccessible };
+        => new() { Id = id, Provider = provider, IsAccessible = isAccessible };
 
     // --- IsAccessible: the scope IAccountAccessResolver hands over -------------------------
 
@@ -82,24 +81,28 @@ public class OffloadTargetEligibilityTests
     }
 
     [Fact]
-    public void Evaluate_ADisabledAccount_IsRejected()
+    public void Evaluate_ADisabledAccount_IsAccepted()
     {
-        var disabled = Candidate(isEnabled: false);
-        Assert.Equal(OffloadTargetRejection.Disabled, OffloadTargetEligibility.Evaluate(disabled, SourceId));
+        // Deliberate, and the reason the rule was removed. IsEnabled governs which accounts the
+        // background sync collects from; an offload appends and collects nothing. Reading it as
+        // "do not write here" blocked provisioning a migration's targets disabled and filling them
+        // ahead of time — and the source side never had the check either.
+        //
+        // A disabled account can also mean a retired one with dead credentials. That fails loudly
+        // on connect, nothing is damaged, and somebody picked the target from a list on purpose.
+        Assert.Equal(OffloadTargetRejection.None, OffloadTargetEligibility.Evaluate(Candidate(), SourceId));
     }
 
     /// <summary>
-    /// Accessibility is checked before the provider and the enabled flag. Otherwise the form
-    /// would answer "that is not an IMAP account" or "that account is disabled" about a mailbox
-    /// the user is not allowed to know anything about.
+    /// Accessibility is checked before the provider. Otherwise the form would answer "that is not
+    /// an IMAP account" about a mailbox the user is not allowed to know anything about.
     /// </summary>
     [Theory]
-    [InlineData(ProviderType.M365, true)]
-    [InlineData(ProviderType.IMAP, false)]
-    [InlineData(ProviderType.M365, false)]
-    public void Evaluate_InaccessibleWins_OverProviderAndEnabledState(ProviderType provider, bool isEnabled)
+    [InlineData(ProviderType.M365)]
+    [InlineData(ProviderType.IMAP)]
+    public void Evaluate_InaccessibleWins_OverTheProvider(ProviderType provider)
     {
-        var candidate = Candidate(provider: provider, isEnabled: isEnabled, isAccessible: false);
+        var candidate = Candidate(provider: provider, isAccessible: false);
         Assert.Equal(OffloadTargetRejection.NotAccessible, OffloadTargetEligibility.Evaluate(candidate, SourceId));
     }
 
@@ -110,7 +113,7 @@ public class OffloadTargetEligibilityTests
     [Fact]
     public void Evaluate_SameAsSourceWins_OverEverythingElse()
     {
-        var self = Candidate(id: SourceId, provider: ProviderType.M365, isEnabled: false, isAccessible: false);
+        var self = Candidate(id: SourceId, provider: ProviderType.M365, isAccessible: false);
         Assert.Equal(OffloadTargetRejection.SameAsSource, OffloadTargetEligibility.Evaluate(self, SourceId));
     }
 
@@ -133,7 +136,6 @@ public class OffloadTargetEligibilityTests
     [InlineData(OffloadTargetRejection.NotFound, "OffloadTargetNotFound")]
     [InlineData(OffloadTargetRejection.NotAccessible, "OffloadTargetNotFound")]
     [InlineData(OffloadTargetRejection.NotImap, "OffloadTargetMustBeImap")]
-    [InlineData(OffloadTargetRejection.Disabled, "OffloadTargetDisabled")]
     public void MessageKey_MapsEveryRejection(OffloadTargetRejection rejection, string expected)
     {
         Assert.Equal(expected, OffloadTargetEligibility.MessageKey(rejection));
@@ -176,7 +178,6 @@ public class OffloadTargetEligibilityTests
             Candidate(id: 1),                                                       // the source
             Candidate(id: 2),                                                       // assigned, usable
             Candidate(id: 3, isAccessible: OffloadTargetEligibility.IsAccessible(3, allowed)),
-            Candidate(id: 4, isEnabled: false, isAccessible: OffloadTargetEligibility.IsAccessible(4, allowed)),
         };
 
         var offered = all.Where(c => OffloadTargetEligibility.IsEligible(c, SourceId)).Select(c => c.Id).ToList();


### PR DESCRIPTION
IsEnabled decides one thing: which accounts the background sync collects from. An offload does not collect, it appends. Reading "do not archive from here" as "do not write here" was a rule we introduced ourselves, and it blocks the workflow the feature exists for - provisioning the target mailboxes of a migration disabled so the sync leaves them alone, filling them ahead of the cutover, and letting people switch archiving on for themselves afterwards.

It was also asymmetric: the source side has no such check, only "not found".

The honest objection is that "disabled" can mean "retired", and an offload would then run at dead credentials. That fails loudly on connect, nothing is damaged, and somebody picked the target from a list on purpose.

The rejection reason, its message key and the resource string are gone rather than left unused, as is IsEnabled on the candidate - the decision no longer looks at it, and a fact nothing decides on is dead weight. The CLI path loses the same check and says why in a comment, so the three paths still agree.