### PR TITLE
Put deletion jobs in the job list

### DIFF
--- a/Controllers/EmailsController.cs
+++ b/Controllers/EmailsController.cs
@@ -2179,6 +2179,8 @@ namespace MailArchiver.Controllers
             var exportJobs = new List<AccountExportJob>();
             var selectedEmailsExportJobs = new List<SelectedEmailsExportJob>();
             var emlImportJobs = new List<EmlImportJob>();
+            var accountDeletionJobs = new List<MailAccountDeletionJob>();
+            var emailDeletionJobs = new List<EmailDeletionJob>();
 
             if (_batchRestoreService != null)
             {
@@ -2274,12 +2276,50 @@ namespace MailArchiver.Controllers
                 // Ignore if service not available
             }
 
+            // Deletion jobs. Both kinds have had their own status page since they were introduced,
+            // reachable only through the redirect that starts them — close the window and there was
+            // no way back, and the job is dropped after 24 hours anyway.
+            try
+            {
+                var accountDeletionService = HttpContext.RequestServices.GetService<IMailAccountDeletionService>();
+                if (accountDeletionService != null)
+                {
+                    accountDeletionJobs = accountDeletionService.GetAllJobs()
+                        .OrderByDescending(j => j.Status == MailAccountDeletionJobStatus.Running || j.Status == MailAccountDeletionJobStatus.Queued)
+                        .ThenByDescending(j => j.Created)
+                        .Take(20) // Apply top 20 restriction consistent with other job types
+                        .ToList();
+                }
+            }
+            catch
+            {
+                // Ignore if service not available
+            }
+
+            try
+            {
+                if (_emailDeletionService != null)
+                {
+                    emailDeletionJobs = _emailDeletionService.GetAllJobs()
+                        .OrderByDescending(j => j.Status == EmailDeletionJobStatus.Running || j.Status == EmailDeletionJobStatus.Queued)
+                        .ThenByDescending(j => j.Created)
+                        .Take(20) // Apply top 20 restriction consistent with other job types
+                        .ToList();
+                }
+            }
+            catch
+            {
+                // Ignore if service not available
+            }
+
             ViewBag.BatchJobs = batchJobs;
             ViewBag.SyncJobs = syncJobs;
             ViewBag.MBoxJobs = mboxJobs;
             ViewBag.ExportJobs = exportJobs;
             ViewBag.SelectedEmailsExportJobs = selectedEmailsExportJobs;
             ViewBag.EmlImportJobs = emlImportJobs;
+            ViewBag.AccountDeletionJobs = accountDeletionJobs;
+            ViewBag.EmailDeletionJobs = emailDeletionJobs;
 
             return View(batchJobs);
         }

--- a/Resources/SharedResource.de.resx
+++ b/Resources/SharedResource.de.resx
@@ -2495,6 +2495,9 @@
   <data name="EmailDeletionJobs" xml:space="preserve">
     <value>E-Mail-Löschvorgänge</value>
   </data>
+  <data name="AccountDeletionJobs" xml:space="preserve">
+    <value>Konto-Löschvorgänge</value>
+  </data>
   <data name="EmailDeletionProgress" xml:space="preserve">
     <value>E-Mail-Löschfortschritt</value>
   </data>

--- a/Resources/SharedResource.es.resx
+++ b/Resources/SharedResource.es.resx
@@ -2454,6 +2454,9 @@
   <data name="EmailDeletionJobs" xml:space="preserve">
     <value>Trabajos de eliminación de correos electrónicos</value>
   </data>
+  <data name="AccountDeletionJobs" xml:space="preserve">
+    <value>Trabajos de eliminación de cuentas</value>
+  </data>
   <data name="EmailDeletionProgress" xml:space="preserve">
     <value>Progreso de eliminación de correos electrónicos</value>
   </data>

--- a/Resources/SharedResource.fr.resx
+++ b/Resources/SharedResource.fr.resx
@@ -2455,6 +2455,9 @@
   <data name="EmailDeletionJobs" xml:space="preserve">
     <value>Tâches de suppression d'emails</value>
   </data>
+  <data name="AccountDeletionJobs" xml:space="preserve">
+    <value>Suppressions de comptes</value>
+  </data>
   <data name="EmailDeletionProgress" xml:space="preserve">
     <value>Progression de suppression d'emails</value>
   </data>

--- a/Resources/SharedResource.hu.resx
+++ b/Resources/SharedResource.hu.resx
@@ -2447,6 +2447,9 @@
   <data name="EmailDeletionJobs" xml:space="preserve">
     <value>E-mail törlési feladatok</value>
   </data>
+  <data name="AccountDeletionJobs" xml:space="preserve">
+    <value>Fióktörlési feladatok</value>
+  </data>
   <data name="EmailDeletionProgress" xml:space="preserve">
     <value>E-mail törlési előrehaladás</value>
   </data>

--- a/Resources/SharedResource.it.resx
+++ b/Resources/SharedResource.it.resx
@@ -2455,6 +2455,9 @@
   <data name="EmailDeletionJobs" xml:space="preserve">
     <value>Lavori di eliminazione email</value>
   </data>
+  <data name="AccountDeletionJobs" xml:space="preserve">
+    <value>Eliminazioni di account</value>
+  </data>
   <data name="EmailDeletionProgress" xml:space="preserve">
     <value>Progresso eliminazione email</value>
   </data>

--- a/Resources/SharedResource.nl.resx
+++ b/Resources/SharedResource.nl.resx
@@ -2455,6 +2455,9 @@
   <data name="EmailDeletionJobs" xml:space="preserve">
     <value>E-mailverwijderingsopdrachten</value>
   </data>
+  <data name="AccountDeletionJobs" xml:space="preserve">
+    <value>Accountverwijderingstaken</value>
+  </data>
   <data name="EmailDeletionProgress" xml:space="preserve">
     <value>E-mailverwijderingsvoortgang</value>
   </data>

--- a/Resources/SharedResource.pl.resx
+++ b/Resources/SharedResource.pl.resx
@@ -2519,6 +2519,9 @@
   <data name="EmailDeletionJobs" xml:space="preserve">
     <value>Zadania Usuwania E-Mail</value>
   </data>
+  <data name="AccountDeletionJobs" xml:space="preserve">
+    <value>Zadania usuwania kont</value>
+  </data>
   <data name="ShowHtml" xml:space="preserve">
   <value>Pokaż HTML</value>
   </data>

--- a/Resources/SharedResource.resx
+++ b/Resources/SharedResource.resx
@@ -2514,6 +2514,9 @@
   <data name="EmailDeletionJobs" xml:space="preserve">
     <value>Email Deletion Jobs</value>
   </data>
+  <data name="AccountDeletionJobs" xml:space="preserve">
+    <value>Account Deletion Jobs</value>
+  </data>
   <data name="ShowHtml" xml:space="preserve">
     <value>Show HTML</value>
   </data>

--- a/Resources/SharedResource.ru.resx
+++ b/Resources/SharedResource.ru.resx
@@ -2455,6 +2455,9 @@
   <data name="EmailDeletionJobs" xml:space="preserve">
     <value>Задачи удаления писем</value>
   </data>
+  <data name="AccountDeletionJobs" xml:space="preserve">
+    <value>Задачи удаления учётных записей</value>
+  </data>
   <data name="EmailDeletionProgress" xml:space="preserve">
     <value>Прогресс удаления писем</value>
   </data>

--- a/Resources/SharedResource.sl.resx
+++ b/Resources/SharedResource.sl.resx
@@ -2455,6 +2455,9 @@
   <data name="EmailDeletionJobs" xml:space="preserve">
     <value>Naloge brisanja e-pošte</value>
   </data>
+  <data name="AccountDeletionJobs" xml:space="preserve">
+    <value>Opravila brisanja računov</value>
+  </data>
   <data name="EmailDeletionProgress" xml:space="preserve">
     <value>Napredek brisanja e-pošte</value>
   </data>

--- a/Views/Emails/Jobs.cshtml
+++ b/Views/Emails/Jobs.cshtml
@@ -853,6 +853,147 @@
         }
     }
     
+    @* Deletion Jobs Section - both kinds have their own status page, and until now the only way
+       there was the redirect that started them. Compact on purpose: the status page carries the
+       detail, this is about being able to find it again. *@
+    @if (ViewBag.AccountDeletionJobs != null)
+    {
+        var accountDeletionJobs = ViewBag.AccountDeletionJobs as List<MailArchiver.Models.MailAccountDeletionJob>;
+        if (accountDeletionJobs != null && accountDeletionJobs.Any())
+        {
+            <div class="card mb-4">
+                <div class="card-header">
+                    <span class="h6 mb-0"><i class="bi bi-trash me-2"></i>@Localizer["AccountDeletionJobs"]</span>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive d-none d-lg-block">
+                        <table class="table table-striped table-hover table-sm mb-0">
+                            <thead class="table-dark">
+                                <tr>
+                                    <th>@Localizer["JobID"]</th>
+                                    <th>@Localizer["AccountName"]</th>
+                                    <th>@Localizer["Status"]</th>
+                                    <th>@Localizer["EmailsLabel"]</th>
+                                    <th>@Localizer["CreatedLabel"]</th>
+                                    <th>@Localizer["Actions"]</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var job in accountDeletionJobs)
+                                {
+                                    var cls = job.Status switch
+                                    {
+                                        MailArchiver.Models.MailAccountDeletionJobStatus.Running => "primary",
+                                        MailArchiver.Models.MailAccountDeletionJobStatus.Completed => "success",
+                                        MailArchiver.Models.MailAccountDeletionJobStatus.Failed => "danger",
+                                        MailArchiver.Models.MailAccountDeletionJobStatus.Cancelled => "warning",
+                                        _ => "secondary"
+                                    };
+                                    <tr>
+                                        <td><code>@job.JobId.Substring(0, 8)...</code></td>
+                                        <td>@job.MailAccountName</td>
+                                        <td><span class="badge bg-@cls">@Localizer[job.Status.ToString()]</span></td>
+                                        <td>@job.DeletedEmails.ToString("N0") / @job.TotalEmails.ToString("N0")</td>
+                                        <td><span class="utc-timestamp" data-utc-time="@job.Created.ToString("yyyy-MM-ddTHH:mm:ss")">@job.Created.ToString("g")</span></td>
+                                        <td>
+                                            <a asp-controller="MailAccounts" asp-action="DeletionStatus" asp-route-jobId="@job.JobId"
+                                               class="btn btn-outline-secondary btn-sm">@Localizer["Details"]</a>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="d-lg-none">
+                        @foreach (var job in accountDeletionJobs)
+                        {
+                            <div class="border rounded p-2 mb-2">
+                                <div class="d-flex justify-content-between align-items-start">
+                                    <strong>@job.MailAccountName</strong>
+                                    <span class="badge bg-secondary">@Localizer[job.Status.ToString()]</span>
+                                </div>
+                                <div class="small text-muted">
+                                    @job.DeletedEmails.ToString("N0") / @job.TotalEmails.ToString("N0")
+                                    · <span class="utc-timestamp" data-utc-time="@job.Created.ToString("yyyy-MM-ddTHH:mm:ss")">@job.Created.ToString("g")</span>
+                                </div>
+                                <a asp-controller="MailAccounts" asp-action="DeletionStatus" asp-route-jobId="@job.JobId"
+                                   class="btn btn-outline-secondary btn-sm mt-2">@Localizer["Details"]</a>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+        }
+    }
+
+    @if (ViewBag.EmailDeletionJobs != null)
+    {
+        var emailDeletionJobs = ViewBag.EmailDeletionJobs as List<MailArchiver.Models.EmailDeletionJob>;
+        if (emailDeletionJobs != null && emailDeletionJobs.Any())
+        {
+            <div class="card mb-4">
+                <div class="card-header">
+                    <span class="h6 mb-0"><i class="bi bi-trash me-2"></i>@Localizer["EmailDeletionJobs"]</span>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive d-none d-lg-block">
+                        <table class="table table-striped table-hover table-sm mb-0">
+                            <thead class="table-dark">
+                                <tr>
+                                    <th>@Localizer["JobID"]</th>
+                                    <th>@Localizer["Status"]</th>
+                                    <th>@Localizer["EmailsLabel"]</th>
+                                    <th>@Localizer["CreatedLabel"]</th>
+                                    <th>@Localizer["Actions"]</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var job in emailDeletionJobs)
+                                {
+                                    var cls = job.Status switch
+                                    {
+                                        MailArchiver.Models.EmailDeletionJobStatus.Running => "primary",
+                                        MailArchiver.Models.EmailDeletionJobStatus.Completed => "success",
+                                        MailArchiver.Models.EmailDeletionJobStatus.Failed => "danger",
+                                        MailArchiver.Models.EmailDeletionJobStatus.Cancelled => "warning",
+                                        _ => "secondary"
+                                    };
+                                    <tr>
+                                        <td><code>@job.JobId.Substring(0, 8)...</code></td>
+                                        <td><span class="badge bg-@cls">@Localizer[job.Status.ToString()]</span></td>
+                                        <td>@job.DeletedEmails.ToString("N0") / @job.TotalEmails.ToString("N0")</td>
+                                        <td><span class="utc-timestamp" data-utc-time="@job.Created.ToString("yyyy-MM-ddTHH:mm:ss")">@job.Created.ToString("g")</span></td>
+                                        <td>
+                                            <a asp-action="EmailDeletionStatus" asp-route-jobId="@job.JobId"
+                                               class="btn btn-outline-secondary btn-sm">@Localizer["Details"]</a>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="d-lg-none">
+                        @foreach (var job in emailDeletionJobs)
+                        {
+                            <div class="border rounded p-2 mb-2">
+                                <div class="d-flex justify-content-between align-items-start">
+                                    <code>@job.JobId.Substring(0, 8)...</code>
+                                    <span class="badge bg-secondary">@Localizer[job.Status.ToString()]</span>
+                                </div>
+                                <div class="small text-muted">
+                                    @job.DeletedEmails.ToString("N0") / @job.TotalEmails.ToString("N0")
+                                    · <span class="utc-timestamp" data-utc-time="@job.Created.ToString("yyyy-MM-ddTHH:mm:ss")">@job.Created.ToString("g")</span>
+                                </div>
+                                <a asp-action="EmailDeletionStatus" asp-route-jobId="@job.JobId"
+                                   class="btn btn-outline-secondary btn-sm mt-2">@Localizer["Details"]</a>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+        }
+    }
+
     @* Batch Restore Jobs Section *@
     @if (ViewBag.BatchJobs != null)
     {


### PR DESCRIPTION
## What happens today

Starting an account deletion redirects to `MailAccounts/DeletionStatus?jobId=…`, and that redirect
is the only way there. The job list collects six job types and neither deletion kind is among them,
no page links to either status view, and the job is dropped after 24 hours. Close the window and the
run becomes unreachable while it is still running.

Email deletions have the same gap, through `Emails/EmailDeletionStatus`.

This is not a regression. `edb7541` introduced both job types with their status pages in December,
and a search through the history for `MailAccountDeletion` in `EmailsController` and `Jobs.cshtml`
finds nothing: the link was never there.

## What this changes

`EmailsController.Jobs()` collects both kinds alongside the six it already has, and `Jobs.cshtml`
renders them as two more tables. Both services already expose `GetAllJobs()`, so nothing new is
stored and nothing new is computed. Same ordering as the other types, running and queued first, then
newest, and the same `Take(20)`.

Each row links straight to the status page that already exists. Kept deliberately compact for that
reason: the status pages carry the detail, these rows exist so the page can be found again.

## What this does not change

No new job state, no new service, no schema change. The 24-hour cleanup is untouched, so a job that
has aged out still disappears from the list. Resolving that would mean persisting jobs, which is a
different question.

One new resource key, `AccountDeletionJobs`. `EmailDeletionJobs` already existed.

## Tests

None, and deliberately so: the change is a controller collecting two more lists from services that
already expose them, and a view rendering them like the six beside them. There is no decision here
to pin. Suite measured on both sides: **858 passed, 1 skipped** on `861c27b`, and **858 passed,
1 skipped** with the branch.